### PR TITLE
Fix "no listener for" race condition on fast server response

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Aaron France](https://github.com/AeroNotix)
 * [Atsushi Watanabe](https://github.com/at-wat)
+* [Tom Clift](https://github.com/tclift)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/client.go
+++ b/client.go
@@ -335,17 +335,19 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 }
 
 // PerformTransaction performs STUN transaction
-func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, dontWait bool) (client.TransactionResult, error) {
+func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult,
+	error) {
 	trKey := b64.StdEncoding.EncodeToString(msg.TransactionID[:])
 
 	raw := make([]byte, len(msg.Raw))
 	copy(raw, msg.Raw)
 
 	tr := client.NewTransaction(&client.TransactionConfig{
-		Key:      trKey,
-		Raw:      raw,
-		To:       to,
-		Interval: c.rto,
+		Key:          trKey,
+		Raw:          raw,
+		To:           to,
+		Interval:     c.rto,
+		IgnoreResult: ignoreResult,
 	})
 
 	c.trMap.Insert(trKey, tr)
@@ -359,7 +361,7 @@ func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, dontWait boo
 	tr.StartRtxTimer(c.onRtxTimeout)
 
 	// If dontWait is true, get the transaction going and return immediately
-	if dontWait {
+	if ignoreResult {
 		return client.TransactionResult{}, nil
 	}
 


### PR DESCRIPTION
#### Description

Fix race condition where we could attempt to process a result before an appropriate handler was in place. This resulted in log lines like:
```
turnc DEBUG: 23:36:54.500219 client.go:489: no listener for Allocate error response l=88 attrs=5 id=WlJEHi6/lMtgixTn
```
This happened frequently when two peers and the STUN/TURN server were on the same host (e.g. during development, running tests, performing a server-local health check).

The issue was when sending on a transaction's unbuffered result channel before a goroutine was started to receive on the channel. By adding a buffer size of one, it doesn't matter if the result is sent slightly earlier, and we can avoid the complexities of handling concurrency with an unbuffered channel.

There is a related concurrency issue here. A caller of `Transaction.WaitForResult` (or `Client.PerformTransaction`) will block until the transaction's internal `resultCh` channel is closed. This channel is only closed if `Transaction.Close` is called. `Transaction.Close` is only called from `TransactionMap.CloseAndDeleteAll`, which is only called when the client is closed. The transaction is not closed e.g. on initial write failure or retransmission limit exceeded. Should we consider calling `Transaction.Close` in these situations? Care would need to be taken to avoid writing to the closed channel. Aside from the `WaitForResult` blocking, this commit is adding more memory (the now buffered result) that would not be collected until the transaction itself is collected.