### PR TITLE
Fixes race condition caused by AfterFunc callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [Aaron France](https://github.com/AeroNotix)
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [Tom Clift](https://github.com/tclift)
+* [lllf](https://github.com/LittleLightLittleFire)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -64,12 +64,15 @@ func (t *Transaction) StartRtxTimer(onTimeout func(trKey string, nRtx int)) {
 	defer t.mutex.Unlock()
 
 	t.timer = time.AfterFunc(t.interval, func() {
+		t.mutex.Lock()
 		t.nRtx++
+		nRtx := t.nRtx
 		t.interval *= 2
 		if t.interval > maxRtxInterval {
 			t.interval = maxRtxInterval
 		}
-		onTimeout(t.Key, t.nRtx)
+		t.mutex.Unlock()
+		onTimeout(t.Key, nRtx)
 	})
 }
 


### PR DESCRIPTION
nRtx is incremented while the lock is not held.
