### PR TITLE
Close accepted TURN listener connections

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ Aleksandr Razumov <ar@gortc.io>
 andrefsp <andrefsp@gmail.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
+Dean Sheather <dean@coder.com>
 Herman Banken <hermanbanken@gmail.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Igor German <igor.german@synesis.ru>


### PR DESCRIPTION
#### Description
To the best of my knowledge, connections accepted from the provided net.Listener would never be closed, even if there was an error.

This changes them to be closed at the top of the connection handling goroutine. I didn't touch the connections from packet conn configs because I didn't want to change the behavior (parent code might already be doing `defer conn.Close()`).

I had to refactor the NewServer method a bit to avoid hitting the gocognit linter. The only real changes I made were to the connection handler goroutine in the net.Listener goroutine.

#### Reference issue
None

cc @coadler @kylecarbs