### PR TITLE
Add STUN message to AuthHandler

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/pion/stun"
 	"github.com/pion/transport/vnet"
 	"github.com/stretchr/testify/assert"
 )
@@ -138,7 +139,7 @@ func TestClientNonceExpiration(t *testing.T) {
 	assert.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+		AuthHandler: func(username, realm string, srcAddr net.Addr, _ *stun.Message) (key []byte, ok bool) {
 			return GenerateAuthKey(username, realm, "pass"), true
 		},
 		PacketConnConfigs: []PacketConnConfig{

--- a/examples/turn-server/add-software-attribute/main.go
+++ b/examples/turn-server/add-software-attribute/main.go
@@ -71,7 +71,7 @@ func main() {
 		// Set AuthHandler callback
 		// This is called everytime a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+		AuthHandler: func(username string, realm string, srcAddr net.Addr, msg *stun.Message) ([]byte, bool) {
 			if key, ok := usersMap[username]; ok {
 				return key, true
 			}

--- a/examples/turn-server/log/main.go
+++ b/examples/turn-server/log/main.go
@@ -80,7 +80,7 @@ func main() {
 		// Set AuthHandler callback
 		// This is called everytime a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+		AuthHandler: func(username string, realm string, srcAddr net.Addr, msg *stun.Message) ([]byte, bool) {
 			if key, ok := usersMap[username]; ok {
 				return key, true
 			}

--- a/examples/turn-server/port-range/main.go
+++ b/examples/turn-server/port-range/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/pion/stun"
 	"github.com/pion/turn/v2"
 )
 
@@ -46,7 +47,7 @@ func main() {
 		// Set AuthHandler callback
 		// This is called everytime a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+		AuthHandler: func(username string, realm string, srcAddr net.Addr, msg *stun.Message) ([]byte, bool) {
 			if key, ok := usersMap[username]; ok {
 				return key, true
 			}

--- a/examples/turn-server/simple/main.go
+++ b/examples/turn-server/simple/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/pion/stun"
 	"github.com/pion/turn/v2"
 )
 
@@ -46,7 +47,7 @@ func main() {
 		// Set AuthHandler callback
 		// This is called everytime a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+		AuthHandler: func(username string, realm string, srcAddr net.Addr, msg *stun.Message) ([]byte, bool) {
 			if key, ok := usersMap[username]; ok {
 				return key, true
 			}

--- a/examples/turn-server/tcp/main.go
+++ b/examples/turn-server/tcp/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/pion/stun"
 	"github.com/pion/turn/v2"
 )
 
@@ -46,7 +47,7 @@ func main() {
 		// Set AuthHandler callback
 		// This is called everytime a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+		AuthHandler: func(username string, realm string, srcAddr net.Addr, msg *stun.Message) ([]byte, bool) {
 			if key, ok := usersMap[username]; ok {
 				return key, true
 			}

--- a/examples/turn-server/tls/main.go
+++ b/examples/turn-server/tls/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/pion/stun"
 	"github.com/pion/turn/v2"
 )
 
@@ -59,7 +60,7 @@ func main() {
 		// Set AuthHandler callback
 		// This is called everytime a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+		AuthHandler: func(username string, realm string, srcAddr net.Addr, msg *stun.Message) ([]byte, bool) {
 			if key, ok := usersMap[username]; ok {
 				return key, true
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,7 +25,7 @@ type Request struct {
 	Nonces            *sync.Map
 
 	// User Configuration
-	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+	AuthHandler        func(username string, realm string, srcAddr net.Addr, m *stun.Message) (key []byte, ok bool)
 	Log                logging.LeveledLogger
 	Realm              string
 	ChannelBindTimeout time.Duration

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -83,7 +83,7 @@ func TestAllocationLifeTime(t *testing.T) {
 			Conn:              l,
 			SrcAddr:           &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5000},
 			Log:               logger,
-			AuthHandler: func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+			AuthHandler: func(username string, realm string, srcAddr net.Addr, _ *stun.Message) (key []byte, ok bool) {
 				return staticKey, true
 			},
 		}

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -62,6 +62,7 @@ func buildMsg(transactionID [stun.TransactionIDSize]byte, msgType stun.MessageTy
 }
 
 func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) (stun.MessageIntegrity, bool, error) {
+
 	respondWithNonce := func(responseCode stun.ErrorCode) (stun.MessageIntegrity, bool, error) {
 		nonce, err := buildNonce()
 		if err != nil {
@@ -107,7 +108,7 @@ func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) 
 		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
 	}
 
-	ourKey, ok := r.AuthHandler(usernameAttr.String(), realmAttr.String(), r.SrcAddr)
+	ourKey, ok := r.AuthHandler(usernameAttr.String(), realmAttr.String(), r.SrcAddr, m)
 	if !ok {
 		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("%w %s", errNoSuchUser, usernameAttr.String()), badRequestMsg...)
 	}

--- a/lt_cred.go
+++ b/lt_cred.go
@@ -9,6 +9,7 @@ import ( //nolint:gci
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/pion/stun"
 )
 
 // GenerateLongTermCredentials can be used to create credentials valid for [duration] time
@@ -35,7 +36,7 @@ func NewLongTermAuthHandler(sharedSecret string, l logging.LeveledLogger) AuthHa
 	if l == nil {
 		l = logging.NewDefaultLoggerFactory().NewLogger("turn")
 	}
-	return func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+	return func(username, realm string, srcAddr net.Addr, _ *stun.Message) (key []byte, ok bool) {
 		l.Tracef("Authentication username=%q realm=%q srcAddr=%v\n", username, realm, srcAddr)
 		t, err := strconv.Atoi(username)
 		if err != nil {

--- a/server_config.go
+++ b/server_config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/pion/stun"
 )
 
 // RelayAddressGenerator is used to generate a RelayAddress when creating an allocation.
@@ -65,7 +66,7 @@ func (c *ListenerConfig) validate() error {
 }
 
 // AuthHandler is a callback used to handle incoming auth requests, allowing users to customize Pion TURN with custom behavior
-type AuthHandler func(username, realm string, srcAddr net.Addr) (key []byte, ok bool)
+type AuthHandler func(username, realm string, srcAddr net.Addr, m *stun.Message) (key []byte, ok bool)
 
 // GenerateAuthKey is a convince function to easily generate keys in the format used by AuthHandler
 func GenerateAuthKey(username, realm, password string) []byte {

--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/pion/stun"
 	"github.com/pion/transport/test"
 	"github.com/pion/transport/vnet"
 	"github.com/pion/turn/v2/internal/proto"
@@ -32,7 +33,7 @@ func TestServer(t *testing.T) {
 		assert.NoError(t, err)
 
 		server, err := NewServer(ServerConfig{
-			AuthHandler: func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+			AuthHandler: func(username, realm string, srcAddr net.Addr, _ *stun.Message) (key []byte, ok bool) {
 				if pw, ok := credMap[username]; ok {
 					return pw, true
 				}
@@ -197,7 +198,7 @@ func buildVNet() (*VNet, error) {
 	}
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+		AuthHandler: func(username, realm string, srcAddr net.Addr, _ *stun.Message) (key []byte, ok bool) {
 			if pw, ok := credMap[username]; ok {
 				return pw, true
 			}


### PR DESCRIPTION
Enables inspection of the message prior to authentication.

For my specific case, I'll be matching message integrity with potentially multiple passwords to ensure a request is authenticated.