### PR TITLE
Enable golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,17 +7,9 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - maligned
     - lll
     - funlen
-    - govet
-    - stylecheck
     - godox
-    - errcheck
-    - gosec
-    - whitespace
-    - gochecknoglobals
-    - scopelint
     - prealloc
     - dupl
 

--- a/client.go
+++ b/client.go
@@ -240,7 +240,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	msg, err := stun.Build(
 		stun.TransactionID,
 		stun.NewType(stun.MethodAllocate, stun.ClassRequest),
-		proto.RequestedTransportUDP,
+		proto.RequestedTransport{Protocol: proto.ProtoUDP},
 		stun.Fingerprint,
 	)
 	if err != nil {
@@ -270,7 +270,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	msg, err = stun.Build(
 		stun.TransactionID,
 		stun.NewType(stun.MethodAllocate, stun.ClassRequest),
-		proto.RequestedTransportUDP,
+		proto.RequestedTransport{Protocol: proto.ProtoUDP},
 		&c.username,
 		&c.realm,
 		&nonce,
@@ -375,7 +375,6 @@ func (c *Client) OnDeallocated(relayedAddr net.Addr) {
 // If not handled, it is assumed that the packet is application data.
 // If an error is returned, the caller should discard the packet regardless.
 func (c *Client) HandleInbound(data []byte, from net.Addr) (bool, error) {
-
 	// +-------------------+-------------------------------+
 	// |   Return Values   |                               |
 	// +-------------------+       Meaning / Action        |
@@ -416,11 +415,11 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error {
 
 	msg := &stun.Message{Raw: raw}
 	if err := msg.Decode(); err != nil {
-		return fmt.Errorf("Failed to decode STUN message: %w", err)
+		return fmt.Errorf("failed to decode STUN message: %w", err)
 	}
 
 	if msg.Type.Class == stun.ClassRequest {
-		return fmt.Errorf("unpexpected STUN request message: %s", msg.String())
+		return fmt.Errorf("unexpected STUN request message: %s", msg.String())
 	}
 
 	if msg.Type.Class == stun.ClassIndication {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,4 @@ require (
 	github.com/pion/stun v0.3.3
 	github.com/pion/transport v0.8.10
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
-	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,14 +12,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
-golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 h1:JA8d3MPx/IToSyXZG/RhwYEtfrKO1Fxrqe8KrkiLXKM=
-golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -1,3 +1,4 @@
+// Package allocation contains all CRUD operations for allocations
 package allocation
 
 import (
@@ -94,7 +95,7 @@ func (a *Allocation) AddChannelBind(c *ChannelBind, lifetime time.Duration) erro
 	channelByNumber := a.GetChannelByNumber(c.Number)
 
 	if channelByNumber != a.GetChannelByAddr(c.Peer) {
-		return fmt.Errorf("You cannot use the same channel number with different peer")
+		return fmt.Errorf("you cannot use the same channel number with different peer")
 	}
 
 	// Add or refresh this channel.
@@ -252,10 +253,8 @@ func (a *Allocation) packetHandler(m *Manager) {
 			if _, err = a.TurnSocket.WriteTo(msg.Raw, a.fiveTuple.SrcAddr); err != nil {
 				a.log.Errorf("Failed to send DataIndication from allocation %v %v", srcAddr, err)
 			}
-
 		} else {
 			a.log.Errorf("Packet unhandled in relay src %v", srcAddr)
 		}
 	}
-
 }

--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -68,33 +68,27 @@ func (m *Manager) Close() error {
 		if err := a.Close(); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }
 
 // CreateAllocation creates a new allocation and starts relaying
-func (m *Manager) CreateAllocation(
-	fiveTuple *FiveTuple,
-	turnSocket net.PacketConn,
-	requestedPort int,
-	lifetime time.Duration) (*Allocation, error) {
-
+func (m *Manager) CreateAllocation(fiveTuple *FiveTuple, turnSocket net.PacketConn, requestedPort int, lifetime time.Duration) (*Allocation, error) {
 	switch {
 	case fiveTuple == nil:
-		return nil, fmt.Errorf("Allocations must not be created with nil FivTuple")
+		return nil, fmt.Errorf("allocations must not be created with nil FivTuple")
 	case fiveTuple.SrcAddr == nil:
-		return nil, fmt.Errorf("Allocations must not be created with nil FiveTuple.SrcAddr")
+		return nil, fmt.Errorf("allocations must not be created with nil FiveTuple.SrcAddr")
 	case fiveTuple.DstAddr == nil:
-		return nil, fmt.Errorf("Allocations must not be created with nil FiveTuple.DstAddr")
+		return nil, fmt.Errorf("allocations must not be created with nil FiveTuple.DstAddr")
 	case turnSocket == nil:
-		return nil, fmt.Errorf("Allocations must not be created with nil turnSocket")
+		return nil, fmt.Errorf("allocations must not be created with nil turnSocket")
 	case lifetime == 0:
-		return nil, fmt.Errorf("Allocations must not be created with a lifetime of 0")
+		return nil, fmt.Errorf("allocations must not be created with a lifetime of 0")
 	}
 
 	if a := m.GetAllocation(fiveTuple); a != nil {
-		return nil, fmt.Errorf("Allocation attempt created with duplicate FiveTuple %v", fiveTuple)
+		return nil, fmt.Errorf("allocation attempt created with duplicate FiveTuple %v", fiveTuple)
 	}
 	a := NewAllocation(turnSocket, fiveTuple, m.log)
 

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -82,7 +82,6 @@ func subTestAddPermission(t *testing.T) {
 
 	foundPermission := a.GetPermission(p.Addr)
 	assert.Equal(t, p, foundPermission)
-
 }
 
 func subTestRemovePermission(t *testing.T) {

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -70,6 +70,5 @@ func TestBindingManager(t *testing.T) {
 		assert.False(t, ok, "should fail")
 		ok = m.deleteByNumber(uint16(5555))
 		assert.False(t, ok, "should fail")
-
 	})
 }

--- a/internal/client/conn.go
+++ b/internal/client/conn.go
@@ -1,3 +1,4 @@
+// Package client implements the API for a TURN client
 package client
 
 import (
@@ -148,7 +149,6 @@ func (c *UDPConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 			}
 		}
 	}
-
 }
 
 // WriteTo writes a packet with payload p to addr.

--- a/internal/ipnet/util.go
+++ b/internal/ipnet/util.go
@@ -1,3 +1,4 @@
+// Package ipnet contains helper functions around net and IP
 package ipnet
 
 import (

--- a/internal/proto/addr_test.go
+++ b/internal/proto/addr_test.go
@@ -71,13 +71,11 @@ func TestFiveTuple_Equal(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if v := tc.a.Equal(tc.b); v != tc.v {
-				t.Errorf("%s [%v!=%v] %s",
-					tc.a, v, tc.v, tc.b,
-				)
-			}
-		})
+		if v := tc.a.Equal(tc.b); v != tc.v {
+			t.Errorf("(%s) %s [%v!=%v] %s",
+				tc.name, tc.a, v, tc.v, tc.b,
+			)
+		}
 	}
 }
 

--- a/internal/proto/chandata.go
+++ b/internal/proto/chandata.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
 )
@@ -84,8 +85,8 @@ func (c *ChannelData) WriteHeader() {
 	}
 	// Early bounds check to guarantee safety of writes below.
 	_ = c.Raw[:channelDataHeaderSize]
-	bin.PutUint16(c.Raw[:channelDataNumberSize], uint16(c.Number))
-	bin.PutUint16(c.Raw[channelDataNumberSize:channelDataHeaderSize],
+	binary.BigEndian.PutUint16(c.Raw[:channelDataNumberSize], uint16(c.Number))
+	binary.BigEndian.PutUint16(c.Raw[channelDataNumberSize:channelDataHeaderSize],
 		uint16(len(c.Data)),
 	)
 }
@@ -100,9 +101,9 @@ func (c *ChannelData) Decode() error {
 	if len(buf) < channelDataHeaderSize {
 		return io.ErrUnexpectedEOF
 	}
-	num := bin.Uint16(buf[:channelDataNumberSize])
+	num := binary.BigEndian.Uint16(buf[:channelDataNumberSize])
 	c.Number = ChannelNumber(num)
-	l := bin.Uint16(buf[channelDataNumberSize:channelDataHeaderSize])
+	l := binary.BigEndian.Uint16(buf[channelDataNumberSize:channelDataHeaderSize])
 	c.Data = buf[channelDataHeaderSize:]
 	c.Length = int(l)
 	if !c.Number.Valid() {
@@ -129,11 +130,11 @@ func IsChannelData(buf []byte) bool {
 		return false
 	}
 
-	if int(bin.Uint16(buf[channelDataNumberSize:channelDataHeaderSize])) > len(buf[channelDataHeaderSize:]) {
+	if int(binary.BigEndian.Uint16(buf[channelDataNumberSize:channelDataHeaderSize])) > len(buf[channelDataHeaderSize:]) {
 		return false
 	}
 
 	// Quick check for channel number.
-	num := bin.Uint16(buf[0:channelNumberSize])
+	num := binary.BigEndian.Uint16(buf[0:channelNumberSize])
 	return isChannelNumberValid(num)
 }

--- a/internal/proto/chandata_test.go
+++ b/internal/proto/chandata_test.go
@@ -87,11 +87,9 @@ func TestChannelData_Equal(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if v := tc.a.Equal(tc.b); v != tc.value {
-				t.Errorf("unexpected: %v != %v", tc.value, v)
-			}
-		})
+		if v := tc.a.Equal(tc.b); v != tc.value {
+			t.Errorf("unexpected: (%s) %v != %v", tc.name, tc.value, v)
+		}
 	}
 }
 
@@ -126,14 +124,12 @@ func TestChannelData_Decode(t *testing.T) {
 			err:  ErrBadChannelDataLength,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			m := &ChannelData{
-				Raw: tc.buf,
-			}
-			if err := m.Decode(); err != tc.err {
-				t.Errorf("unexpected: %v != %v", tc.err, err)
-			}
-		})
+		m := &ChannelData{
+			Raw: tc.buf,
+		}
+		if err := m.Decode(); err != tc.err {
+			t.Errorf("unexpected: (%s) %v != %v", tc.name, tc.err, err)
+		}
 	}
 }
 
