### PR TITLE
Change allocation's permissions type

### DIFF
--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -79,12 +79,7 @@ func (m *Manager) CreateAllocation(fiveTuple *FiveTuple, turnSocket net.PacketCo
 		return nil, errors.Errorf("Allocations must not be created with a lifetime of 0")
 	}
 
-	a := &Allocation{
-		fiveTuple:  fiveTuple,
-		TurnSocket: turnSocket,
-		closed:     make(chan interface{}),
-		log:        m.log,
-	}
+	a := NewAllocation(turnSocket, fiveTuple, m.log)
 
 	network := "udp4"
 	conn, err := m.net.ListenPacket(network, fmt.Sprintf("0.0.0.0:%d", requestedPort))

--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pion/turn/internal/ipnet"
 )
 
-func TestAllocation(t *testing.T) {
+func TestManager(t *testing.T) {
 	tt := []struct {
 		name string
 		f    func(*testing.T, ipnet.PacketConn)

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -1,0 +1,99 @@
+package allocation
+
+import (
+	"net"
+	"testing"
+)
+
+func TestAllocation(t *testing.T) {
+	tt := []struct {
+		name string
+		f    func(*testing.T)
+	}{
+		{"GetPermission", subTestGetPermission},
+		{"AddPermission", subTestAddPermission},
+		{"RemovePermission", subTestRemovePermission},
+	}
+
+	for _, tc := range tt {
+		f := tc.f
+		t.Run(tc.name, func(t *testing.T) {
+			f(t)
+		})
+	}
+}
+
+func subTestGetPermission(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	addr2, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3479")
+	addr3, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3480")
+
+	p := &Permission{
+		Addr: addr,
+	}
+	p2 := &Permission{
+		Addr: addr2,
+	}
+
+	a.AddPermission(p)
+	a.AddPermission(p2)
+
+	foundP1 := a.GetPermission(addr.String())
+	if foundP1 != p {
+		t.Error("Got permission is not same as the the added.")
+	}
+
+	foundP2 := a.GetPermission(addr2.String())
+	if foundP2 != p2 {
+		t.Error("Got permission is not same as the the added.")
+	}
+
+	foundP3 := a.GetPermission(addr3.String())
+	if foundP3 != nil {
+		t.Error("Got permission should be nil if not added.")
+	}
+}
+
+func subTestAddPermission(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	p := &Permission{
+		Addr: addr,
+	}
+
+	a.AddPermission(p)
+	if p.allocation != a {
+		t.Error("Permission's allocation should be the adder.")
+	}
+
+	foundPermission := a.GetPermission(p.Addr.String())
+	if foundPermission != p {
+		t.Error("Got permission is not same as the the added.")
+	}
+}
+
+func subTestRemovePermission(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	p := &Permission{
+		Addr: addr,
+	}
+
+	a.AddPermission(p)
+
+	foundPermission := a.GetPermission(p.Addr.String())
+	if foundPermission != p {
+		t.Error("Got permission is not same as the the added.")
+	}
+
+	a.RemovePermission(p.Addr.String())
+
+	foundPermission = a.GetPermission(p.Addr.String())
+	if foundPermission != nil {
+		t.Error("Got permission should be nil after removed.")
+	}
+}

--- a/internal/allocation/channel_bind.go
+++ b/internal/allocation/channel_bind.go
@@ -11,8 +11,9 @@ import (
 // ChannelBind represents a TURN Channel
 // https://tools.ietf.org/html/rfc5766#section-2.5
 type ChannelBind struct {
-	Peer          net.Addr
-	ID            turn.ChannelNumber
+	Peer net.Addr
+	ID   turn.ChannelNumber
+
 	allocation    *Allocation
 	lifetimeTimer *time.Timer
 	log           logging.LeveledLogger

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestChannelBind(t *testing.T) {
 	c := newChannelBind(2 * time.Second)
+
 	if c.allocation.GetChannelByID(c.ID) != c {
 		t.Errorf("GetChannelByID(%d) shouldn't be nil after added to allocation", c.ID)
 	}
@@ -17,7 +18,9 @@ func TestChannelBind(t *testing.T) {
 
 func TestChannelBindStart(t *testing.T) {
 	c := newChannelBind(2 * time.Second)
+
 	time.Sleep(3 * time.Second)
+
 	if c.allocation.GetChannelByID(c.ID) != nil {
 		t.Errorf("GetChannelByID(%d) should be nil if timeout", c.ID)
 	}
@@ -25,16 +28,18 @@ func TestChannelBindStart(t *testing.T) {
 
 func TestChannelBindReset(t *testing.T) {
 	c := newChannelBind(3 * time.Second)
+
 	time.Sleep(2 * time.Second)
 	c.refresh(3 * time.Second)
 	time.Sleep(2 * time.Second)
+
 	if c.allocation.GetChannelByID(c.ID) == nil {
 		t.Errorf("GetChannelByID(%d) shouldn't be nil after refresh", c.ID)
 	}
 }
 
 func newChannelBind(lifetime time.Duration) *ChannelBind {
-	allocation := &Allocation{}
+	a := NewAllocation(nil, nil, nil)
 
 	addr, _ := net.ResolveUDPAddr("udp", "0.0.0.0:0")
 	c := &ChannelBind{
@@ -42,7 +47,7 @@ func newChannelBind(lifetime time.Duration) *ChannelBind {
 		Peer: addr,
 	}
 
-	_ = allocation.AddChannelBind(c, lifetime)
+	_ = a.AddChannelBind(c, lifetime)
 
 	return c
 }

--- a/internal/allocation/permission.go
+++ b/internal/allocation/permission.go
@@ -27,16 +27,14 @@ func NewPermission(addr net.Addr, log logging.LeveledLogger) *Permission {
 	}
 }
 
-func (p *Permission) start() {
-	p.lifetimeTimer = time.AfterFunc(permissionTimeout, func() {
-		if !p.allocation.RemovePermission(p.Addr) {
-			p.log.Errorf("Failed to remove permission for %v %v", p.Addr, p.allocation.fiveTuple)
-		}
+func (p *Permission) start(lifetime time.Duration) {
+	p.lifetimeTimer = time.AfterFunc(lifetime, func() {
+		p.allocation.RemovePermission(p.Addr.String())
 	})
 }
 
-func (p *Permission) refresh() {
-	if !p.lifetimeTimer.Reset(permissionTimeout) {
+func (p *Permission) refresh(lifetime time.Duration) {
+	if !p.lifetimeTimer.Reset(lifetime) {
 		p.log.Errorf("Failed to reset permission timer for %v %v", p.Addr, p.allocation.fiveTuple)
 	}
 }

--- a/turn.go
+++ b/turn.go
@@ -369,7 +369,7 @@ func (s *Server) handleSendIndication(conn net.PacketConn, srcAddr net.Addr, m *
 	}
 
 	msgDst := &net.UDPAddr{IP: peerAddress.IP, Port: peerAddress.Port}
-	if perm := a.GetPermission(msgDst); perm == nil {
+	if perm := a.GetPermission(msgDst.String()); perm == nil {
 		return errors.Errorf("Unable to handle send-indication, no permission added: %v", msgDst)
 	}
 


### PR DESCRIPTION
From slice to map.

Benchmark code is:

```golang
const (
	permissionsCount = 5000
	startPort        = 3000
)

func getPermissionInSlice(target net.Addr, b *testing.B) {
	permissions := make([]*allocation.Permission, permissionsCount)

	for index := range permissions {
		addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+index))
		permissions[index] = &allocation.Permission{
			Addr: addr,
		}
	}

	fn := func() *allocation.Permission {
		for _, permission := range permissions {
			if ipnet.AddrEqual(target, permission.Addr) {
				return permission
			}
		}

		return nil
	}

	for n := 0; n < b.N; n++ {
		fn()
	}
}

func getPermissionInMap(target string, b *testing.B) {
	permissions := make(map[string]*allocation.Permission, 1024)

	for index := 0; index < permissionsCount; index++ {
		addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", 3000+index))
		permissions[addr.String()] = &allocation.Permission{
			Addr: addr,
		}
	}

	fn := func() *allocation.Permission {
		return permissions[target]
	}

	for n := 0; n < b.N; n++ {
		fn()
	}
}

func BenchmarkGetPermissionInSliceAtHead(b *testing.B) {
	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+5))
	getPermissionInSlice(addr, b)
}

func BenchmarkGetPermissionInSliceAtHalf(b *testing.B) {
	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+permissionsCount/2))
	getPermissionInSlice(addr, b)
}

func BenchmarkGetPermissionInSliceAtTail(b *testing.B) {
	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+permissionsCount))
	getPermissionInSlice(addr, b)
}

func BenchmarkGetPermissionGInMap1(b *testing.B) {
	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+5))
	getPermissionInMap(addr.String(), b)
}

func BenchmarkGetPermissionInMap2(b *testing.B) {
	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+permissionsCount/2))
	getPermissionInMap(addr.String(), b)
}

func BenchmarkGetPermissionInMap3(b *testing.B) {
	addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", startPort+permissionsCount))
	getPermissionInMap(addr.String(), b)
}
```

The result is:

```
go test -bench=.

pkg: github.com/pion/turn/benchmarks
BenchmarkGetPermissionInSliceAtHead-8   	20000000	        70.8 ns/op
BenchmarkGetPermissionInSliceAtHalf-8   	   50000	     31284 ns/op
BenchmarkGetPermissionInSliceAtTail-8   	   20000	     62415 ns/op
BenchmarkGetPermissionGInMap1-8         	100000000	        13.8 ns/op
BenchmarkGetPermissionInMap2-8          	100000000	        14.3 ns/op
BenchmarkGetPermissionInMap3-8          	50000000	        22.0 ns/op
PASS
ok  	github.com/pion/turn/benchmarks	9.338s
```

Summary:  

When permissions's number is 5000,  get permission with map is 100x speed than slice in on average.
