### PR TITLE
Fix nil transaction result message

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [namreg](https://github.com/namreg) - *Igor German*
 * [Aleksandr Razumov](https://github.com/ernado) - *protocol*
 * [Robert Eperjesi](https://github.com/epes)
+* [Lukas Rezek](https://github.com/lrezek)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -88,7 +88,14 @@ func (t *Transaction) WriteResult(res TransactionResult) bool {
 
 // WaitForResult waits for the transaction result
 func (t *Transaction) WaitForResult() TransactionResult {
-	return <-t.resultCh
+	result := <-t.resultCh
+
+	// Msg can be nil if we got this result from a channel close
+	if result.Msg == nil {
+		result.Msg = &stun.Message{}
+	}
+
+	return result
 }
 
 // Close closes the transaction

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -88,13 +89,10 @@ func (t *Transaction) WriteResult(res TransactionResult) bool {
 
 // WaitForResult waits for the transaction result
 func (t *Transaction) WaitForResult() TransactionResult {
-	result := <-t.resultCh
-
-	// Msg can be nil if we got this result from a channel close
-	if result.Msg == nil {
-		result.Msg = &stun.Message{}
+	result, ok := <-t.resultCh
+	if !ok {
+		result.Err = fmt.Errorf("transaction closed")
 	}
-
 	return result
 }
 


### PR DESCRIPTION
#### Description
When we're waiting for a transaction result and the channel is closed, `Msg` will be nil within the returned result. Since result.Msg is in use all over the place, this fixes various nil pointer issues without having to go through all the usages and do nil checks.

