### PR TITLE
Add support for Long-Term Credential Mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ examples/turn-server/add-software-attribute/add-software-attribute
 examples/turn-server/log/log
 examples/turn-server/simple/simple
 examples/turn-server/tcp/tcp
+examples/lt-cred-generator/lt-cred-generator
+examples/turn-server/lt-cred/lt-cred

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [lllf](https://github.com/LittleLightLittleFire)
 * nindolabs (Marouane)
 * [Onwuka Gideon](https://github.com/dongido001)
+* [Herman Banken](https://github.com/hermanbanken)
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,22 @@
 # Examples
 
 ## turn-server
-The `turn-server` directory contains 4 examples that show common Pion TURN usages. All of these examples take the following arguments.
+The `turn-server` directory contains 5 examples that show common Pion TURN usages.
+
+All of these except `lt-creds` take the following arguments.
 
 * -users     : &lt;username&gt;=&lt;password&gt;[,&lt;username&gt;=&lt;password&gt;,...] pairs
 * -realm     : Realm name (defaults to "pion.ly")
 * -port      : Listening port (defaults to 3478)
 * -public-ip : IP that your TURN server is reachable on, for local development then can just be your local IP, avoid using `127.0.0.1` as some browsers discard from that IP.
 
-The four example servers are
+```sh
+$ cd simple
+$ go build
+$ ./simple -public-ip 127.0.0.1 -users username=password,foo=bar
+```
+
+The five example servers are
 
 #### add-software-attribute
 This examples adds the SOFTWARE attribute with the value "CustomTURNServer" to every outbound STUN packet. This could be useful if you want to add debug info to your outbound packets.
@@ -26,11 +34,13 @@ This example is the most minimal invocation of a Pion TURN instance possible. It
 #### tcp
 This example demonstrates listening on TCP. You could combine this example with `simple` and you will have a Pion TURN instance that is available via TCP and UDP.
 
-```sh
-$ cd simple
-$ go build
-$ ./simple -public-ip 127.0.0.1 -users username=password,foo=bar
-```
+#### lt-creds
+
+This example shows how to use long term credentials. You can issue passwords that automatically expire, and you don't have the store them.
+
+The only downside is that you can't revoke a single username/password. You need to rotate the shared secret. Instead of `users` it has the follow arguments instead
+
+* -authSecret     : Shared secret for the Long Term Credential Mechanism
 
 ## turn-client
 The `turn-client` directory contains 2 examples that show common Pion TURN usages. All of these examples take the following arguments.

--- a/examples/lt-cred-generator/README.md
+++ b/examples/lt-cred-generator/README.md
@@ -1,0 +1,21 @@
+# Usage
+This command generates credentials used by the Long-Term Credential Mechanism
+
+Defined in [RFC5389-10.2](https://tools.ietf.org/search/rfc5389#section-10.2). The idea is to use the
+expiry time of the credential as the username, and let the password contain some cryptographic hash
+of a (server-side) shared-secret and the expiry time.
+
+```bash
+export SECRET=somesecret
+
+# Build binaries
+(cd examples/lt-cred-generator && go build .)
+(cd examples/turn-server/lt-cred && go build .)
+(cd examples/turn-client/udp && go build .)
+
+# Start server
+./examples/turn-server/lt-cred/lt-cred -public-ip=127.0.0.1 -authSecret=$SECRET
+
+# Start client using generated credentials
+./examples/lt-cred-generator/lt-cred-generator -authSecret=$SECRET | xargs -I{} ./examples/turn-client/udp/udp -host=127.0.0.1 -ping -user={}
+```

--- a/examples/lt-cred-generator/main.go
+++ b/examples/lt-cred-generator/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/pion/turn/v2"
+)
+
+// Outputs username & password according to the
+// Long-Term Credential Mechanism (RFC5389-10.2: https://tools.ietf.org/search/rfc5389#section-10.2)
+func main() {
+	authSecret := flag.String("authSecret", "", "Shared secret for the Long Term Credential Mechanism")
+	showHelp := flag.Bool("h", false, "Show usage")
+	flag.Parse()
+
+	if showHelp != nil && *showHelp {
+		log.Println("Usage:")
+		log.Println("$ lt-cred-generator | xargs go run examples/turn-client/udp/main.go -host localhost -ping=true -user=")
+		return
+	}
+
+	if authSecret == nil || len(*authSecret) == 0 {
+		log.Fatal("Missing -authSecret parameter")
+	}
+
+	u, p, _ := turn.GenerateLongTermCredentials(*authSecret, time.Minute)
+	os.Stdout.WriteString(fmt.Sprintf("%s=%s", u, p)) // for use with xargs
+	os.Stderr.WriteString("\n")                       // ignored by xargs
+}

--- a/examples/turn-client/tcp/main.go
+++ b/examples/turn-client/tcp/main.go
@@ -35,7 +35,7 @@ func main() {
 		panic(err)
 	}
 
-	cred := strings.Split(*user, "=")
+	cred := strings.SplitN(*user, "=", 2)
 
 	// Start a new TURN Client and wrap our net.Conn in a STUNConn
 	// This allows us to simulate datagram based communication over a net.Conn

--- a/examples/turn-client/udp/main.go
+++ b/examples/turn-client/udp/main.go
@@ -28,7 +28,7 @@ func main() {
 		log.Fatalf("'user' is required")
 	}
 
-	cred := strings.Split(*user, "=")
+	cred := strings.SplitN(*user, "=", 2)
 
 	// TURN client won't create a local listening socket by itself.
 	conn, err := net.ListenPacket("udp4", "0.0.0.0:0")

--- a/examples/turn-server/lt-cred/main.go
+++ b/examples/turn-server/lt-cred/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/pion/logging"
+	"github.com/pion/turn/v2"
+)
+
+func main() {
+	publicIP := flag.String("public-ip", "", "IP Address that TURN can be contacted by.")
+	port := flag.Int("port", 3478, "Listening port.")
+	authSecret := flag.String("authSecret", "", "Shared secret for the Long Term Credential Mechanism")
+	realm := flag.String("realm", "pion.ly", "Realm (defaults to \"pion.ly\")")
+	flag.Parse()
+
+	if len(*publicIP) == 0 {
+		log.Fatalf("'public-ip' is required")
+	} else if len(*authSecret) == 0 {
+		log.Fatalf("'authSecret' is required")
+	}
+
+	// Create a UDP listener to pass into pion/turn
+	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
+	// this allows us to add logging, storage or modify inbound/outbound traffic
+	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port))
+	if err != nil {
+		log.Panicf("Failed to create TURN server listener: %s", err)
+	}
+
+	// NewLongTermAuthHandler takes a pion.LeveledLogger. This allows you to intercept messages
+	// and process them yourself.
+	logger := logging.NewDefaultLeveledLoggerForScope("lt-creds", logging.LogLevelTrace, os.Stdout)
+
+	s, err := turn.NewServer(turn.ServerConfig{
+		Realm: *realm,
+		// Set AuthHandler callback
+		// This is called everytime a user tries to authenticate with the TURN server
+		// Return the key for that user, or false when no user is found
+		AuthHandler: turn.NewLongTermAuthHandler(*authSecret, logger),
+		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
+		PacketConnConfigs: []turn.PacketConnConfig{
+			{
+				PacketConn: udpListener,
+				RelayAddressGenerator: &turn.RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP(*publicIP), // Claim that we are listening on IP passed by user (This should be your Public IP)
+					Address:      "0.0.0.0",              // But actually be listening on every interface
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Block until user sends SIGINT or SIGTERM
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	if err = s.Close(); err != nil {
+		log.Panic(err)
+	}
+}

--- a/lt_cred.go
+++ b/lt_cred.go
@@ -1,0 +1,56 @@
+package turn
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/pion/logging"
+)
+
+// GenerateCredentials can be used to create credentials valid for [duration] time
+func GenerateLongTermCredentials(sharedSecret string, duration time.Duration) (string, string, error) {
+	t := time.Now().Add(duration).Unix()
+	username := strconv.FormatInt(t, 10)
+	password, err := longTermCredentials(username, sharedSecret)
+	return username, password, err
+}
+
+func longTermCredentials(username string, sharedSecret string) (string, error) {
+	mac := hmac.New(sha1.New, []byte(sharedSecret))
+	_, err := mac.Write([]byte(username))
+	if err != nil {
+		return "", err // Not sure if this will ever happen
+	}
+	password := mac.Sum(nil)
+	return base64.StdEncoding.EncodeToString(password), nil
+}
+
+// NewAuthHandler returns a turn.AuthAuthHandler used with Long Term (or Time Windowed) Credentials.
+// https://tools.ietf.org/search/rfc5389#section-10.2
+func NewLongTermAuthHandler(sharedSecret string, l logging.LeveledLogger) AuthHandler {
+	if l == nil {
+		l = logging.NewDefaultLoggerFactory().NewLogger("turn")
+	}
+	return func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+		l.Tracef("Authentication username=%q realm=%q srcAddr=%v\n", username, realm, srcAddr)
+		t, err := strconv.Atoi(username)
+		if err != nil {
+			l.Errorf("Invalid time-windowed username %q", username)
+			return nil, false
+		}
+		if int64(t) < time.Now().Unix() {
+			l.Errorf("Expired time-windowed username %q", username)
+			return nil, false
+		}
+		password, err := longTermCredentials(username, sharedSecret)
+		if err != nil {
+			l.Error(err.Error())
+			return nil, false
+		}
+		return GenerateAuthKey(username, realm, password), true
+	}
+}

--- a/lt_cred_test.go
+++ b/lt_cred_test.go
@@ -1,0 +1,26 @@
+package turn
+
+import (
+	"testing"
+)
+
+func TestLtCredMech(t *testing.T) {
+	username := "1599491771"
+	sharedSecret := "foobar"
+
+	expectedPassword := "Tpz/nKkyvX/vMSLKvL4sbtBt8Vs="
+	actualPassword, _ := longTermCredentials(username, sharedSecret)
+	if expectedPassword != actualPassword {
+		t.Errorf("Expected %q, got %q", expectedPassword, actualPassword)
+	}
+}
+
+// export SECRET=foobar
+// secret=$SECRET && \
+// time=$(date +%s) && \
+// expiry=8400 && \
+// username=$(( $time + $expiry )) &&\
+// echo username:$username && \
+// echo password : $(echo -n $username | openssl dgst -binary -sha1 -hmac $secret | openssl base64)
+// username : 1599491771
+// password : M+WLqSVjDc7kfj2U8ZUmk+hTQl8=


### PR DESCRIPTION
Defined in RFC5389-10.2. The idea is to use the
expiry time of the credential as the username, and
let the password contain some cryptographic hash
of a (server-side) shared-secret and the expiry time.

[0] https://tools.ietf.org/search/rfc5389#section-10.2
