### PR TITLE
Add PermissionHandler to ServerConfig #134 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,10 @@ The only downside is that you can't revoke a single username/password. You need 
 
 * -authSecret     : Shared secret for the Long Term Credential Mechanism
 
+#### perm-filter
+
+This example demonstrates the use of a permission handler in the PION TURN server. The example implements a filtering policy that lets clients to connect back to their own host or server-reflexive address but will drop everything else. This will let the client ping-test through but will block essentially all other peer connection attempts.
+
 ## turn-client
 The `turn-client` directory contains 2 examples that show common Pion TURN usages. All of these examples take the following arguments.
 

--- a/examples/turn-server/perm-filter/main.go
+++ b/examples/turn-server/perm-filter/main.go
@@ -1,0 +1,96 @@
+// This example demonstrates the use of a permission handler in the PION TURN server. The
+// permission handler implements a filtering policy that lets clients to connect back to their own
+// host or server-reflexive address but will filter out everything else. This will let the client
+// ping-test through but will block essentially all other peer connection attempts.
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/pion/turn/v2"
+)
+
+func main() {
+	publicIP := flag.String("public-ip", "", "IP Address that TURN can be contacted by.")
+	port := flag.Int("port", 3478, "Listening port.")
+	users := flag.String("users", "", "List of username and password (e.g. \"user=pass,user=pass\")")
+	realm := flag.String("realm", "pion.ly", "Realm (defaults to \"pion.ly\")")
+	flag.Parse()
+
+	if len(*publicIP) == 0 {
+		log.Fatalf("'public-ip' is required")
+	} else if len(*users) == 0 {
+		log.Fatalf("'users' is required")
+	}
+
+	// Create a UDP listener to pass into pion/turn
+	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
+	// this allows us to add logging, storage or modify inbound/outbound traffic
+	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port))
+	if err != nil {
+		log.Panicf("Failed to create TURN server listener: %s", err)
+	}
+
+	// Cache -users flag for easy lookup later
+	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
+	usersMap := map[string][]byte{}
+	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
+		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	}
+
+	s, err := turn.NewServer(turn.ServerConfig{
+		Realm: *realm,
+		// Set AuthHandler callback
+		// This is called everytime a user tries to authenticate with the TURN server
+		// Return the key for that user, or false when no user is found
+		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+			if key, ok := usersMap[username]; ok {
+				return key, true
+			}
+			return nil, false
+		},
+		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
+		PacketConnConfigs: []turn.PacketConnConfig{
+			{
+				PacketConn: udpListener,
+				RelayAddressGenerator: &turn.RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP(*publicIP), // Claim that we are listening on IP passed by user (This should be your Public IP)
+					Address:      "0.0.0.0",              // But actually be listening on every interface
+				},
+				// allow peer connections only to the client's own (host or server-reflexive) IP
+				PermissionHandler: func(clientAddr net.Addr, peerIP net.IP) bool {
+					clientIP := strings.SplitN(clientAddr.String(), ":", 2)
+					if clientIP[0] != peerIP.String() {
+						log.Printf("Blocking request from client IP %s to peer %s",
+							clientIP[0], peerIP.String())
+						return false
+					}
+
+					log.Printf("Admitting request from client IP %s to peer %s",
+						clientIP[0], peerIP.String())
+					return true
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Block until user sends SIGINT or SIGTERM
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	if err = s.Close(); err != nil {
+		log.Panic(err)
+	}
+}

--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -14,6 +14,7 @@ type ManagerConfig struct {
 	LeveledLogger      logging.LeveledLogger
 	AllocatePacketConn func(network string, requestedPort int) (net.PacketConn, net.Addr, error)
 	AllocateConn       func(network string, requestedPort int) (net.Conn, net.Addr, error)
+	PermissionHandler  func(sourceAddr net.Addr, peerIP net.IP) bool
 }
 
 type reservation struct {
@@ -31,6 +32,7 @@ type Manager struct {
 
 	allocatePacketConn func(network string, requestedPort int) (net.PacketConn, net.Addr, error)
 	allocateConn       func(network string, requestedPort int) (net.Conn, net.Addr, error)
+	permissionHandler  func(sourceAddr net.Addr, peerIP net.IP) bool
 }
 
 // NewManager creates a new instance of Manager.
@@ -49,6 +51,7 @@ func NewManager(config ManagerConfig) (*Manager, error) {
 		allocations:        make(map[string]*Allocation, 64),
 		allocatePacketConn: config.AllocatePacketConn,
 		allocateConn:       config.AllocateConn,
+		permissionHandler:  config.PermissionHandler,
 	}, nil
 }
 
@@ -194,4 +197,19 @@ func (m *Manager) GetRandomEvenPort() (int, error) {
 		}
 	}
 	return 0, errFailedToAllocateEvenPort
+}
+
+// GrantPermission handles permission requests by calling the permission handler callback
+// associated with the TURN server listener socket
+func (m *Manager) GrantPermission(sourceAddr net.Addr, peerIP net.IP) error {
+	// no permission handler: open
+	if m.permissionHandler == nil {
+		return nil
+	}
+
+	if m.permissionHandler(sourceAddr, peerIP) {
+		return nil
+	}
+
+	return errAdminProhibited
 }

