### PR TITLE
Removing outer locks around setLifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [Yutaka Takeda](https://github.com/enobufs) - *vnet*
 * [namreg](https://github.com/namreg) - *Igor German*
 * [Aleksandr Razumov](https://github.com/ernado) - *protocol*
+* [Robert Eperjesi](https://github.com/epes)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/internal/client/conn.go
+++ b/internal/client/conn.go
@@ -474,10 +474,8 @@ func (c *UDPConn) refreshAllocation(lifetime time.Duration, dontWait bool) error
 		return fmt.Errorf("failed to get lifetime from refresh response: %s", err.Error())
 	}
 
-	c.mutex.Lock()
 	c.setLifetime(updatedLifetime.Duration)
 	c.log.Debugf("updated lifetime: %d seconds", int(c.lifetime().Seconds()))
-	c.mutex.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
#### Description
Removing the outer locks around the setLifetime call which
causes a deadlock as setLifetime wants the same lock.

