### PR TITLE
Fix process partial stun message

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,6 +8,7 @@ Aleksandr Razumov <ar@gortc.io>
 andrefsp <andrefsp@gmail.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
+cnderrauber <zengjie9004@gmail.com>
 David Colburn <xero73@gmail.com>
 Herman Banken <hermanbanken@gmail.com>
 Hugo Arregui <hugo.arregui@gmail.com>

--- a/server_test.go
+++ b/server_test.go
@@ -377,7 +377,8 @@ func TestConsumeSingleTURNFrame(t *testing.T) {
 		"stun message":                          {data: []byte{0x0, 0x16, 0x00, 0x02, 0x21, 0x12, 0xA4, 0x42, 0xf7, 0x43, 0x81, 0xa3, 0xc9, 0xcd, 0x88, 0x89, 0x70, 0x58, 0xac, 0x73, 0x0, 0x0}},
 	}
 
-	for name, c := range cases {
+	for name, cs := range cases {
+		c := cs
 		t.Run(name, func(t *testing.T) {
 			n, e := consumeSingleTURNFrame(c.data)
 			assert.Equal(t, c.err, e)

--- a/server_test.go
+++ b/server_test.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package turn
@@ -362,4 +363,27 @@ func TestServerVNet(t *testing.T) {
 		assert.NoError(t, lconn.Close(), "should succeed")
 		assert.NoError(t, v.Close(), "should succeed")
 	})
+}
+
+func TestConsumeSingleTURNFrame(t *testing.T) {
+	type testCase struct {
+		data []byte
+		err  error
+	}
+	cases := map[string]testCase{
+		"channel data":                          {data: []byte{0x40, 0x01, 0x00, 0x08, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, err: nil},
+		"partial data less than channel header": {data: []byte{1}, err: errIncompleteTURNFrame},
+		"partial stun message":                  {data: []byte{0x0, 0x16, 0x02, 0xDC, 0x21, 0x12, 0xA4, 0x42, 0x0, 0x0, 0x0}, err: errIncompleteTURNFrame},
+		"stun message":                          {data: []byte{0x0, 0x16, 0x00, 0x02, 0x21, 0x12, 0xA4, 0x42, 0xf7, 0x43, 0x81, 0xa3, 0xc9, 0xcd, 0x88, 0x89, 0x70, 0x58, 0xac, 0x73, 0x0, 0x0}},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			n, e := consumeSingleTURNFrame(c.data)
+			assert.Equal(t, c.err, e)
+			if e == nil {
+				assert.Equal(t, len(c.data), n)
+			}
+		})
+	}
 }

--- a/stun_conn.go
+++ b/stun_conn.go
@@ -44,13 +44,15 @@ func consumeSingleTURNFrame(p []byte) (int, error) {
 	var datagramSize uint16
 	if stun.IsMessage(p) {
 		datagramSize = binary.BigEndian.Uint16(p[2:4]) + stunHeaderSize
-	} else if num := binary.BigEndian.Uint16(p[0:4]); proto.ChannelNumber(num).Valid() {
+	} else if num := binary.BigEndian.Uint16(p[0:2]); proto.ChannelNumber(num).Valid() {
 		datagramSize = binary.BigEndian.Uint16(p[channelDataNumberSize:channelDataHeaderSize])
 		if paddingOverflow := (datagramSize + channelDataPadding) % channelDataPadding; paddingOverflow != 0 {
 			datagramSize = (datagramSize + channelDataPadding) - paddingOverflow
 		}
 
 		datagramSize += channelDataHeaderSize
+	} else if len(p) < stunHeaderSize {
+		return 0, errIncompleteTURNFrame
 	} else {
 		return 0, errInvalidTURNFrame
 	}

--- a/stun_conn.go
+++ b/stun_conn.go
@@ -42,18 +42,19 @@ func consumeSingleTURNFrame(p []byte) (int, error) {
 	}
 
 	var datagramSize uint16
-	if stun.IsMessage(p) {
+	switch {
+	case stun.IsMessage(p):
 		datagramSize = binary.BigEndian.Uint16(p[2:4]) + stunHeaderSize
-	} else if num := binary.BigEndian.Uint16(p[0:2]); proto.ChannelNumber(num).Valid() {
+	case proto.ChannelNumber(binary.BigEndian.Uint16(p[0:2])).Valid():
 		datagramSize = binary.BigEndian.Uint16(p[channelDataNumberSize:channelDataHeaderSize])
 		if paddingOverflow := (datagramSize + channelDataPadding) % channelDataPadding; paddingOverflow != 0 {
 			datagramSize = (datagramSize + channelDataPadding) - paddingOverflow
 		}
 
 		datagramSize += channelDataHeaderSize
-	} else if len(p) < stunHeaderSize {
+	case len(p) < stunHeaderSize:
 		return 0, errIncompleteTURNFrame
-	} else {
+	default:
 		return 0, errInvalidTURNFrame
 	}
 


### PR DESCRIPTION
When StunConn get partial stun message (lager than
channel data header and less than stun header),
should return errIncompleteTURNFrame.

#### Description

#### Reference issue
Fixes #...
