### PR TITLE
Support WASM build/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [Lukas Rezek](https://github.com/lrezek)
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Aaron France](https://github.com/AeroNotix)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package turn
 
 import (

--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package allocation
 
 import (

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package allocation
 
 import (

--- a/server_test.go
+++ b/server_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package turn
 
 import (


### PR DESCRIPTION
Some tests using net.Conn connection are disabled for now
as it is not fully supported by WASM MVP stage.

preparation for https://github.com/pion/.goassets/pull/4