### PR TITLE
Fix #192 - Configurable server inboundMTU

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) to join the group of amazing pe
 * [Onwuka Gideon](https://github.com/dongido001)
 * [Herman Banken](https://github.com/hermanbanken)
 * [Jannis Mattheis](https://github.com/jmattheis)
+* [andre da palma](https://github.com/andrefsp)
+
 
 ### License
 MIT License - see [LICENSE.md](LICENSE.md) for full text

--- a/server_config.go
+++ b/server_config.go
@@ -93,6 +93,9 @@ type ServerConfig struct {
 
 	// ChannelBindTimeout sets the lifetime of channel binding. Defaults to 10 minutes.
 	ChannelBindTimeout time.Duration
+
+	// Sets the server inbound MTU(Maximum transmition unit). Defaults to 1500 bytes.
+	InboundMTU int
 }
 
 func (s *ServerConfig) validate() error {

--- a/server_test.go
+++ b/server_test.go
@@ -72,6 +72,47 @@ func TestServer(t *testing.T) {
 
 		assert.NoError(t, server.Close())
 	})
+
+	t.Run("default inboundMTU", func(t *testing.T) {
+		udpListener, err := net.ListenPacket("udp4", "0.0.0.0:3478")
+		assert.NoError(t, err)
+		server, err := NewServer(ServerConfig{
+			LoggerFactory: loggerFactory,
+			PacketConnConfigs: []PacketConnConfig{
+				{
+					PacketConn: udpListener,
+					RelayAddressGenerator: &RelayAddressGeneratorStatic{
+						RelayAddress: net.ParseIP("127.0.0.1"),
+						Address:      "0.0.0.0",
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, server.inboundMTU, defaultInboundMTU)
+		assert.NoError(t, server.Close())
+	})
+
+	t.Run("Set inboundMTU", func(t *testing.T) {
+		udpListener, err := net.ListenPacket("udp4", "0.0.0.0:3478")
+		assert.NoError(t, err)
+		server, err := NewServer(ServerConfig{
+			InboundMTU:    2000,
+			LoggerFactory: loggerFactory,
+			PacketConnConfigs: []PacketConnConfig{
+				{
+					PacketConn: udpListener,
+					RelayAddressGenerator: &RelayAddressGeneratorStatic{
+						RelayAddress: net.ParseIP("127.0.0.1"),
+						Address:      "0.0.0.0",
+					},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, server.inboundMTU, 2000)
+		assert.NoError(t, server.Close())
+	})
 }
 
 type VNet struct {


### PR DESCRIPTION
#### Description
This PR creates a server option so the inbound MTU may be configured. Currently hardcoded to 1500 bytes it may sometimes cause issues when the stun/turn payload becomes to big. In such cases it seems that increasing max payload size fixes the issue.

#### Reference issue
Fixes #192 
