### PR TITLE
RFC6062 TURN TCP allocations

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package turn
 
 import (
 	b64 "encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"net"
@@ -19,6 +20,11 @@ const (
 	defaultRTO        = 200 * time.Millisecond
 	maxRtxCount       = 7              // total 7 requests (Rc)
 	maxDataBufferSize = math.MaxUint16 //message size limit for Chromium
+)
+
+const (
+	ProtoUDP = proto.ProtoUDP
+	ProtoTCP = proto.ProtoTCP
 )
 
 //              interval [msec]
@@ -43,6 +49,8 @@ type ClientConfig struct {
 	Conn           net.PacketConn // Listening socket (net.PacketConn)
 	LoggerFactory  logging.LoggerFactory
 	Net            *vnet.Net
+
+	TransportProtocol proto.Protocol // Protocol to peer, UDP: 17 (default) or TCP: 6
 }
 
 // Client is a STUN server client
@@ -66,6 +74,9 @@ type Client struct {
 	mutex         sync.RWMutex           // thread-safe
 	mutexTrMap    sync.Mutex             // thread-safe
 	log           logging.LeveledLogger  // read-only
+
+	transportProtocol proto.Protocol
+	nonce             stun.Nonce
 }
 
 // NewClient returns a new Client instance. listeningAddress is the address and port to listen on, default "0.0.0.0:0"
@@ -87,23 +98,51 @@ func NewClient(config *ClientConfig) (*Client, error) {
 		log.Warn("vnet is enabled")
 	}
 
+	switch config.TransportProtocol {
+	case 0:
+		config.TransportProtocol = ProtoUDP
+	case proto.ProtoTCP, proto.ProtoUDP:
+	default:
+		return nil, fmt.Errorf("unsupported protocol: %v", config.TransportProtocol)
+	}
+
 	var stunServ, turnServ net.Addr
 	var stunServStr, turnServStr string
 	var err error
 	if len(config.STUNServerAddr) > 0 {
 		log.Debugf("resolving %s", config.STUNServerAddr)
-		stunServ, err = config.Net.ResolveUDPAddr("udp4", config.STUNServerAddr)
-		if err != nil {
-			return nil, err
+		switch config.TransportProtocol {
+		case ProtoUDP:
+			stunServ, err = config.Net.ResolveUDPAddr("udp4", config.STUNServerAddr)
+			if err != nil {
+				return nil, err
+			}
+		case ProtoTCP:
+			// TODO: add tcp support to vnet
+			// stunServ, err = config.Net.ResolveTCPAddr("tcp4", config.STUNServerAddr)
+			stunServ, err = net.ResolveTCPAddr("tcp4", config.STUNServerAddr)
+			if err != nil {
+				return nil, err
+			}
 		}
 		stunServStr = stunServ.String()
 		log.Debugf("stunServ: %s", stunServStr)
 	}
 	if len(config.TURNServerAddr) > 0 {
 		log.Debugf("resolving %s", config.TURNServerAddr)
-		turnServ, err = config.Net.ResolveUDPAddr("udp4", config.TURNServerAddr)
-		if err != nil {
-			return nil, err
+		switch config.TransportProtocol {
+		case ProtoUDP:
+			turnServ, err = config.Net.ResolveUDPAddr("udp4", config.TURNServerAddr)
+			if err != nil {
+				return nil, err
+			}
+		case ProtoTCP:
+			// TODO: add tcp support to vnet
+			// turnServ, err = config.Net.ResolveUDPAddr("udp4", config.TURNServerAddr)
+			turnServ, err = net.ResolveTCPAddr("tcp4", config.TURNServerAddr)
+			if err != nil {
+				return nil, err
+			}
 		}
 		turnServStr = turnServ.String()
 		log.Debugf("turnServ: %s", turnServStr)
@@ -115,19 +154,20 @@ func NewClient(config *ClientConfig) (*Client, error) {
 	}
 
 	c := &Client{
-		conn:        config.Conn,
-		stunServ:    stunServ,
-		turnServ:    turnServ,
-		stunServStr: stunServStr,
-		turnServStr: turnServStr,
-		username:    stun.NewUsername(config.Username),
-		password:    config.Password,
-		realm:       stun.NewRealm(config.Realm),
-		software:    stun.NewSoftware(config.Software),
-		net:         config.Net,
-		trMap:       client.NewTransactionMap(),
-		rto:         rto,
-		log:         log,
+		conn:              config.Conn,
+		stunServ:          stunServ,
+		turnServ:          turnServ,
+		stunServStr:       stunServStr,
+		turnServStr:       turnServStr,
+		username:          stun.NewUsername(config.Username),
+		password:          config.Password,
+		realm:             stun.NewRealm(config.Realm),
+		software:          stun.NewSoftware(config.Software),
+		net:               config.Net,
+		trMap:             client.NewTransactionMap(),
+		rto:               rto,
+		log:               log,
+		transportProtocol: config.TransportProtocol,
 	}
 
 	return c, nil
@@ -249,7 +289,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	msg, err := stun.Build(
 		stun.TransactionID,
 		stun.NewType(stun.MethodAllocate, stun.ClassRequest),
-		proto.RequestedTransport{Protocol: proto.ProtoUDP},
+		proto.RequestedTransport{Protocol: c.transportProtocol},
 		stun.Fingerprint,
 	)
 	if err != nil {
@@ -264,8 +304,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	res := trRes.Msg
 
 	// Anonymous allocate failed, trying to authenticate.
-	var nonce stun.Nonce
-	if err = nonce.GetFrom(res); err != nil {
+	if err = c.nonce.GetFrom(res); err != nil {
 		return nil, err
 	}
 	if err = c.realm.GetFrom(res); err != nil {
@@ -279,10 +318,10 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	msg, err = stun.Build(
 		stun.TransactionID,
 		stun.NewType(stun.MethodAllocate, stun.ClassRequest),
-		proto.RequestedTransport{Protocol: proto.ProtoUDP},
+		proto.RequestedTransport{Protocol: c.transportProtocol},
 		&c.username,
 		&c.realm,
-		&nonce,
+		&c.nonce,
 		&c.integrity,
 		stun.Fingerprint,
 	)
@@ -304,6 +343,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 		return nil, fmt.Errorf("%s", res.Type)
 	}
 
+	// TODO: switch for TCP?
 	// Getting relayed addresses from response.
 	var relayed proto.RelayedAddress
 	if err := relayed.GetFrom(res); err != nil {
@@ -320,11 +360,12 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 		return nil, err
 	}
 
+	// TODO: switch for TCP?
 	relayedConn = client.NewUDPConn(&client.UDPConnConfig{
 		Observer:    c,
 		RelayedAddr: relayedAddr,
 		Integrity:   c.integrity,
-		Nonce:       nonce,
+		Nonce:       c.nonce,
 		Lifetime:    lifetime.Duration,
 		Log:         c.log,
 	})
@@ -567,4 +608,121 @@ func (c *Client) relayedUDPConn() *client.UDPConn {
 	defer c.mutex.RUnlock()
 
 	return c.relayedConn
+}
+
+// Connect initiates a new TCP connection to a peer
+func (c *Client) Connect(peer *net.TCPAddr) (ConnectionID, error) {
+	msg := stun.New()
+	msg.WriteHeader()
+	stun.TransactionID.AddTo(msg)
+	stun.NewType(stun.MethodConnect, stun.ClassRequest).AddTo(msg)
+	stun.XORMappedAddress{
+		IP:   peer.IP,
+		Port: peer.Port,
+	}.AddToAs(msg, stun.AttrXORPeerAddress)
+	c.username.AddTo(msg)
+	c.nonce.AddTo(msg)
+	c.realm.AddTo(msg)
+	c.integrity.AddTo(msg)
+	stun.Fingerprint.AddTo(msg)
+
+	trRes, err := c.PerformTransaction(msg, c.turnServ, false)
+	if err != nil {
+		return 0, err
+	}
+	res := trRes.Msg
+
+	if res.Type.Class == stun.ClassErrorResponse {
+		var code stun.ErrorCodeAttribute
+		if err = code.GetFrom(res); err == nil {
+			return 0, fmt.Errorf("%s (error %s)", res.Type, code)
+		}
+		return 0, fmt.Errorf("%s", res.Type)
+	}
+
+	// TODO: extract connection ID res
+	var cid ConnectionID
+	err = cid.GetFrom(res)
+	if err != nil {
+		return 0, err
+	}
+
+	return cid, nil
+}
+
+// ConnectionBind associates the given tcp connection with the remote connection ID.
+// After a successful return the connection can be used normally.
+func (c *Client) ConnectionBind(dataConn net.Conn, cid ConnectionID) error {
+	msg, err := stun.Build(
+		stun.TransactionID,
+		stun.NewType(stun.MethodConnectionBind, stun.ClassRequest),
+		cid,
+		&c.username,
+		&c.realm,
+		&c.nonce,
+		&c.integrity,
+		stun.Fingerprint,
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = dataConn.Write(msg.Raw)
+	if err != nil {
+		return err
+	}
+
+	b := make([]byte, stunHeaderSize)
+	n, err := dataConn.Read(b)
+	if n != stunHeaderSize {
+		return errIncompleteTURNFrame
+	} else if err != nil {
+		return err
+	}
+	if !stun.IsMessage(b) {
+		return errInvalidTURNFrame
+	}
+
+	datagramSize := binary.BigEndian.Uint16(b[2:4]) + stunHeaderSize
+	raw := make([]byte, datagramSize)
+	copy(raw, b)
+	_, err = dataConn.Read(raw[stunHeaderSize:])
+	if err != nil {
+		return err
+	}
+	res := &stun.Message{Raw: raw}
+	if err := res.Decode(); err != nil {
+		return fmt.Errorf("failed to decode STUN message: %s", err.Error())
+	}
+
+	switch res.Type.Class {
+	case stun.ClassErrorResponse:
+		var code stun.ErrorCodeAttribute
+		if err = code.GetFrom(res); err == nil {
+			return fmt.Errorf("%s (error %s)", res.Type, code)
+		}
+		return fmt.Errorf("%s", res.Type)
+	case stun.ClassSuccessResponse:
+		return nil
+	default:
+		return fmt.Errorf("unexpected STUN request message: %s", res.String())
+	}
+}
+
+type ConnectionID uint32
+
+func (c ConnectionID) AddTo(m *stun.Message) error {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(c))
+	m.Add(stun.AttrConnectionID, b)
+	return nil
+}
+
+func (c *ConnectionID) GetFrom(m *stun.Message) error {
+	b, err := m.Get(stun.AttrConnectionID)
+	if err != nil {
+		return err
+	}
+	*c = ConnectionID(binary.BigEndian.Uint32(b))
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/pion/stun v0.3.5
 	github.com/pion/transport v0.10.0
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -51,6 +51,8 @@ func NewManager(config ManagerConfig) (*Manager, error) {
 	return &Manager{
 		log:                config.LeveledLogger,
 		allocations:        make(map[string]*Allocation, 64),
+		waitingconns:       make(map[uint32]*Allocation),
+		runningconns:       make(map[uint32]*Allocation),
 		allocatePacketConn: config.AllocatePacketConn,
 		allocateConn:       config.AllocateConn,
 	}, nil

--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -182,7 +182,7 @@ func newTestManager() (*Manager, error) {
 
 			return conn, conn.LocalAddr(), nil
 		},
-		AllocateConn: func(network string, requestedPort int) (net.Conn, net.Addr, error) { return nil, nil, nil },
+		AllocateConn: func(network string, requestedPort int) (net.Listener, net.Addr, error) { return nil, nil, nil },
 	}
 	return NewManager(config)
 }

--- a/internal/ipnet/util.go
+++ b/internal/ipnet/util.go
@@ -22,17 +22,22 @@ func AddrIPPort(a net.Addr) (net.IP, int, error) {
 }
 
 // AddrEqual asserts that two net.Addrs are equal
-// Currently only supprots UDP but will be extended in the future to support others
+// Currently only supprots UDP and TCP
 func AddrEqual(a, b net.Addr) bool {
-	aUDP, ok := a.(*net.UDPAddr)
-	if !ok {
+	switch a := a.(type) {
+	case *net.UDPAddr:
+		bUDP, ok := b.(*net.UDPAddr)
+		if !ok {
+			return false
+		}
+		return a.IP.Equal(bUDP.IP) && a.Port == bUDP.Port
+	case *net.TCPAddr:
+		bTCP, ok := b.(*net.TCPAddr)
+		if !ok {
+			return false
+		}
+		return a.IP.Equal(bTCP.IP) && a.Port == bTCP.Port
+	default:
 		return false
 	}
-
-	bUDP, ok := b.(*net.UDPAddr)
-	if !ok {
-		return false
-	}
-
-	return aUDP.IP.Equal(bUDP.IP) && aUDP.Port == bUDP.Port
 }

--- a/internal/proto/addr.go
+++ b/internal/proto/addr.go
@@ -20,6 +20,12 @@ func (a *Addr) FromUDPAddr(n *net.UDPAddr) {
 	a.Port = n.Port
 }
 
+// FromTCPAddr sets addr to TCPAddr.
+func (a *Addr) FromTCPAddr(n *net.TCPAddr) {
+	a.IP = n.IP
+	a.Port = n.Port
+}
+
 // Equal returns true if b == a.
 func (a Addr) Equal(b Addr) bool {
 	if a.Port != b.Port {

--- a/internal/proto/addr_test.go
+++ b/internal/proto/addr_test.go
@@ -21,6 +21,21 @@ func TestAddr_FromUDPAddr(t *testing.T) {
 	}
 }
 
+func TestAddr_FromTCPAddr(t *testing.T) {
+	u := &net.TCPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 1234,
+	}
+	a := new(Addr)
+	a.FromTCPAddr(u)
+	if !u.IP.Equal(a.IP) || u.Port != a.Port || u.String() != a.String() {
+		t.Error("not equal")
+	}
+	if a.Network() != "turn" {
+		t.Error("unexpected network")
+	}
+}
+
 func TestAddr_EqualIP(t *testing.T) {
 	a := Addr{
 		IP:   net.IPv4(127, 0, 0, 1),

--- a/internal/proto/reqtrans.go
+++ b/internal/proto/reqtrans.go
@@ -10,12 +10,16 @@ import (
 type Protocol byte
 
 const (
+	// ProtoTCP is IANA assigned protocol number for TCP.
+	ProtoTCP Protocol = 6
 	// ProtoUDP is IANA assigned protocol number for UDP.
 	ProtoUDP Protocol = 17
 )
 
 func (p Protocol) String() string {
 	switch p {
+	case ProtoTCP:
+		return "TCP"
 	case ProtoUDP:
 		return "UDP"
 	default:
@@ -27,7 +31,8 @@ func (p Protocol) String() string {
 //
 // This attribute is used by the client to request a specific transport
 // protocol for the allocated transport address. RFC 5766 only allows the use of
-// codepoint 17 (User Datagram Protocol).
+// codepoint 17 (User Datagram Protocol). RFC 6062 extends support to include
+// codepoint 6 (Transmission Control Protocol).
 //
 // RFC 5766 Section 14.7
 type RequestedTransport struct {

--- a/internal/proto/reqtrans_test.go
+++ b/internal/proto/reqtrans_test.go
@@ -16,6 +16,12 @@ func TestRequestedTransport(t *testing.T) {
 				"protocol: UDP",
 			)
 		}
+		r.Protocol = 6
+		if r.String() != "protocol: TCP" {
+			t.Errorf("bad string %q, expected %q", r,
+				"protocol: TCP",
+			)
+		}
 		r.Protocol = 254
 		if r.String() != "protocol: 254" {
 			if r.String() != "protocol: UDP" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,10 @@ func getMessageHandler(class stun.MessageClass, method stun.Method) (func(r Requ
 			return handleChannelBindRequest, nil
 		case stun.MethodBinding:
 			return handleBindingRequest, nil
+		case stun.MethodConnect:
+			return handleConnectRequest, nil
+		case stun.MethodConnectionBind:
+			return handleConnectionBindRequest, nil
 		default:
 			return nil, fmt.Errorf("unexpected method: %s", method)
 		}

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"encoding/binary"
 	"fmt"
+	"io"
 	"net"
 
 	"github.com/pion/stun"
@@ -49,12 +51,22 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 	//    Request) error.  Otherwise, if the attribute is included but
 	//    specifies a protocol other that UDP, the server rejects the
 	//    request with a 442 (Unsupported Transport Protocol) error.
+	//
+	// Updated by https://tools.ietf.org/html/rfc6062#section-5.1
+	// 1. If the REQUESTED-TRANSPORT attribute is included and specifies a
+	//    protocol other than UDP or TCP, the server MUST reject the
+	//    request with a 442 (Unsupported Transport Protocol) error.  If
+	//    the value is UDP, and if UDP transport is allowed by local
+	//    policy, the server MUST continue with the procedures of [RFC5766]
+	//    instead of this document.  If the value is UDP, and if UDP
+	//    transport is forbidden by local policy, the server MUST reject
+	//    the request with a 403 (Forbidden) error.
 	var requestedTransport proto.RequestedTransport
 	if err = requestedTransport.GetFrom(m); err != nil {
 		return buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
-	} else if requestedTransport.Protocol != proto.ProtoUDP {
+	} else if requestedTransport.Protocol != proto.ProtoUDP && requestedTransport.Protocol != proto.ProtoTCP {
 		msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodAllocate, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeUnsupportedTransProto})
-		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("RequestedTransport must be UDP"), msg...)
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("RequestedTransport must be UDP or TCP"), msg...)
 	}
 
 	// 4. The request may contain a DONT-FRAGMENT attribute.  If it does,
@@ -62,6 +74,11 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 	//    bit set to 1 (see Section 12), then the server treats the DONT-
 	//    FRAGMENT attribute in the Allocate request as an unknown
 	//    comprehension-required attribute.
+	//
+	// Updated by https://tools.ietf.org/html/rfc6062#section-5.1
+	// 3. If the request contains the DONT-FRAGMENT, EVEN-PORT, or
+	//    RESERVATION-TOKEN attribute, the server MUST reject the request
+	//    with a 400 (Bad Request) error.
 	if m.Contains(stun.AttrDontFragment) {
 		msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodAllocate, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeUnknownAttribute}, &stun.UnknownAttributes{stun.AttrDontFragment})
 		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("no support for DONT-FRAGMENT"), msg...)
@@ -81,6 +98,14 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 		if err = evenPort.GetFrom(m); err == nil {
 			return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("Request must not contain RESERVATION-TOKEN and EVEN-PORT"), badRequestMsg...)
 		}
+
+		// Updated by https://tools.ietf.org/html/rfc6062#section-5.1
+		// 3. If the request contains the DONT-FRAGMENT, EVEN-PORT, or
+		//    RESERVATION-TOKEN attribute, the server MUST reject the request
+		//    with a 400 (Bad Request) error.
+		if requestedTransport.Protocol == proto.ProtoTCP {
+			return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("Request must not contain RESERVATION-TOKEN for TCP"), badRequestMsg...)
+		}
 	}
 
 	// 6. The server checks if the request contains an EVEN-PORT attribute.
@@ -91,6 +116,14 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 	//    error.
 	var evenPort proto.EvenPort
 	if err = evenPort.GetFrom(m); err == nil {
+		// Updated by https://tools.ietf.org/html/rfc6062#section-5.1
+		// 3. If the request contains the DONT-FRAGMENT, EVEN-PORT, or
+		//    RESERVATION-TOKEN attribute, the server MUST reject the request
+		//    with a 400 (Bad Request) error.
+		if requestedTransport.Protocol == proto.ProtoTCP {
+			return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("Request must not contain EVEN-PORT for TCP"), badRequestMsg...)
+		}
+
 		randomPort := 0
 		randomPort, err = r.AllocationManager.GetRandomEvenPort()
 		if err != nil {
@@ -156,7 +189,10 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 		},
 	}
 
-	if reservationToken != "" {
+	// Updated by https://tools.ietf.org/html/rfc6062#section-5.1
+	// 5.  The RESERVATION-TOKEN attribute MUST NOT be present in the
+	//     success response.
+	if requestedTransport.Protocol == proto.ProtoUDP && reservationToken != "" {
 		r.AllocationManager.CreateReservation(reservationToken, relayPort)
 		responseAttrs = append(responseAttrs, proto.ReservationToken([]byte(reservationToken)))
 	}
@@ -324,6 +360,140 @@ func handleChannelBindRequest(r Request, m *stun.Message) error {
 	return buildAndSend(r.Conn, r.SrcAddr, buildMsg(m.TransactionID, stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse), []stun.Setter{messageIntegrity}...)...)
 }
 
+// // Updated by https://tools.ietf.org/html/rfc6062#section-5.2
+func handleConnectRequest(r Request, m *stun.Message) error {
+	r.Log.Debugf("received ConnectionRequest from %s", r.SrcAddr.String())
+
+	badRequestMsg := buildMsg(m.TransactionID, stun.NewType(stun.MethodConnectionBind, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeBadRequest})
+
+	// If the request is received on a TCP connection for which no
+	// allocation exists, the server MUST return a 437 (Allocation Mismatch)
+	// error.
+	a := r.AllocationManager.GetAllocation(&allocation.FiveTuple{
+		Protocol: allocation.TCP,
+		SrcAddr:  r.SrcAddr,
+		DstAddr:  r.Conn.LocalAddr(),
+	})
+	if a == nil {
+		msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodConnect, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeAllocMismatch})
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("no allocation"), msg...)
+	}
+
+	// If the request does not contain an XOR-PEER-ADDRESS attribute, or if
+	// such attribute is invalid, the server MUST return a 400 (Bad Request)
+	// error.
+	var peerAddr stun.XORMappedAddress
+	if err := peerAddr.GetFromAs(m, stun.AttrXORPeerAddress); err != nil {
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("no XOR-PEER-ADDRESS"), badRequestMsg...)
+	}
+
+	// If the server is currently processing a Connect request for this
+	// allocation with the same XOR-PEER-ADDRESS, it MUST return a 446
+	// (Connection Already Exists) error.
+	//
+	// If the server has already successfully processed a Connect request
+	// for this allocation with the same XOR-PEER-ADDRESS, and the resulting
+	// client and peer data connections are either pending or active, it
+	// MUST return a 446 (Connection Already Exists) error.
+	if c := a.GetConnectionByAddr(peerAddr.String()); c != nil {
+		msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodConnect, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeConnAlreadyExists})
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("connection already exists"), msg...)
+	}
+
+	// If the new connection is forbidden by local policy, the server MUST
+	// reject the request with a 403 (Forbidden) error.
+	//
+	// Otherwise, the server MUST initiate an outgoing TCP connection.  The
+	// local endpoint is the relayed transport address associated with the
+	// allocation.  The remote endpoint is the one indicated by the XOR-
+	// PEER-ADDRESS attribute.  If the connection attempt fails or times
+	// out, the server MUST return a 447 (Connection Timeout or Failure)
+	// error.  The timeout value MUST be at least 30 seconds.
+	cid, err := r.AllocationManager.Connect(a, peerAddr.String())
+	if err != nil {
+		msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodConnect, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeConnTimeoutOrFailure})
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("connection failure"), msg...)
+	}
+
+	// If the connection is successful, it is now called a peer data
+	// connection.  The server MUST buffer any data received from the
+	// client.  The server adjusts its advertised TCP receive window to
+	// reflect the amount of empty buffer space.
+	//
+	// The server MUST include the CONNECTION-ID attribute in the Connect
+	// success response.  The attribute's value MUST uniquely identify the
+	// peer data connection.
+	return buildAndSend(r.Conn, r.SrcAddr, buildMsg(m.TransactionID, stun.NewType(stun.MethodConnect, stun.ClassSuccessResponse), ConnectionID(cid))...)
+}
+
+// // https://tools.ietf.org/html/rfc6062#section-5.4
+func handleConnectionBindRequest(r Request, m *stun.Message) error {
+	r.Log.Debugf("received ConnectionBindRequest from %s", r.SrcAddr.String())
+
+	badRequestMsg := buildMsg(m.TransactionID, stun.NewType(stun.MethodConnectionBind, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeBadRequest})
+
+	// TODO: check if auth necessary?
+	messageIntegrity, hasAuth, err := authenticateRequest(r, m, stun.MethodRefresh)
+	if !hasAuth {
+
+		return err
+	}
+
+	// If the client connection transport is not TCP or TLS, the server MUST
+	// return a 400 (Bad Request) error.
+	type conner interface{ Conn() net.Conn }
+	stunconn, ok := r.Conn.(conner)
+	if !ok {
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("must use TCP transport"), badRequestMsg...)
+	}
+	clientConn := stunconn.Conn()
+
+	// If the request does not contain the CONNECTION-ID attribute, or if
+	// this attribute does not refer to an existing pending connection, the
+	// server MUST return a 400 (Bad Request) error.
+	var cid ConnectionID
+	if err := cid.GetFrom(m); err != nil {
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("no CONNECTION-ID"), badRequestMsg...)
+	}
+
+	peerConn := r.AllocationManager.BindConnection(uint32(cid))
+	if peerConn == nil {
+		return buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("must use TCP transport"), badRequestMsg...)
+	}
+
+	// Otherwise, the client connection is now called a client data
+	// connection.  Data received on it MUST be sent as-is to the associated
+	// peer data connection.
+	//
+	// Data received on the associated peer data connection MUST be sent
+	// as-is on this client data connection.  This includes data that was
+	// received after the associated Connect or request was successfully
+	// processed and before this ConnectionBind request was received.
+	//
+	// https://tools.ietf.org/html/rfc6062#section-5.5
+	//
+	// If the allocation associated with a data connection expires, the data
+	// connection MUST be closed.
+	//
+	// When a client data connection is closed, the server MUST close the
+	// corresponding peer data connection.
+	//
+	// When a peer data connection is closed, the server MUST close the
+	// corresponding client data connection.
+	go func() {
+		io.Copy(clientConn, peerConn)
+		clientConn.Close()
+		peerConn.Close()
+	}()
+	go func() {
+		io.Copy(peerConn, clientConn)
+		clientConn.Close()
+		peerConn.Close()
+	}()
+
+	return buildAndSend(r.Conn, r.SrcAddr, buildMsg(m.TransactionID, stun.NewType(stun.MethodConnectionBind, stun.ClassSuccessResponse), []stun.Setter{messageIntegrity}...)...)
+}
+
 func handleChannelData(r Request, c *proto.ChannelData) error {
 	r.Log.Debugf("received ChannelData from %s", r.SrcAddr.String())
 
@@ -348,5 +518,23 @@ func handleChannelData(r Request, c *proto.ChannelData) error {
 		return fmt.Errorf("packet write smaller than packet %d != %d (expected)", l, len(c.Data))
 	}
 
+	return nil
+}
+
+type ConnectionID uint32
+
+func (c ConnectionID) AddTo(m *stun.Message) error {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(c))
+	m.Add(stun.AttrConnectionID, b)
+	return nil
+}
+
+func (c *ConnectionID) GetFrom(m *stun.Message) error {
+	b, err := m.Get(stun.AttrConnectionID)
+	if err != nil {
+		return err
+	}
+	*c = ConnectionID(binary.BigEndian.Uint32(b))
 	return nil
 }

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -69,7 +69,7 @@ func TestAllocationLifeTime(t *testing.T) {
 
 				return conn, conn.LocalAddr(), nil
 			},
