### PR TITLE
Bug fix for invalid channel address

### DIFF
--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -1,8 +1,16 @@
 package allocation
 
 import (
+	"fmt"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/gortc/turn"
+	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pion/turn/internal/ipnet"
 )
 
 func TestAllocation(t *testing.T) {
@@ -13,6 +21,12 @@ func TestAllocation(t *testing.T) {
 		{"GetPermission", subTestGetPermission},
 		{"AddPermission", subTestAddPermission},
 		{"RemovePermission", subTestRemovePermission},
+		{"AddChannelBind", subTestAddChannelBind},
+		{"GetChannelByNumber", subTestGetChannelByNumber},
+		{"GetChannelByAddr", subTestGetChannelByAddr},
+		{"RemoveChannelBind", subTestRemoveChannelBind},
+		{"Close", subTestAllocationClose},
+		{"packetHandler", subTestPacketHandler},
 	}
 
 	for _, tc := range tt {
@@ -45,19 +59,13 @@ func subTestGetPermission(t *testing.T) {
 	a.AddPermission(p3)
 
 	foundP1 := a.GetPermission(addr)
-	if foundP1 != p {
-		t.Error("Should keep the first one.")
-	}
+	assert.Equal(t, p, foundP1, "Should keep the first one.")
 
 	foundP2 := a.GetPermission(addr2)
-	if foundP2 != p {
-		t.Error("Second one should be ignored.")
-	}
+	assert.Equal(t, p, foundP2, "Second one should be ignored.")
 
 	foundP3 := a.GetPermission(addr3)
-	if foundP3 != p3 {
-		t.Error("Permission with another IP should be found")
-	}
+	assert.Equal(t, p3, foundP3, "Permission with another IP should be found")
 }
 
 func subTestAddPermission(t *testing.T) {
@@ -69,14 +77,11 @@ func subTestAddPermission(t *testing.T) {
 	}
 
 	a.AddPermission(p)
-	if p.allocation != a {
-		t.Error("Permission's allocation should be the adder.")
-	}
+	assert.Equal(t, a, p.allocation, "Permission's allocation should be the adder.")
 
 	foundPermission := a.GetPermission(p.Addr)
-	if foundPermission != p {
-		t.Error("Got permission is not same as the the added.")
-	}
+	assert.Equal(t, p, foundPermission)
+
 }
 
 func subTestRemovePermission(t *testing.T) {
@@ -90,14 +95,202 @@ func subTestRemovePermission(t *testing.T) {
 	a.AddPermission(p)
 
 	foundPermission := a.GetPermission(p.Addr)
-	if foundPermission != p {
-		t.Error("Got permission is not same as the the added.")
-	}
+	assert.Equal(t, p, foundPermission, "Got permission is not same as the the added.")
 
 	a.RemovePermission(p.Addr)
 
 	foundPermission = a.GetPermission(p.Addr)
-	if foundPermission != nil {
-		t.Error("Got permission should be nil after removed.")
+	assert.Nil(t, foundPermission, "Got permission should be nil after removed.")
+}
+
+func subTestAddChannelBind(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	c := NewChannelBind(turn.MinChannelNumber, addr, nil)
+
+	err := a.AddChannelBind(c, turn.DefaultLifetime)
+	assert.Nil(t, err, "should succeed")
+	assert.Equal(t, a, c.allocation, "allocation should be the caller.")
+
+	c2 := NewChannelBind(turn.MinChannelNumber+1, addr, nil)
+	err = a.AddChannelBind(c2, turn.DefaultLifetime)
+	assert.NotNil(t, err, "should failed with conflicted peer address")
+
+	addr2, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3479")
+	c3 := NewChannelBind(turn.MinChannelNumber, addr2, nil)
+	err = a.AddChannelBind(c3, turn.DefaultLifetime)
+	assert.NotNil(t, err, "should fail with conflicted number.")
+}
+
+func subTestGetChannelByNumber(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	c := NewChannelBind(turn.MinChannelNumber, addr, nil)
+
+	_ = a.AddChannelBind(c, turn.DefaultLifetime)
+
+	existChannel := a.GetChannelByNumber(c.Number)
+	assert.Equal(t, c, existChannel)
+
+	notExistChannel := a.GetChannelByNumber(turn.MinChannelNumber + 1)
+	assert.Nil(t, notExistChannel, "should be nil for not existed channel.")
+}
+
+func subTestGetChannelByAddr(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	c := NewChannelBind(turn.MinChannelNumber, addr, nil)
+
+	_ = a.AddChannelBind(c, turn.DefaultLifetime)
+
+	existChannel := a.GetChannelByAddr(c.Peer)
+	assert.Equal(t, c, existChannel)
+
+	addr2, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3479")
+	notExistChannel := a.GetChannelByAddr(addr2)
+	assert.Nil(t, notExistChannel, "should be nil for not existed channel.")
+}
+
+func subTestRemoveChannelBind(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+
+	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
+	c := NewChannelBind(turn.MinChannelNumber, addr, nil)
+
+	_ = a.AddChannelBind(c, turn.DefaultLifetime)
+
+	a.RemoveChannelBind(c.Number)
+
+	channelByNumber := a.GetChannelByNumber(c.Number)
+	assert.Nil(t, channelByNumber)
+
+	channelByAddr := a.GetChannelByAddr(c.Peer)
+	assert.Nil(t, channelByAddr)
+}
+
+func subTestAllocationClose(t *testing.T) {
+	network := "udp"
+
+	l, err := net.ListenPacket(network, "0.0.0.0:0")
+	if err != nil {
+		panic(err)
 	}
+
+	a := NewAllocation(nil, nil, nil)
+	a.RelaySocket = l
+	// add mock lifetimeTimer
+	a.lifetimeTimer = time.AfterFunc(turn.DefaultLifetime, func() {})
+
+	// add channel
+	addr, _ := net.ResolveUDPAddr(network, "127.0.0.1:3478")
+	c := NewChannelBind(turn.MinChannelNumber, addr, nil)
+	_ = a.AddChannelBind(c, turn.DefaultLifetime)
+
+	// add permission
+	a.AddPermission(NewPermission(addr, nil))
+
+	err = a.Close()
+	assert.Nil(t, err, "should succeed")
+	assert.True(t, isClose(a.RelaySocket), "should be closed")
+}
+
+func subTestPacketHandler(t *testing.T) {
+	network := "udp"
+
+	m := newTestManager()
+
+	// turn server initialization
+	turnSocket, err := net.ListenPacket(network, "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+
+	// client listener initialization
+	clientListener, err := net.ListenPacket(network, "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+
+	dataCh := make(chan []byte)
+	// client listener read data
+	go func() {
+		buffer := make([]byte, rtpMTU)
+		for {
+			n, _, err2 := clientListener.ReadFrom(buffer)
+			if err2 != nil {
+				return
+			}
+
+			dataCh <- buffer[:n]
+		}
+	}()
+
+	a, err := m.CreateAllocation(&FiveTuple{
+		SrcAddr: clientListener.LocalAddr(),
+		DstAddr: turnSocket.LocalAddr(),
+	}, turnSocket, 0, turn.DefaultLifetime)
+
+	assert.Nil(t, err, "should succeed")
+
+	peerListener1, err := net.ListenPacket(network, "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+
+	peerListener2, err := net.ListenPacket(network, "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+
+	// add permission with peer1 address
+	a.AddPermission(NewPermission(peerListener1.LocalAddr(), m.log))
+	// add channel with min channel number and peer2 address
+	channelBind := NewChannelBind(turn.MinChannelNumber, peerListener2.LocalAddr(), m.log)
+	_ = a.AddChannelBind(channelBind, turn.DefaultLifetime)
+
+	_, port, _ := ipnet.AddrIPPort(a.RelaySocket.LocalAddr())
+	relayAddrWithHostStr := fmt.Sprintf("127.0.0.1:%d", port)
+	relayAddrWithHost, _ := net.ResolveUDPAddr(network, relayAddrWithHostStr)
+
+	// test for permission and data message
+	targetText := "permission"
+	_, _ = peerListener1.WriteTo([]byte(targetText), relayAddrWithHost)
+	data := <-dataCh
+
+	// resolve stun data message
+	assert.True(t, stun.IsMessage(data), "should be stun message")
+
+	var msg stun.Message
+	err = stun.Decode(data, &msg)
+	assert.Nil(t, err, "decode data to stun message failed")
+
+	var msgData turn.Data
+	err = msgData.GetFrom(&msg)
+	assert.Nil(t, err, "get data from stun message failed")
+	assert.Equal(t, targetText, string(msgData), "get message doesn't equal the target text")
+
+	// test for channel bind and channel data
+	targetText2 := "channel bind"
+	_, _ = peerListener2.WriteTo([]byte(targetText2), relayAddrWithHost)
+	data = <-dataCh
+
+	// resolve channel data
+	assert.True(t, turn.IsChannelData(data), "should be channel data")
+
+	channelData := turn.ChannelData{
+		Raw: data,
+	}
+	err = channelData.Decode()
+	assert.Nil(t, err, fmt.Sprintf("channel data decode with error: %v", err))
+	assert.Equal(t, channelBind.Number, channelData.Number, "get channel data's number is invalid")
+	assert.Equal(t, targetText2, string(channelData.Data), "get data doesn't equal the target text.")
+
+	// listeners close
+	_ = m.Close()
+	_ = clientListener.Close()
+	_ = peerListener1.Close()
+	_ = peerListener2.Close()
 }

--- a/internal/allocation/channel_bind.go
+++ b/internal/allocation/channel_bind.go
@@ -11,8 +11,8 @@ import (
 // ChannelBind represents a TURN Channel
 // https://tools.ietf.org/html/rfc5766#section-2.5
 type ChannelBind struct {
-	Peer net.Addr
-	ID   turn.ChannelNumber
+	Peer   net.Addr
+	Number turn.ChannelNumber
 
 	allocation    *Allocation
 	lifetimeTimer *time.Timer
@@ -20,24 +20,24 @@ type ChannelBind struct {
 }
 
 // NewChannelBind creates a new ChannelBind
-func NewChannelBind(id turn.ChannelNumber, peer net.Addr, log logging.LeveledLogger) *ChannelBind {
+func NewChannelBind(number turn.ChannelNumber, peer net.Addr, log logging.LeveledLogger) *ChannelBind {
 	return &ChannelBind{
-		ID:   id,
-		Peer: peer,
-		log:  log,
+		Number: number,
+		Peer:   peer,
+		log:    log,
 	}
 }
 
 func (c *ChannelBind) start(lifetime time.Duration) {
 	c.lifetimeTimer = time.AfterFunc(lifetime, func() {
-		if !c.allocation.RemoveChannelBind(c.ID) {
-			c.log.Errorf("Failed to remove ChannelBind for %v %x %v", c.ID, c.Peer, c.allocation.fiveTuple)
+		if !c.allocation.RemoveChannelBind(c.Number) {
+			c.log.Errorf("Failed to remove ChannelBind for %v %x %v", c.Number, c.Peer, c.allocation.fiveTuple)
 		}
 	})
 }
 
 func (c *ChannelBind) refresh(lifetime time.Duration) {
 	if !c.lifetimeTimer.Reset(lifetime) {
-		c.log.Errorf("Failed to reset ChannelBind timer for %v %x %v", c.ID, c.Peer, c.allocation.fiveTuple)
+		c.log.Errorf("Failed to reset ChannelBind timer for %v %x %v", c.Number, c.Peer, c.allocation.fiveTuple)
 	}
 }

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -11,8 +11,8 @@ import (
 func TestChannelBind(t *testing.T) {
 	c := newChannelBind(2 * time.Second)
 
-	if c.allocation.GetChannelByID(c.ID) != c {
-		t.Errorf("GetChannelByID(%d) shouldn't be nil after added to allocation", c.ID)
+	if c.allocation.GetChannelByNumber(c.Number) != c {
+		t.Errorf("GetChannelByNumber(%d) shouldn't be nil after added to allocation", c.Number)
 	}
 }
 
@@ -21,8 +21,8 @@ func TestChannelBindStart(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	if c.allocation.GetChannelByID(c.ID) != nil {
-		t.Errorf("GetChannelByID(%d) should be nil if timeout", c.ID)
+	if c.allocation.GetChannelByNumber(c.Number) != nil {
+		t.Errorf("GetChannelByNumber(%d) should be nil if timeout", c.Number)
 	}
 }
 
@@ -33,8 +33,8 @@ func TestChannelBindReset(t *testing.T) {
 	c.refresh(3 * time.Second)
 	time.Sleep(2 * time.Second)
 
-	if c.allocation.GetChannelByID(c.ID) == nil {
-		t.Errorf("GetChannelByID(%d) shouldn't be nil after refresh", c.ID)
+	if c.allocation.GetChannelByNumber(c.Number) == nil {
+		t.Errorf("GetChannelByNumber(%d) shouldn't be nil after refresh", c.Number)
 	}
 }
 
@@ -43,8 +43,8 @@ func newChannelBind(lifetime time.Duration) *ChannelBind {
 
 	addr, _ := net.ResolveUDPAddr("udp", "0.0.0.0:0")
 	c := &ChannelBind{
-		ID:   turn.ChannelNumber(turn.MinChannelNumber + 1),
-		Peer: addr,
+		Number: turn.MinChannelNumber,
+		Peer:   addr,
 	}
 
 	_ = a.AddChannelBind(c, lifetime)

--- a/turn.go
+++ b/turn.go
@@ -132,7 +132,7 @@ func (s *Server) handleAllocateRequest(conn net.PacketConn, srcAddr net.Addr, m 
 	// 2. The server checks if the 5-tuple is currently in use by an
 	//    existing allocation.  If yes, the server rejects the request with
 	//    a 437 (Allocation Mismatch) error.
-	if allocation := s.manager.GetAllocation(fiveTuple); allocation != nil {
+	if alloc := s.manager.GetAllocation(fiveTuple); alloc != nil {
 		return respondWithError(errors.Errorf("Relay already allocated for 5-TUPLE"), messageIntegrity, stun.CodeAllocMismatch)
 	}
 
@@ -440,7 +440,7 @@ func (s *Server) handleChannelData(conn net.PacketConn, srcAddr net.Addr, c *tur
 		return errors.Errorf("No allocation found for %v:%v", srcAddr, dstAddr)
 	}
 
-	channel := a.GetChannelByID(c.Number)
+	channel := a.GetChannelByNumber(c.Number)
 	if channel == nil {
 		return errors.Errorf("No channel bind found for %x \n", uint16(c.Number))
 	}


### PR DESCRIPTION
I did:
1. fix the bug about invalid address for `GetChannelByAddr`  in `(a *Allocation) packetHandler(m *Manager)` .
2.  rename ChannelBind's `ID` to `Number` and `Allocation`'s method `GetChannelByID` to `GetChannelByNumber`, the ` number` is more intuitive than id.
3. improve `Allocation`'s test coverage.
