### PR TITLE
Long-Term Credentials (lt-cred mechanism)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [lllf](https://github.com/LittleLightLittleFire)
 * nindolabs (Marouane)
 * [Onwuka Gideon](https://github.com/dongido001)
+* [Herman Banken](https://github.com/hermanbanken)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/examples/turn-client/lt-cred/README.md
+++ b/examples/turn-client/lt-cred/README.md
@@ -1,0 +1,16 @@
+# Usage
+
+```bash
+export SECRET=somesecret
+
+# Build binaries
+(cd examples/turn-client/lt-cred && go build .)
+(cd examples/turn-server/lt-cred && go build .)
+(cd examples/turn-client/tcp && go build .)
+
+# Start server
+./examples/turn-server/lt-cred/lt-cred -public-ip=127.0.0.1 -authSecret=$SECRET &
+
+# Start client using generated credentials
+./examples/turn-client/lt-cred/lt-cred -authSecret=$SECRET | xargs -I {} ./examples/turn-client/tcp/tcp -user="{}={}" -host=shard-1.eu.gcp.borrel.app -port=443 -ping -realm=meet.jitsi
+```

--- a/examples/turn-client/lt-cred/main.go
+++ b/examples/turn-client/lt-cred/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -11,13 +12,20 @@ import (
 
 // Outputs username & password according to the
 // Long-Term Credential Mechanism (RFC5389-10.2: https://tools.ietf.org/search/rfc5389#section-10.2)
-//
-// Usage:
-// $ ltcred | xargs -n 2 -I {} turn-client-tcp -host example.org -user={}={} -ping=true
-//
 func main() {
 	authSecret := flag.String("authSecret", "", "Shared secret for the Long Term Credential Mechanism")
+	showHelp := flag.Bool("h", false, "Show usage")
 	flag.Parse()
+
+	if showHelp != nil && *showHelp {
+		log.Println("Usage:")
+		log.Println("$ ltcred | xargs -n 2 -I {} turn-client-tcp -host example.org -user={}={} -ping=true")
+		return
+	}
+
+	if authSecret == nil || len(*authSecret) == 0 {
+		log.Fatal("Missing -authSecret parameter")
+	}
 
 	u, p, _ := ltcred.GenerateCredentials(*authSecret, time.Minute)
 	os.Stderr.WriteString("username\tpassword\n")      // ignored by xargs

--- a/examples/turn-client/ltcred/main.go
+++ b/examples/turn-client/ltcred/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pion/turn/v2/internal/ltcred"
+)
+
+// Outputs username & password according to the
+// Long-Term Credential Mechanism (RFC5389-10.2: https://tools.ietf.org/search/rfc5389#section-10.2)
+//
+// Usage:
+// $ ltcred | xargs -n 2 -I {} turn-client-tcp -host example.org -user={}={} -ping=true
+//
+func main() {
+	authSecret := flag.String("authSecret", "", "Shared secret for the Long Term Credential Mechanism")
+	flag.Parse()
+
+	u, p, _ := ltcred.GenerateCredentials(*authSecret, time.Minute)
+	os.Stderr.WriteString("username\tpassword\n")      // ignored by xargs
+	os.Stdout.WriteString(fmt.Sprintf("%s\t%s", u, p)) // for use with xargs
+	os.Stderr.WriteString("\n")                        // ignored by xargs
+}

--- a/examples/turn-server/lt-cred/main.go
+++ b/examples/turn-server/lt-cred/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	loglib "log"
+
+	"github.com/pion/turn/v2"
+	"github.com/pion/turn/v2/internal/ltcred"
+)
+
+var log *loglib.Logger = loglib.New(os.Stderr, "", loglib.LstdFlags)
+
+func main() {
+	publicIP := flag.String("public-ip", "", "IP Address that TURN can be contacted by.")
+	port := flag.Int("port", 3478, "Listening port.")
+	authSecret := flag.String("authSecret", "", "Shared secret for the Long Term Credential Mechanism")
+	realm := flag.String("realm", "pion.ly", "Realm (defaults to \"pion.ly\")")
+	flag.Parse()
+
+	if len(*publicIP) == 0 {
+		log.Fatalf("'public-ip' is required")
+	} else if len(*authSecret) == 0 {
+		log.Fatalf("'authSecret' is required")
+	}
+
+	// Create a UDP listener to pass into pion/turn
+	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
+	// this allows us to add logging, storage or modify inbound/outbound traffic
+	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port))
+	if err != nil {
+		log.Panicf("Failed to create TURN server listener: %s", err)
+	}
+
+	s, err := turn.NewServer(turn.ServerConfig{
+		Realm: *realm,
+		// Set AuthHandler callback
+		// This is called everytime a user tries to authenticate with the TURN server
+		// Return the key for that user, or false when no user is found
+		AuthHandler: ltcred.NewAuthHandler(*authSecret, log),
+		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
+		PacketConnConfigs: []turn.PacketConnConfig{
+			{
+				PacketConn: udpListener,
+				RelayAddressGenerator: &turn.RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP(*publicIP), // Claim that we are listening on IP passed by user (This should be your Public IP)
+					Address:      "0.0.0.0",              // But actually be listening on every interface
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Block until user sends SIGINT or SIGTERM
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	if err = s.Close(); err != nil {
+		log.Panic(err)
+	}
+}

--- a/internal/ltcred/log.go
+++ b/internal/ltcred/log.go
@@ -1,0 +1,10 @@
+package ltcred
+
+// Feedback is a way to receive debug information from the AuthHandler
+type Feedback interface {
+	Print(...interface{})
+}
+
+type noFeedback int
+
+func (noFeedback) Print(...interface{}) {}

--- a/internal/ltcred/lt_cred.go
+++ b/internal/ltcred/lt_cred.go
@@ -4,7 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
-	loglib "log"
+	"fmt"
 	"net"
 	"strconv"
 	"time"
@@ -23,21 +23,24 @@ func longTermCredentials(username string, sharedSecret string) (string, error) {
 }
 
 // NewAuthHandler returns a turn.AuthAuthHandler used with Long Term (or Time Windowed) Credentials.
-func NewAuthHandler(sharedSecret string, log *loglib.Logger) turn.AuthHandler {
+func NewAuthHandler(sharedSecret string, f Feedback) turn.AuthHandler {
+	if f == nil {
+		f = noFeedback(0)
+	}
 	return func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
-		log.Printf("Authentication username=%q realm=%q srcAddr=%v\n", username, realm, srcAddr)
+		f.Print(fmt.Sprintf("Authentication username=%q realm=%q srcAddr=%v\n", username, realm, srcAddr))
 		t, err := strconv.Atoi(username)
 		if err != nil {
-			log.Printf("Invalid time-windowed username %q", username)
+			f.Print(fmt.Sprintf("Invalid time-windowed username %q", username))
 			return nil, false
 		}
 		if int64(t) < time.Now().Unix() {
-			log.Printf("Expired time-windowed username %q", username)
+			f.Print(fmt.Sprintf("Expired time-windowed username %q", username))
 			return nil, false
 		}
 		password, err := longTermCredentials(username, sharedSecret)
 		if err != nil {
-			log.Print(err)
+			f.Print(err)
 			return nil, false
 		}
 		return turn.GenerateAuthKey(username, realm, password), true

--- a/internal/ltcred/lt_cred.go
+++ b/internal/ltcred/lt_cred.go
@@ -12,6 +12,14 @@ import (
 	"github.com/pion/turn/v2"
 )
 
+// GenerateCredentials can be used to create credentials valid for [duration] time
+func GenerateCredentials(sharedSecret string, duration time.Duration) (string, string, error) {
+	t := time.Now().Add(duration).Unix()
+	username := strconv.FormatInt(t, 10)
+	password, err := longTermCredentials(username, sharedSecret)
+	return username, password, err
+}
+
 func longTermCredentials(username string, sharedSecret string) (string, error) {
 	mac := hmac.New(sha1.New, []byte(sharedSecret))
 	_, err := mac.Write([]byte(username))

--- a/internal/ltcred/lt_cred.go
+++ b/internal/ltcred/lt_cred.go
@@ -1,0 +1,38 @@
+package ltcred
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	loglib "log"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/pion/turn/v2"
+)
+
+func longTermCredentials(username string, sharedSecret string) string {
+	mac := hmac.New(sha1.New, []byte(sharedSecret))
+	mac.Write([]byte(username))
+	password := mac.Sum(nil)
+	return base64.StdEncoding.EncodeToString(password)
+}
+
+// NewAuthHandler returns a turn.AuthAuthHandler used with Long Term (or Time Windowed) Credentials.
+func NewAuthHandler(sharedSecret string, log *loglib.Logger) turn.AuthHandler {
+	return func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+		log.Printf("Authentication username=%q realm=%q srcAddr=%v\n", username, realm, srcAddr)
+		t, err := strconv.Atoi(username)
+		if err != nil {
+			log.Printf("Invalid time-windowed username %q", username)
+			return nil, false
+		}
+		if int64(t) < time.Now().Unix() {
+			log.Printf("Expired time-windowed username %q", username)
+			return nil, false
+		}
+		password := longTermCredentials(username, sharedSecret)
+		return turn.GenerateAuthKey(username, realm, password), true
+	}
+}

--- a/internal/ltcred/lt_cred_test.go
+++ b/internal/ltcred/lt_cred_test.go
@@ -1,0 +1,26 @@
+package ltcred
+
+import (
+	"testing"
+)
+
+func TestLtCredMech(t *testing.T) {
+	username := "1599491771"
+	sharedSecret := "foobar"
+
+	expectedPassword := "Tpz/nKkyvX/vMSLKvL4sbtBt8Vs="
+	actualPassword := longTermCredentials(username, sharedSecret)
+	if expectedPassword != actualPassword {
+		t.Errorf("Expected %q, got %q", expectedPassword, actualPassword)
+	}
+}
+
+// export SECRET=foobar
+// secret=$SECRET && \
+// time=$(date +%s) && \
+// expiry=8400 && \
+// username=$(( $time + $expiry )) &&\
+// echo username:$username && \
+// echo password : $(echo -n $username | openssl dgst -binary -sha1 -hmac $secret | openssl base64)
+// username : 1599491771
+// password : M+WLqSVjDc7kfj2U8ZUmk+hTQl8=

--- a/internal/ltcred/lt_cred_test.go
+++ b/internal/ltcred/lt_cred_test.go
@@ -9,7 +9,7 @@ func TestLtCredMech(t *testing.T) {
 	sharedSecret := "foobar"
 
 	expectedPassword := "Tpz/nKkyvX/vMSLKvL4sbtBt8Vs="
-	actualPassword := longTermCredentials(username, sharedSecret)
+	actualPassword, _ := longTermCredentials(username, sharedSecret)
 	if expectedPassword != actualPassword {
 		t.Errorf("Expected %q, got %q", expectedPassword, actualPassword)
 	}


### PR DESCRIPTION
#### Description
Context: For Jitsi I was first using coTURN and then stumbled upon Pion. What I liked was owning the server code so that I could diagnose authentications. I was having trouble with that with coTURN I believed.

Jitsi proposes to use ephemeral credentials. They reference a draft from their [TURN documentation](https://jitsi.github.io/handbook/docs/devops-guide/turn). The idea is to use the expiry time of the credential as the username, and let the password contain some cryptographic hash of a (server-side) shared-secret and the expiry time.

This is the same mechanism used by coTURN and it is documented here how to generate a quick pair of credentials if you have the shared-secret:
https://meetrix.io/blog/webrtc/coturn/installation.html#testing

# RFC
Long-Term Credential Mechanism (RFC5389-10.2: https://tools.ietf.org/search/rfc5389#section-10.2)