-			AllocateConn: func(network string, requestedPort int) (net.Conn, net.Addr, error) {
+			AllocateConn: func(network string, requestedPort int) (net.Listener, net.Addr, error) {
 				return nil, nil, nil
 			},
 			LeveledLogger: logger,

--- a/relay_address_generator_none.go
+++ b/relay_address_generator_none.go
@@ -1,7 +1,6 @@
 package turn
 
 import (
-	"fmt"
 	"net"
 	"strconv"
 
@@ -32,7 +31,7 @@ func (r *RelayAddressGeneratorNone) Validate() error {
 
 // AllocatePacketConn generates a new PacketConn to receive traffic on and the IP/Port to populate the allocation response with
 func (r *RelayAddressGeneratorNone) AllocatePacketConn(network string, requestedPort int) (net.PacketConn, net.Addr, error) {
-	conn, err := r.Net.ListenPacket(network, r.Address+":"+strconv.Itoa(requestedPort))
+	conn, err := r.Net.ListenPacket(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -41,6 +40,12 @@ func (r *RelayAddressGeneratorNone) AllocatePacketConn(network string, requested
 }
 
 // AllocateConn generates a new Conn to receive traffic on and the IP/Port to populate the allocation response with
-func (r *RelayAddressGeneratorNone) AllocateConn(network string, requestedPort int) (net.Conn, net.Addr, error) {
-	return nil, nil, fmt.Errorf("TODO")
+func (r *RelayAddressGeneratorNone) AllocateConn(network string, requestedPort int) (net.Listener, net.Addr, error) {
+	// TODO: switch to vnet
+	listener, err := net.Listen(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return listener, listener.Addr(), nil
 }

--- a/relay_address_generator_none.go
+++ b/relay_address_generator_none.go
@@ -1,10 +1,13 @@
 package turn
 
 import (
+	"context"
 	"net"
 	"strconv"
+	"syscall"
 
 	"github.com/pion/transport/vnet"
+	"golang.org/x/sys/unix"
 )
 
 // RelayAddressGeneratorNone returns the listener with no modifications
@@ -41,8 +44,17 @@ func (r *RelayAddressGeneratorNone) AllocatePacketConn(network string, requested
 
 // AllocateConn generates a new Conn to receive traffic on and the IP/Port to populate the allocation response with
 func (r *RelayAddressGeneratorNone) AllocateConn(network string, requestedPort int) (net.Listener, net.Addr, error) {
-	// TODO: switch to vnet
-	listener, err := net.Listen(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
+	// TODO: switch to vnet, make multiplatform
+	lc := &net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var err error
+			c.Control(func(fd uintptr) {
+				err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEADDR|unix.SO_REUSEPORT, 1)
+			})
+			return err
+		},
+	}
+	listener, err := lc.Listen(context.Background(), network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/relay_address_generator_static.go
+++ b/relay_address_generator_static.go
@@ -1,7 +1,6 @@
 package turn
 
 import (
-	"fmt"
 	"net"
 	"strconv"
 
@@ -51,6 +50,16 @@ func (r *RelayAddressGeneratorStatic) AllocatePacketConn(network string, request
 }
 
 // AllocateConn generates a new Conn to receive traffic on and the IP/Port to populate the allocation response with
-func (r *RelayAddressGeneratorStatic) AllocateConn(network string, requestedPort int) (net.Conn, net.Addr, error) {
-	return nil, nil, fmt.Errorf("TODO")
+func (r *RelayAddressGeneratorStatic) AllocateConn(network string, requestedPort int) (net.Listener, net.Addr, error) {
+	// TODO: switch to vnet
+	listener, err := net.Listen(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Replace actual listening IP with the user requested one of RelayAddressGeneratorStatic
+	relayAddr := listener.Addr().(*net.TCPAddr)
+	relayAddr.IP = r.RelayAddress
+
+	return listener, relayAddr, nil
 }

--- a/server.go
+++ b/server.go
@@ -58,8 +58,8 @@ func NewServer(config ServerConfig) (*Server, error) {
 		go func(p PacketConnConfig) {
 			allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
 				AllocatePacketConn: p.RelayAddressGenerator.AllocatePacketConn,
-				AllocateConn:       p.RelayAddressGenerator.AllocateConn,
-				LeveledLogger:      s.log,
+				// AllocateConn: not set, not allowed from packet conns
+				LeveledLogger: s.log,
 			})
 			if err != nil {
 				s.log.Errorf("exit read loop on error: %s", err.Error())

--- a/server_config.go
+++ b/server_config.go
@@ -21,7 +21,7 @@ type RelayAddressGenerator interface {
 	AllocatePacketConn(network string, requestedPort int) (net.PacketConn, net.Addr, error)
 
 	// Allocate a Conn (TCP) RelayAddress
-	AllocateConn(network string, requestedPort int) (net.Conn, net.Addr, error)
+	AllocateConn(network string, requestedPort int) (net.Listener, net.Addr, error)
 }
 
 // PacketConnConfig is a single net.PacketConn to listen/write on. This will be used for UDP listeners

--- a/stun_conn.go
+++ b/stun_conn.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -70,7 +69,6 @@ func (s *STUNConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 	s.l.Lock() // Not using defer because this function is recursive
 	n, err = consumeSingleTURNFrame(s.buff)
 	if err == errInvalidTURNFrame {
-		fmt.Println(s)
 		s.l.Unlock()
 		return 0, nil, err
 	} else if err == nil {


### PR DESCRIPTION
#### Description

Implements both client and server side support for TCP allocations and connections to peers.

Things to do:
- [ ] tests, what to test?
- [ ] add example(s)
- [ ] review/break out use of syscalls for port reuse
- [ ] review double lookup `internal/server/turn.go`

#### Reference issue

Fixes #143, #118 