--- a/internal/allocation/errors.go
+++ b/internal/allocation/errors.go
@@ -15,4 +15,5 @@ var (
 	errDupeFiveTuple               = errors.New("allocation attempt created with duplicate FiveTuple")
 	errFailedToCastUDPAddr         = errors.New("failed to cast net.Addr to *net.UDPAddr")
 	errFailedToAllocateEvenPort    = errors.New("failed to allocate an even port")
+	errAdminProhibited             = errors.New("permission request administratively prohibited")
 )

--- a/server_config.go
+++ b/server_config.go
@@ -23,6 +23,19 @@ type RelayAddressGenerator interface {
 	AllocateConn(network string, requestedPort int) (net.Conn, net.Addr, error)
 }
 
+// PermissionHandler is a callback to filter incoming CreatePermission and ChannelBindRequest
+// requests based on the client IP address and port and the peer IP address the client intends to
+// connect to. If the client is behind a NAT then the filter acts on the server reflexive
+// ("mapped") address instead of the real client IP address and port. Note that TURN permissions
+// are per-allocation and per-peer-IP-address, to mimic the address-restricted filtering mechanism
+// of NATs that comply with [RFC4787], see https://tools.ietf.org/html/rfc5766#section-2.3.
+type PermissionHandler func(clientAddr net.Addr, peerIP net.IP) (ok bool)
+
+// DefaultPermissionHandler is convince function that grants permission to all peers
+func DefaultPermissionHandler(clientAddr net.Addr, peerIP net.IP) (ok bool) {
+	return true
+}
+
 // PacketConnConfig is a single net.PacketConn to listen/write on. This will be used for UDP listeners
 type PacketConnConfig struct {
 	PacketConn net.PacketConn
@@ -30,6 +43,11 @@ type PacketConnConfig struct {
 	// When an allocation is generated the RelayAddressGenerator
 	// creates the net.PacketConn and returns the IP/Port it is available at
 	RelayAddressGenerator RelayAddressGenerator
+
+	// PermissionHandler is a callback to filter peer addresses. Can be set as nil, in which
+	// case the DefaultPermissionHandler is automatically instantiated to admit all peer
+	// connections
+	PermissionHandler PermissionHandler
 }
 
 func (c *PacketConnConfig) validate() error {
@@ -50,6 +68,11 @@ type ListenerConfig struct {
 	// When an allocation is generated the RelayAddressGenerator
 	// creates the net.PacketConn and returns the IP/Port it is available at
 	RelayAddressGenerator RelayAddressGenerator
+
+	// PermissionHandler is a callback to filter peer addresses. Can be set as nil, in which
+	// case the DefaultPermissionHandler is automatically instantiated to admit all peer
+	// connections
+	PermissionHandler PermissionHandler
 }
 
 func (c *ListenerConfig) validate() error {


### PR DESCRIPTION
#### This is another take on  #134 

#### This is another attempt to address #134, see an earlier attempt in #222

#222 introduces the DeniedPeerRange stanza into the ServerConfig to implement peer address blacklisting. This approach has a couple of issues:
- implements only peer blacklists, but does not allow whiletelisting or filtering based on DNS, etc.
- handles only the ChannelBindRequest codepath, but leaves the CreatePermission codepath (https://datatracker.ietf.org/doc/html/rfc8656#section-3.4) open 
- introduces a new package dependency on "inet.af/netaddr"

This patch takes a different approach: it allows the user to specify a PermissionHandler callback for each PacketConnConfig/ListenerConfig in the ServerConfig. Whenever a permission is about to be created via the associated PacketConn/Listener (either via a ChannelBindRequest or a CreatePermission), the PermissionHandler is called with the requested peer address and it can decide whether to accommodate the permission request (return boolean true) or deny it (return false). In the latter case, a "permission request administratively prohibited" error is returned to the client.

Also added tests and an example.