### PR TITLE
Allocation count methods

### DIFF
--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -59,6 +59,13 @@ func (m *Manager) GetAllocation(fiveTuple *FiveTuple) *Allocation {
 	return m.allocations[fiveTuple.Fingerprint()]
 }
 
+// AllocationCount returns the number of existing allocations
+func (m *Manager) AllocationCount() int {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return len(m.allocations)
+}
+
 // Close closes the manager and closes all allocations it manages
 func (m *Manager) Close() error {
 	m.lock.Lock()

--- a/server_test.go
+++ b/server_test.go
@@ -317,6 +317,9 @@ func TestServerVNet(t *testing.T) {
 		echoConn, err := v.net1.ListenPacket("udp4", "1.2.3.5:5678")
 		assert.NoError(t, err)
 
+		// ensure allocation is counted
+		assert.Equal(t, 1, v.server.AllocationCount())
+
 		go func() {
 			buf := make([]byte, 1600)
 			for {


### PR DESCRIPTION
#### Description

Adds an allocation count method to the server, returning the number of active allocations. This is useful for draining, where you can stop routing traffic to an instance and then wait until `server.AllocationCount() == 0` before shutting down.

