### PR TITLE
Fix retry allocation

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -29,6 +29,7 @@ Sean DuBois <seaduboi@amazon.com>
 Sean DuBois <sean@pion.ly>
 Sean DuBois <sean@siobud.com>
 songjiayang <songjiayang@jd.com>
+ted <ted@skydio.com>
 Tom Clift <tom@clift.id.au>
 Yusuke Nakamura <yusuke1994525@gmail.com>
 Yutaka Takeda <yt0916@gmail.com>

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -176,13 +176,15 @@ func (a *Allocation) Refresh(lifetime time.Duration) {
 	}
 }
 
+// SetReponseCache cache allocation response for retransmit allocation request
 func (a *Allocation) SetResponseCache(transactionID [stun.TransactionIDSize]byte, attrs []stun.Setter) {
-	a.responseCache.CompareAndSwap(nil, &allocationResponse{
+	a.responseCache.Store(&allocationResponse{
 		transactionID: transactionID,
 		responseAttrs: attrs,
 	})
 }
 
+// GetResponseCache return response cache for retransmit allocation request
 func (a *Allocation) GetResponseCache() (id [stun.TransactionIDSize]byte, attrs []stun.Setter) {
 	if r := a.responseCache.Load(); r != nil {
 		res := r.(*allocationResponse)

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -176,7 +176,7 @@ func (a *Allocation) Refresh(lifetime time.Duration) {
 	}
 }
 
-// SetReponseCache cache allocation response for retransmit allocation request
+// SetResponseCache cache allocation response for retransmit allocation request
 func (a *Allocation) SetResponseCache(transactionID [stun.TransactionIDSize]byte, attrs []stun.Setter) {
 	a.responseCache.Store(&allocationResponse{
 		transactionID: transactionID,

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -4,6 +4,7 @@ package allocation
 import (
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pion/logging"
@@ -11,6 +12,11 @@ import (
 	"github.com/pion/turn/v2/internal/ipnet"
 	"github.com/pion/turn/v2/internal/proto"
 )
+
+type allocationResponse struct {
+	transactionID [stun.TransactionIDSize]byte
+	responseAttrs []stun.Setter
+}
 
 // Allocation is tied to a FiveTuple and relays traffic
 // use CreateAllocation and GetAllocation to operate
@@ -27,6 +33,12 @@ type Allocation struct {
 	lifetimeTimer       *time.Timer
 	closed              chan interface{}
 	log                 logging.LeveledLogger
+
+	// some clients (firefox or others using resiprocate's nICE lib) may retry allocation
+	// with same 5 tuple when received 413, for compatible with these clients,
+	// cache for response lost and client retry to implement 'stateless stack approach'
+	// https://datatracker.ietf.org/doc/html/rfc5766#section-6.2
+	responseCache atomic.Value // *allocationResponse
 }
 
 func addr2IPFingerprint(addr net.Addr) string {
@@ -162,6 +174,21 @@ func (a *Allocation) Refresh(lifetime time.Duration) {
 	if !a.lifetimeTimer.Reset(lifetime) {
 		a.log.Errorf("Failed to reset allocation timer for %v", a.fiveTuple)
 	}
+}
+
+func (a *Allocation) SetResponseCache(transactionID [stun.TransactionIDSize]byte, attrs []stun.Setter) {
+	a.responseCache.CompareAndSwap(nil, &allocationResponse{
+		transactionID: transactionID,
+		responseAttrs: attrs,
+	})
+}
+
+func (a *Allocation) GetResponseCache() (id [stun.TransactionIDSize]byte, attrs []stun.Setter) {
+	if r := a.responseCache.Load(); r != nil {
+		res := r.(*allocationResponse)
+		id, attrs = res.transactionID, res.responseAttrs
+	}
+	return
 }
 
 // Close closes the allocation

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package allocation
@@ -30,6 +31,7 @@ func TestAllocation(t *testing.T) {
 		{"Refresh", subTestAllocationRefresh},
 		{"Close", subTestAllocationClose},
 		{"packetHandler", subTestPacketHandler},
+		{"ResponseCache", subTestResponseCache},
 	}
 
 	for _, tc := range tt {
@@ -310,4 +312,19 @@ func subTestPacketHandler(t *testing.T) {
 	_ = clientListener.Close()
 	_ = peerListener1.Close()
 	_ = peerListener2.Close()
+}
+
+func subTestResponseCache(t *testing.T) {
+	a := NewAllocation(nil, nil, nil)
+	transactionID := [stun.TransactionIDSize]byte{1, 2, 3}
+	responseAttrs := []stun.Setter{
+		&proto.Lifetime{
+			Duration: proto.DefaultLifetime,
+		},
+	}
+	a.SetResponseCache(transactionID, responseAttrs)
+
+	cacheID, cacheAttr := a.GetResponseCache()
+	assert.Equal(t, transactionID, cacheID)
+	assert.Equal(t, responseAttrs, cacheAttr)
 }

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -1,4 +1,3 @@
-//go:build !js
 // +build !js
 
 package allocation

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -41,7 +41,6 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 	if alloc := r.AllocationManager.GetAllocation(fiveTuple); alloc != nil {
 		id, attrs := alloc.GetResponseCache()
 		if id != m.TransactionID {
-			r.Log.Errorf("retry allocation with different id, prev %v, retry %v", id, m.TransactionID)
 			msg := buildMsg(m.TransactionID, stun.NewType(stun.MethodAllocate, stun.ClassErrorResponse), &stun.ErrorCodeAttribute{Code: stun.CodeAllocMismatch})
 			return buildAndSendErr(r.Conn, r.SrcAddr, errRelayAlreadyAllocatedForFiveTuple, msg...)
 		}


### PR DESCRIPTION
Implement 'stateless stack approach' for allocation retransmit.
Some clients like firefox don't retry allocation with different
transport when 437 received as RFC required. Server side should 
process the retransmit of allocation.

#### Description

#### Reference issue
Fixes #206 

https://github.com/livekit/livekit-server/issues/156

