### PR TITLE
Add generic Dockerfile and docker-compose.yml for pion examples/turn-server/simple

### DIFF
--- a/examples/turn-server/simple/Dockerfile
+++ b/examples/turn-server/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:latest
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=master

--- a/examples/turn-server/simple/Dockerfile
+++ b/examples/turn-server/simple/Dockerfile
@@ -1,0 +1,50 @@
+FROM golang:1.10
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION=master
+
+LABEL org.label-schema.build-date="${BUILD_DATE}" \
+      org.label-schema.name="pion-turn" \
+      org.label-schema.description="A toolkit for building TURN clients and servers in Go" \
+      org.label-schema.usage="https://github.com/pion/turn#readme" \
+      org.label-schema.vcs-ref="${VCS_REF}" \
+      org.label-schema.vcs-url="https://github.com/pion/turn" \
+      org.label-schema.vendor="Sean-Der" \
+      org.label-schema.version="${VERSION}" \
+      maintainer="https://github.com/pion"
+
+ENV GOPATH /usr/local
+ENV REALM localhost
+ENV USERS username=password
+ENV UDP_PORT 3478
+ENV PUBLIC_IP 127.0.0.1
+
+# Use turn-server/simple by default
+ENV EXAMPLE_DIR examples/turn-server
+ENV EXAMPLE_BIN simple
+
+WORKDIR /usr/local/src/github.com/pions
+
+# Clone Source using GIT
+RUN git clone --branch=$VERSION --depth=1 https://github.com/pion/turn.git turn && rm -rf turn/.git
+
+WORKDIR /usr/local/src/github.com/pions/turn/$EXAMPLE_DIR
+
+# Download all the dependencies
+RUN go get -d -v ./...
+
+# Install the package
+RUN go install -v ./...
+
+EXPOSE 3478
+#EXPOSE 49152:65535/tcp
+#EXPOSE 49152:65535/udp
+
+RUN chown -R nobody:nogroup ./ && chmod -R a-w ./
+USER nobody
+
+# Run the executable
+CMD $EXAMPLE_BIN -public-ip $PUBLIC_IP -users $USERS -realm $REALM -port $UDP_PORT
+
+# docker build -t pion-turn -f Dockerfile .
+# docker run -e REALM="localhost" -e USERS="username=password" -e UDP_PORT="3478" -e PUBLIC_IP="127.0.0.1" -p 3478:3478 pion-turn

--- a/examples/turn-server/simple/docker-compose.yml
+++ b/examples/turn-server/simple/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.1"
+
+pion-turn:
+  freeswitch:
+    container_name: pion-turn
+     image: pion-turn:${VERSION:-latest}
+    build:
+      context: ./
+    tty: true
+    stdin_open: true
+    environment:
+      - VERSION=${PION_TURN_VERSION:-master}
+      - REALM=${PION_TURN_REALM:-localhost}
+      - USERS=${PION_TURN_USERS:-username=password}
+      - PUBLIC_IP=${PION_TURN_PUBLIC_IP:-127.0.0.1}
+      - UDP_PORT=${PION_TURN_UDP_PORT:-3478}
+    #networks:
+    #  - backend
+    network_mode: host
+    ports:
+      # STUN
+      - "3478:3478"
+      # TURN
+      - "49152-65535:49152-65535"
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+   
+#networks:
+#  frontend:
+#  backend:

--- a/examples/turn-server/simple/docker-compose.yml
+++ b/examples/turn-server/simple/docker-compose.yml
@@ -1,12 +1,11 @@
 version: "3.1"
 
-pion-turn:
-  freeswitch:
-    container_name: pion-turn
-     image: pion-turn:${VERSION:-latest}
+services:
+  pion-turn:
+    container_name: "pion-turn"
+    image: pion-turn:${VERSION:-latest}
     build:
       context: ./
-    tty: true
     stdin_open: true
     environment:
       - VERSION=${PION_TURN_VERSION:-master}
@@ -14,18 +13,12 @@ pion-turn:
       - USERS=${PION_TURN_USERS:-username=password}
       - PUBLIC_IP=${PION_TURN_PUBLIC_IP:-127.0.0.1}
       - UDP_PORT=${PION_TURN_UDP_PORT:-3478}
-    #networks:
-    #  - backend
     network_mode: host
     ports:
       # STUN
-      - "3478:3478"
+      - "${PION_TURN_UDP_PORT:-3478}:${PION_TURN_UDP_PORT:-3478}"
       # TURN
       - "49152-65535:49152-65535"
     cap_add:
       - NET_ADMIN
       - NET_RAW
-   
-#networks:
-#  frontend:
-#  backend:


### PR DESCRIPTION
#### Description

add generic Dockerfile and docker-compose.yml for pion examples/turn-server/simple

Usage:
> git clone https://github.com/pion/turn.git pion-turn
> cd pion-turn/examples/turn-server/simple
> docker build -t pion-turn -f Dockerfile .
> docker run -e REALM="localhost" -e USERS="username=password" -e UDP_PORT="3478" -e PUBLIC_IP="127.0.0.1" -p 3478:3478 pion-turn

#### Reference issue
Fixes #151
Fixes #238