@@ -170,11 +166,9 @@ func TestIsChannelData(t *testing.T) {
 			buf:  []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if v := IsChannelData(tc.buf); v != tc.value {
-				t.Errorf("unexpected: %v != %v", tc.value, v)
-			}
-		})
+		if v := IsChannelData(tc.buf); v != tc.value {
+			t.Errorf("unexpected: (%s) %v != %v", tc.name, tc.value, v)
+		}
 	}
 }
 

--- a/internal/proto/chann.go
+++ b/internal/proto/chann.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"encoding/binary"
 	"errors"
 	"strconv"
 
@@ -22,7 +23,7 @@ const channelNumberSize = 4
 // AddTo adds CHANNEL-NUMBER to message.
 func (n ChannelNumber) AddTo(m *stun.Message) error {
 	v := make([]byte, channelNumberSize)
-	bin.PutUint16(v[:2], uint16(n))
+	binary.BigEndian.PutUint16(v[:2], uint16(n))
 	// v[2:4] are zeroes (RFFU = 0)
 	m.Add(stun.AttrChannelNumber, v)
 	return nil
@@ -38,7 +39,7 @@ func (n *ChannelNumber) GetFrom(m *stun.Message) error {
 		return err
 	}
 	_ = v[channelNumberSize-1] // asserting length
-	*n = ChannelNumber(bin.Uint16(v[:2]))
+	*n = ChannelNumber(binary.BigEndian.Uint16(v[:2]))
 	// v[2:4] is RFFU and equals to 0.
 	return nil
 }

