### PR TITLE
Add CreatePermission method to the TURN client

### DIFF
--- a/client.go
+++ b/client.go
@@ -333,6 +333,12 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	return relayedConn, nil
 }
 
+// CreatePermission Issues a CreatePermission request for the supplied addresses
+// as described in https://datatracker.ietf.org/doc/html/rfc5766#section-9
+func (c *Client) CreatePermission(addrs ...net.Addr) error {
+	return c.relayedUDPConn().CreatePermissions(addrs...)
+}
+
 // PerformTransaction performs STUN transaction
 func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult,
 	error) {

--- a/internal/client/conn.go
+++ b/internal/client/conn.go
@@ -185,7 +185,7 @@ func (c *UDPConn) WriteTo(p []byte, addr net.Addr) (int, error) { //nolint: goco
 
 		if perm.state() == permStateIdle {
 			// punch a hole! (this would block a bit..)
-			if err = c.createPermissions(addr); err != nil {
+			if err = c.CreatePermissions(addr); err != nil {
 				c.permMap.delete(addr)
 				return err
 			}
@@ -359,7 +359,9 @@ func addr2PeerAddress(addr net.Addr) proto.PeerAddress {
 	return peerAddr
 }
 
-func (c *UDPConn) createPermissions(addrs ...net.Addr) error {
+// CreatePermissions Issues a CreatePermission request for the supplied addresses
+// as described in https://datatracker.ietf.org/doc/html/rfc5766#section-9
+func (c *UDPConn) CreatePermissions(addrs ...net.Addr) error {
 	setters := []stun.Setter{
 		stun.TransactionID,
 		stun.NewType(stun.MethodCreatePermission, stun.ClassRequest),
@@ -496,7 +498,7 @@ func (c *UDPConn) refreshPermissions() error {
 		c.log.Debug("no permission to refresh")
 		return nil
 	}
-	if err := c.createPermissions(addrs...); err != nil {
+	if err := c.CreatePermissions(addrs...); err != nil {
 		if errors.Is(err, errTryAgain) {
 			return errTryAgain
 		}


### PR DESCRIPTION
#### Description
This adds a `CreatePermission()` method to the turn client, which sends a CreatePermission request as described in [RFC 5766, Section 9](https://datatracker.ietf.org/doc/html/rfc5766#section-9).

This method allows a TURN client to request or refresh permissions for a specific set of IP address / port pairs.

* Makes the existing `UPDConn.CreatePermission()` method public.
* Adds a `CreatePermission()` method on `Client` that exposes the underlying `relayedUDPConn().CreatePermissions()` method.

#### Reference issue
There's not a github issue for it. I just needed this functionality and discovered it wasn't available and couldn't be achieved with the library as-is due to the `CreatePermissionRequest` and `PeerAddress` types being in an internal package.