### PR TITLE
Fix Go 1.12 build

### DIFF
--- a/client.go
+++ b/client.go
@@ -415,7 +415,7 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error {
 
 	msg := &stun.Message{Raw: raw}
 	if err := msg.Decode(); err != nil {
-		return fmt.Errorf("failed to decode STUN message: %w", err)
+		return fmt.Errorf("failed to decode STUN message: %s", err.Error())
 	}
 
 	if msg.Type.Class == stun.ClassRequest {

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -352,7 +352,7 @@ func handleChannelData(r Request, c *proto.ChannelData) error {
 
 	l, err := a.RelaySocket.WriteTo(c.Data, channel.Peer)
 	if err != nil {
-		return fmt.Errorf("failed writing to socket: %w", err)
+		return fmt.Errorf("failed writing to socket: %s", err.Error())
 	} else if l != len(c.Data) {
 		return fmt.Errorf("packet write smaller than packet %d != %d (expected)", l, len(c.Data))
 	}

--- a/server.go
+++ b/server.go
@@ -92,7 +92,7 @@ func (s *Server) Close() error {
 
 	err := fmt.Errorf("Server failed to close")
 	for _, e := range errors {
-		err = fmt.Errorf("%w; Close error (%v) ", err, e)
+		err = fmt.Errorf("%s; Close error (%v) ", err.Error(), e)
 	}
 
 	return err


### PR DESCRIPTION
Error wrapping is not yet supported on Go 1.12 fmt package.
It would be nice to be migrated to "%w" error wrapping once
Go 1.12 is deprecated.

ref: https://github.com/pion/turn/pull/112

@Sean-Der any ideas on it?