--- a/internal/proto/chann_test.go
+++ b/internal/proto/chann_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkChannelNumber(b *testing.B) {
@@ -20,7 +21,7 @@ func BenchmarkChannelNumber(b *testing.B) {
 	})
 	b.Run("GetFrom", func(b *testing.B) {
 		m := new(stun.Message)
-		ChannelNumber(12).AddTo(m)
+		assert.NoError(b, ChannelNumber(12).AddTo(m))
 		for i := 0; i < b.N; i++ {
 			var n ChannelNumber
 			if err := n.GetFrom(m); err != nil {
@@ -42,7 +43,7 @@ func TestChannelNumber(t *testing.T) {
 		if wasAllocs(func() {
 			// Case with ChannelNumber on stack.
 			n := ChannelNumber(6)
-			n.AddTo(m)
+			n.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -52,7 +53,7 @@ func TestChannelNumber(t *testing.T) {
 		nP := &n
 		if wasAllocs(func() {
 			// On heap.
-			nP.AddTo(m)
+			nP.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -79,7 +80,7 @@ func TestChannelNumber(t *testing.T) {
 			}
 			if wasAllocs(func() {
 				var num ChannelNumber
-				num.GetFrom(decoded)
+				num.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}
@@ -109,10 +110,8 @@ func TestChannelNumber_Valid(t *testing.T) {
 		{MaxChannelNumber, true},
 		{MaxChannelNumber + 1, false},
 	} {
-		t.Run(tc.n.String(), func(t *testing.T) {
-			if v := tc.n.Valid(); v != tc.value {
-				t.Errorf("unexpected: %v != %v", tc.value, v)
-			}
-		})
+		if v := tc.n.Valid(); v != tc.value {
+			t.Errorf("unexpected: (%s) %v != %v", tc.n.String(), tc.value, v)
+		}
 	}
 }

--- a/internal/proto/data_test.go
+++ b/internal/proto/data_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkData(b *testing.B) {
@@ -12,7 +13,7 @@ func BenchmarkData(b *testing.B) {
 		m := new(stun.Message)
 		d := make(Data, 10)
 		for i := 0; i < b.N; i++ {
-			d.AddTo(m)
+			assert.NoError(b, d.AddTo(m))
 			m.Reset()
 		}
 	})
@@ -34,7 +35,7 @@ func TestData(t *testing.T) {
 		if wasAllocs(func() {
 			// On stack.
 			d := Data(v)
-			d.AddTo(m)
+			d.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -43,7 +44,7 @@ func TestData(t *testing.T) {
 		d := &Data{1, 2, 3, 4}
 		if wasAllocs(func() {
 			// On heap.
-			d.AddTo(m)
+			d.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -70,7 +71,7 @@ func TestData(t *testing.T) {
 			}
 			if wasAllocs(func() {
 				var dataDecoded Data
-				dataDecoded.GetFrom(decoded)
+				dataDecoded.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}

--- a/internal/proto/dontfrag.go
+++ b/internal/proto/dontfrag.go
@@ -16,6 +16,3 @@ func (DontFragmentAttr) IsSet(m *stun.Message) bool {
 	_, err := m.Get(stun.AttrDontFragment)
 	return err == nil
 }
-
-// DontFragment is shorthand for DontFragmentAttr.
-var DontFragment DontFragmentAttr

--- a/internal/proto/dontfrag_test.go
+++ b/internal/proto/dontfrag_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestDontFragment(t *testing.T) {
+	var DontFragment DontFragmentAttr
+
 	t.Run("False", func(t *testing.T) {
 		m := new(stun.Message)
 		m.WriteHeader()

--- a/internal/proto/evenport_test.go
+++ b/internal/proto/evenport_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEvenPort(t *testing.T) {
@@ -28,10 +29,9 @@ func TestEvenPort(t *testing.T) {
 		m.WriteHeader()
 		decoded := new(stun.Message)
 		var port EvenPort
-		decoded.Write(m.Raw)
-		if err := port.GetFrom(m); err != nil {
-			t.Fatal(err)
-		}
+		_, err := decoded.Write(m.Raw)
+		assert.NoError(t, err)
+		assert.NoError(t, port.GetFrom(m))
 		if port != p {
 			t.Fatal("not equal")
 		}
@@ -58,7 +58,7 @@ func TestEvenPort(t *testing.T) {
 				t.Errorf("Decoded %q, expected %q", port.String(), p.String())
 			}
 			if wasAllocs(func() {
-				port.GetFrom(decoded)
+				port.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}

--- a/internal/proto/lifetime.go
+++ b/internal/proto/lifetime.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"encoding/binary"
 	"time"
 
 	"github.com/pion/stun"
@@ -30,7 +31,7 @@ const lifetimeSize = 4 // 4 bytes, 32 bits
 // AddTo adds LIFETIME to message.
 func (l Lifetime) AddTo(m *stun.Message) error {
 	v := make([]byte, lifetimeSize)
-	bin.PutUint32(v, uint32(l.Seconds()))
+	binary.BigEndian.PutUint32(v, uint32(l.Seconds()))
 	m.Add(stun.AttrLifetime, v)
 	return nil
 }
@@ -45,11 +46,7 @@ func (l *Lifetime) GetFrom(m *stun.Message) error {
 		return err
 	}
 	_ = v[lifetimeSize-1] // asserting length
-	seconds := bin.Uint32(v)
+	seconds := binary.BigEndian.Uint32(v)
 	l.Duration = time.Second * time.Duration(seconds)
 	return nil
 }
-
-// ZeroLifetime is shorthand for setting zero lifetime
-// that indicates to close allocation.
-var ZeroLifetime stun.Setter = Lifetime{}

--- a/internal/proto/lifetime_test.go
+++ b/internal/proto/lifetime_test.go
@@ -3,30 +3,11 @@ package proto
 import (
 	"testing"
 
-	"fmt"
 	"time"
 
 	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
 )
-
-func ExampleLifetime() {
-	// Encoding lifetime to message.
-	m := new(stun.Message)
-	Lifetime{time.Minute}.AddTo(m)
-	m.WriteHeader()
-
-	// Decoding message.
-	mDec := new(stun.Message)
-	if _, err := m.WriteTo(mDec); err != nil {
-		panic(err)
-	}
-	// Decoding lifetime from message.
-	l := Lifetime{}
-	l.GetFrom(m)
-	fmt.Println("Decoded:", l)
-	// Output:
-	// Decoded: 1m0s
-}
 
 func BenchmarkLifetime(b *testing.B) {
 	b.Run("AddTo", func(b *testing.B) {
@@ -42,7 +23,7 @@ func BenchmarkLifetime(b *testing.B) {
 	})
 	b.Run("GetFrom", func(b *testing.B) {
 		m := new(stun.Message)
-		Lifetime{time.Minute}.AddTo(m)
+		assert.NoError(b, Lifetime{time.Minute}.AddTo(m))
 		for i := 0; i < b.N; i++ {
 			l := Lifetime{}
 			if err := l.GetFrom(m); err != nil {
@@ -66,7 +47,7 @@ func TestLifetime(t *testing.T) {
 			l := Lifetime{
 				Duration: time.Minute,
 			}
-			l.AddTo(m)
+			l.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -75,7 +56,7 @@ func TestLifetime(t *testing.T) {
 		l := &Lifetime{time.Second}
 		if wasAllocs(func() {
 			// On heap.
-			l.AddTo(m)
+			l.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -101,7 +82,7 @@ func TestLifetime(t *testing.T) {
 				t.Errorf("Decoded %q, expected %q", life, l)
 			}
 			if wasAllocs(func() {
-				life.GetFrom(decoded)
+				life.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}

--- a/internal/proto/peeraddr_test.go
+++ b/internal/proto/peeraddr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPeerAddress(t *testing.T) {
@@ -24,9 +25,10 @@ func TestPeerAddress(t *testing.T) {
 	}
 	m.WriteHeader()
 	decoded := new(stun.Message)
-	decoded.Write(m.Raw)
+
+	_, err := decoded.Write(m.Raw)
+	assert.NoError(t, err)
+
 	var aGot PeerAddress
-	if err := aGot.GetFrom(decoded); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, aGot.GetFrom(decoded))
 }

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -4,13 +4,8 @@
 package proto
 
 import (
-	"encoding/binary"
-
 	"github.com/pion/stun"
 )
-
-// bin is shorthand for binary.BigEndian.
-var bin = binary.BigEndian
 
 // Default ports for TURN from RFC 5766 Section 4.
 const (
@@ -20,13 +15,16 @@ const (
 	DefaultTLSPort = stun.DefaultTLSPort
 )
 
-var (
-	// AllocateRequest is shorthand for allocation request message type.
-	AllocateRequest = stun.NewType(stun.MethodAllocate, stun.ClassRequest)
-	// CreatePermissionRequest is shorthand for create permission request type.
-	CreatePermissionRequest = stun.NewType(stun.MethodCreatePermission, stun.ClassRequest)
-	// SendIndication is shorthand for send indication message type.
-	SendIndication = stun.NewType(stun.MethodSend, stun.ClassIndication)
-	// RefreshRequest is shorthand for refresh request message type.
-	RefreshRequest = stun.NewType(stun.MethodRefresh, stun.ClassRequest)
-)
+// CreatePermissionRequest is shorthand for create permission request type.
+func CreatePermissionRequest() stun.MessageType {
+	return stun.NewType(stun.MethodCreatePermission, stun.ClassRequest)
+}
+
+// AllocateRequest is shorthand for allocation request message type.
+func AllocateRequest() stun.MessageType { return stun.NewType(stun.MethodAllocate, stun.ClassRequest) }
+
+// SendIndication is shorthand for send indication message type.
+func SendIndication() stun.MessageType { return stun.NewType(stun.MethodSend, stun.ClassIndication) }
+
+// RefreshRequest is shorthand for refresh request message type.
+func RefreshRequest() stun.MessageType { return stun.NewType(stun.MethodRefresh, stun.ClassRequest) }

--- a/internal/proto/proto_test.go
+++ b/internal/proto/proto_test.go
@@ -16,7 +16,7 @@ func wasAllocs(f func()) bool {
 
 func loadData(tb testing.TB, name string) []byte {
 	name = filepath.Join("testdata", name)
-	f, err := os.Open(name)
+	f, err := os.Open(name) // #nosec
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/proto/relayedaddr_test.go
+++ b/internal/proto/relayedaddr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRelayedAddress(t *testing.T) {
@@ -24,9 +25,10 @@ func TestRelayedAddress(t *testing.T) {
 	}
 	m.WriteHeader()
 	decoded := new(stun.Message)
-	decoded.Write(m.Raw)
+
+	_, err := decoded.Write(m.Raw)
+	assert.NoError(t, err)
+
 	var aGot RelayedAddress
-	if err := aGot.GetFrom(decoded); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, aGot.GetFrom(decoded))
 }

--- a/internal/proto/reqfamily_test.go
+++ b/internal/proto/reqfamily_test.go
@@ -27,7 +27,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 		if wasAllocs(func() {
 			// On stack.
 			r := RequestedFamilyIPv4
-			r.AddTo(m)
+			r.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -37,7 +37,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 		*r = RequestedFamilyIPv4
 		if wasAllocs(func() {
 			// On heap.
-			r.AddTo(m)
+			r.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -63,7 +63,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 				t.Errorf("Decoded %q, expected %q", req, r)
 			}
 			if wasAllocs(func() {
-				r.GetFrom(decoded)
+				r.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}

--- a/internal/proto/reqtrans.go
+++ b/internal/proto/reqtrans.go
@@ -63,9 +63,3 @@ func (t *RequestedTransport) GetFrom(m *stun.Message) error {
 	t.Protocol = Protocol(v[0])
 	return nil
 }
-
-// RequestedTransportUDP is setter for requested transport attribute with
-// value ProtoUDP (17).
-var RequestedTransportUDP stun.Setter = RequestedTransport{
-	Protocol: ProtoUDP,
-}

--- a/internal/proto/reqtrans_test.go
+++ b/internal/proto/reqtrans_test.go
@@ -32,7 +32,7 @@ func TestRequestedTransport(t *testing.T) {
 			r := RequestedTransport{
 				Protocol: ProtoUDP,
 			}
-			r.AddTo(m)
+			r.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -43,7 +43,7 @@ func TestRequestedTransport(t *testing.T) {
 		}
 		if wasAllocs(func() {
 			// On heap.
-			r.AddTo(m)
+			r.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -73,7 +73,7 @@ func TestRequestedTransport(t *testing.T) {
 				t.Errorf("Decoded %q, expected %q", req, r)
 			}
 			if wasAllocs(func() {
-				r.GetFrom(decoded)
+				r.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}

--- a/internal/proto/rsrvtoken_test.go
+++ b/internal/proto/rsrvtoken_test.go
@@ -14,7 +14,7 @@ func TestReservationToken(t *testing.T) {
 		if wasAllocs(func() {
 			// On stack.
 			tk := ReservationToken(tok)
-			tk.AddTo(m)
+			tk.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -23,7 +23,7 @@ func TestReservationToken(t *testing.T) {
 		tk := make(ReservationToken, 8)
 		if wasAllocs(func() {
 			// On heap.
-			tk.AddTo(m)
+			tk.AddTo(m) //nolint
 			m.Reset()
 		}) {
 			t.Error("Unexpected allocations")
@@ -57,7 +57,7 @@ func TestReservationToken(t *testing.T) {
 				t.Errorf("Decoded %v, expected %v", tok, tk)
 			}
 			if wasAllocs(func() {
-				tok.GetFrom(decoded)
+				tok.GetFrom(decoded) //nolint
 			}) {
 				t.Error("Unexpected allocations")
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,4 @@
+//Package server implements the private API for implement a TURN server
 package server
 
 import (

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	// #nosec
-
 	"fmt"
 	"net"
 
@@ -51,7 +49,7 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 	//    a 437 (Allocation Mismatch) error.
 	if alloc := r.AllocationManager.GetAllocation(fiveTuple); alloc != nil {
 		msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodAllocate, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeAllocMismatch})
-		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("Relay already allocated for 5-TUPLE"), msg...)
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("relay already allocated for 5-TUPLE"), msg...)
 	}
 
 	// 3. The server checks if the request contains a REQUESTED-TRANSPORT
@@ -92,7 +90,6 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 		if err = evenPort.GetFrom(m); err == nil {
 			return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("Request must not contain RESERVATION-TOKEN and EVEN-PORT"), badRequestMsg...)
 		}
-
 	}
 
 	// 6. The server checks if the request contains an EVEN-PORT attribute.
@@ -191,7 +188,7 @@ func handleRefreshRequest(r Request, m *stun.Message) error {
 		Protocol: allocation.UDP,
 	})
 	if a == nil {
-		return fmt.Errorf("No allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
+		return fmt.Errorf("no allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
 	}
 
 	lifetimeDuration := allocationLifeTime(m)
@@ -214,7 +211,7 @@ func handleCreatePermissionRequest(r Request, m *stun.Message) error {
 		Protocol: allocation.UDP,
 	})
 	if a == nil {
-		return fmt.Errorf("No allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
+		return fmt.Errorf("no allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
 	}
 
 	messageIntegrity, _, err := authenticateRequest(r, m, stun.MethodChannelBind)
@@ -261,7 +258,7 @@ func handleSendIndication(r Request, m *stun.Message) error {
 		Protocol: allocation.UDP,
 	})
 	if a == nil {
-		return fmt.Errorf("No allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
+		return fmt.Errorf("no allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
 	}
 
 	dataAttr := proto.Data{}
@@ -276,7 +273,7 @@ func handleSendIndication(r Request, m *stun.Message) error {
 
 	msgDst := &net.UDPAddr{IP: peerAddress.IP, Port: peerAddress.Port}
 	if perm := a.GetPermission(msgDst); perm == nil {
-		return fmt.Errorf("Unable to handle send-indication, no permission added: %v", msgDst)
+		return fmt.Errorf("unable to handle send-indication, no permission added: %v", msgDst)
 	}
 
 	l, err := a.RelaySocket.WriteTo(dataAttr, msgDst)
@@ -295,7 +292,7 @@ func handleChannelBindRequest(r Request, m *stun.Message) error {
 		Protocol: allocation.UDP,
 	})
 	if a == nil {
-		return fmt.Errorf("No allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
+		return fmt.Errorf("no allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
 	}
 
 	badRequestMsg := buildMsg(m.TransactionID, stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeBadRequest})
@@ -339,7 +336,7 @@ func handleChannelData(r Request, c *proto.ChannelData) error {
 		Protocol: allocation.UDP,
 	})
 	if a == nil {
-		return fmt.Errorf("No allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
+		return fmt.Errorf("no allocation found for %v:%v", r.SrcAddr, r.Conn.LocalAddr())
 	}
 
 	channel := a.GetChannelByNumber(c.Number)

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -43,5 +43,4 @@ func TestAllocationLifeTime(t *testing.T) {
 			t.Errorf("Expect lifetimeDuration is %s, but %s", proto.DefaultLifetime, lifetimeDuration)
 		}
 	}
-
 }

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -53,7 +53,7 @@ func buildAndSend(conn net.PacketConn, dst net.Addr, attrs ...stun.Setter) error
 // Send a STUN packet and return the original error to the caller
 func buildAndSendErr(conn net.PacketConn, dst net.Addr, err error, attrs ...stun.Setter) error {
 	if sendErr := buildAndSend(conn, dst, attrs...); sendErr != nil {
-		err = fmt.Errorf("Failed to send error message %w %w", sendErr, err)
+		err = fmt.Errorf("failed to send error message %v %v", sendErr, err)
 	}
 	return err
 }
@@ -75,7 +75,6 @@ func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) 
 			stun.NewNonce(nonce),
 			stun.NewRealm(r.Realm),
 		), nil
-
 	}
 
 	nonceAttr := &stun.Nonce{}
@@ -97,7 +96,7 @@ func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) 
 
 	ourKey, ok := r.AuthHandler(usernameAttr.String(), usernameAttr.String(), r.SrcAddr)
 	if !ok {
-		return nil, badRequestMsg, fmt.Errorf("No user exists for %s", usernameAttr.String())
+		return nil, badRequestMsg, fmt.Errorf("no user exists for %s", usernameAttr.String())
 	}
 
 	if err := stun.MessageIntegrity(ourKey).Check(m); err != nil {

--- a/server_config.go
+++ b/server_config.go
@@ -1,6 +1,7 @@
 package turn
 
 import (
+	// #nosec
 	"crypto/md5"
 	"fmt"
 	"net"


### PR DESCRIPTION
Enable following linters
* gochecknoglobals
* scopelint
* govet
* stylecheck
* gosec
* errcheck
* whitespace
