### PR TITLE
Fix missing default binding lifetime

### DIFF
--- a/server.go
+++ b/server.go
@@ -28,12 +28,18 @@ type AuthHandler func(username string, srcAddr net.Addr) (password string, ok bo
 
 // ServerConfig is a bag of config parameters for Server.
 type ServerConfig struct {
-	Realm              string
-	AuthHandler        AuthHandler
+	// Realm sets the realm for this server
+	Realm string
+	// AuthHandler is the handler called on each incoming auth requests.
+	AuthHandler AuthHandler
+	// ChannelBindTimeout sets the lifetime of channel binding. Defaults to 10 minutes.
 	ChannelBindTimeout time.Duration
-	ListeningPort      int
-	LoggerFactory      logging.LoggerFactory
-	Net                *vnet.Net
+	// ListeningPort sets the listening port number. Defaults to 3478.
+	ListeningPort int
+	// LoggerFactory must be set for logging from this server.
+	LoggerFactory logging.LoggerFactory
+	// Net is used by pion developers. Do not use in your application.
+	Net *vnet.Net
 }
 
 type listener struct {
@@ -76,13 +82,18 @@ func NewServer(config *ServerConfig) *Server {
 		listenPort = 3478
 	}
 
+	channelBindTimeout := config.ChannelBindTimeout
+	if channelBindTimeout == 0 {
+		channelBindTimeout = turn.DefaultLifetime
+	}
+
 	return &Server{
 		listenPort:         listenPort,
 		realm:              config.Realm,
 		authHandler:        config.AuthHandler,
 		manager:            manager,
 		reservationManager: &allocation.ReservationManager{},
-		channelBindTimeout: config.ChannelBindTimeout,
+		channelBindTimeout: channelBindTimeout,
 		log:                log,
 		net:                config.Net,
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gortc/turn"
 	"github.com/pion/logging"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,6 +28,8 @@ func TestServer(t *testing.T) {
 			Realm:         "pion.ly",
 			LoggerFactory: loggerFactory,
 		})
+
+		assert.Equal(t, turn.DefaultLifetime, server.channelBindTimeout, "should match")
 
 		err := server.AddListeningIPAddr("127.0.0.1")
 		assert.NoError(t, err, "should succeed")


### PR DESCRIPTION
For details, see #61

I did:
* Added (brought back) default channel binding lifetime
* Added a test to check if the default value is correctly used
* Added comments (for godoc) to ServerConfig struct