### PR TITLE
Implementation of per-client UDP readloops

### DIFF
--- a/examples/turn-server/udp-connect/main.go
+++ b/examples/turn-server/udp-connect/main.go
@@ -1,0 +1,105 @@
+// Package main implements a performance optimized TURN server that uses client-specific connected
+// sockets using SO_REUSEPORT.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"syscall"
+
+	"github.com/pion/logging"
+	"github.com/pion/turn/v2"
+)
+
+func main() {
+	publicIP := flag.String("public-ip", "", "IP Address that TURN can be contacted by.")
+	port := flag.Int("port", 3478, "Listening port.")
+	users := flag.String("users", "", "List of username and password (e.g. \"user=pass,user=pass\")")
+	realm := flag.String("realm", "pion.ly", "Realm (defaults to \"pion.ly\")")
+	flag.Parse()
+
+	if len(*publicIP) == 0 {
+		log.Fatalf("'public-ip' is required")
+	} else if len(*users) == 0 {
+		log.Fatalf("'users' is required")
+	}
+
+	// Create a UDP listener to pass into pion/turn
+	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
+	// this allows us to add logging, storage or modify inbound/outbound traffic
+	listenerConfig := &net.ListenConfig{Control: reuseAddr}
+	udpListener, err := listenerConfig.ListenPacket(context.Background(), "udp4",
+		"0.0.0.0:"+strconv.Itoa(*port))
+	if err != nil {
+		log.Panicf("Failed to create TURN server listener: %s", err)
+	}
+
+	// Cache -users flag for easy lookup later
+	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
+	usersMap := map[string][]byte{}
+	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
+		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	}
+
+	logger := logging.NewDefaultLoggerFactory()
+	// uncomment this to raise loglevel
+	// logger.DefaultLogLevel = logging.LogLevelTrace
+
+	s, err := turn.NewServer(turn.ServerConfig{
+		Realm: *realm,
+		// Set AuthHandler callback
+		// This is called every time a user tries to authenticate with the TURN server
+		// Return the key for that user, or false when no user is found
+		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+			if key, ok := usersMap[username]; ok {
+				return key, true
+			}
+			return nil, false
+		},
+		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
+		PacketConnConfigs: []turn.PacketConnConfig{
+			{
+				PacketConn: udpListener,
+				Connect: func(conn net.PacketConn, remoteAddr net.Addr) (net.PacketConn, error) {
+					log.Printf("connecting back to client %q", remoteAddr.String())
+					dialer := &net.Dialer{LocalAddr: conn.LocalAddr(), Control: reuseAddr}
+					newConn, err := dialer.Dial(remoteAddr.Network(), remoteAddr.String())
+					if err != nil {
+						return nil, err
+					}
+					return turn.NewWrapConn(newConn, conn.LocalAddr()), nil
+				},
+				RelayAddressGenerator: &turn.RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP(*publicIP), // Claim that we are listening on IP passed by user (This should be your Public IP)
+					Address:      "0.0.0.0",              // But actually be listening on every interface
+				},
+			},
+		},
+		LoggerFactory: logger,
+	})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Block until user sends SIGINT or SIGTERM
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	if err = s.Close(); err != nil {
+		log.Panic(err)
+	}
+}
+
+func reuseAddr(network, address string, conn syscall.RawConn) error {
+	return conn.Control(func(descriptor uintptr) {
+		_ = syscall.SetsockoptInt(int(descriptor), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+		// syscall.SetsockoptInt(int(descriptor), syscall.SOL_SOCKET, syscall.SO_REUSEPORT, 1)
+	})
+}

--- a/internal/server/readloop.go
+++ b/internal/server/readloop.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/turn/v2/internal/allocation"
+)
+
+type State struct {
+	// Connection State
+	Conn net.PacketConn
+
+	// Server State
+	AllocationManager *allocation.Manager
+	Connect           func(conn net.PacketConn, remoteAddr net.Addr) (net.PacketConn, error)
+	Nonces            *sync.Map
+	InboundMTU        int
+	Log               logging.LeveledLogger
+
+	// User Configuration
+	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+	Realm              string
+	ChannelBindTimeout time.Duration
+}
+
+func ReadLoop(r State) {
+	buf := make([]byte, r.InboundMTU)
+	for {
+		n, addr, err := r.Conn.ReadFrom(buf)
+		switch {
+		case err != nil:
+			r.Log.Debugf("exit read loop on error: %s", err.Error())
+			return
+		case n >= r.InboundMTU:
+			r.Log.Debugf("read bytes exceeded MTU, packet is possibly truncated")
+		}
+
+		if err := HandleRequest(Request{
+			State:   r,
+			SrcAddr: addr,
+			Buff:    buf[:n],
+		}); err != nil {
+			r.Log.Errorf("error when handling datagram: %v", err)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,31 +4,17 @@ package server
 import (
 	"fmt"
 	"net"
-	"sync"
-	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun"
-	"github.com/pion/turn/v2/internal/allocation"
 	"github.com/pion/turn/v2/internal/proto"
 )
 
 // Request contains all the state needed to process a single incoming datagram
 type Request struct {
+	State
 	// Current Request State
-	Conn    net.PacketConn
 	SrcAddr net.Addr
 	Buff    []byte
-
-	// Server State
-	AllocationManager *allocation.Manager
-	Nonces            *sync.Map
-
-	// User Configuration
-	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
-	Log                logging.LeveledLogger
-	Realm              string
-	ChannelBindTimeout time.Duration
 }
 
 // HandleRequest processes the give Request

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -79,14 +79,16 @@ func TestAllocationLifeTime(t *testing.T) {
 
 		staticKey := []byte("ABC")
 		r := Request{
-			AllocationManager: allocationManager,
-			Nonces:            &sync.Map{},
-			Conn:              l,
-			SrcAddr:           &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5000},
-			Log:               logger,
-			AuthHandler: func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool) {
-				return staticKey, true
+			State: State{
+				AllocationManager: allocationManager,
+				Nonces:            &sync.Map{},
+				Conn:              l,
+				Log:               logger,
+				AuthHandler: func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool) {
+					return staticKey, true
+				},
 			},
+			SrcAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5000},
 		}
 		r.Nonces.Store(string(staticKey), time.Now())
 

--- a/server_config.go
+++ b/server_config.go
@@ -40,8 +40,13 @@ func DefaultPermissionHandler(clientAddr net.Addr, peerIP net.IP) (ok bool) {
 type PacketConnConfig struct {
 	PacketConn net.PacketConn
 
-	// When an allocation is generated the RelayAddressGenerator
-	// creates the net.PacketConn and returns the IP/Port it is available at
+	// Connect makes it possible to connect a PacketConn back to a specific remote
+	// address. This makes it possible to spawn a separate readLoop thread for the connected
+	// socket amd improve scalability.
+	Connect func(conn net.PacketConn, remoteAddr net.Addr) (net.PacketConn, error)
+
+	// RelayAddressGenerator creates the net.PacketConn when an allocation is generated and
+	// returns the IP/Port it is available at
 	RelayAddressGenerator RelayAddressGenerator
 
 	// PermissionHandler is a callback to filter peer addresses. Can be set as nil, in which


### PR DESCRIPTION
This is a first attempt to address #287.

The aim is to allow the server to maintain a specific per-client UDP readloop thread instead of one global readloop, which would allow it to drain each client connection on a separate CPU thread. See more on this [here](https://github.com/l7mp/stunner/issues/60).

**Problem:** Currently pion/turn server-side performance is limited at about 40-50 kpps per TURN/UDP listener. This is because we allocate a single *global* `net.PacketConn` per UDP listener, which is then [drained by a single CPU go-routine](https://github.com/l7mp/turn/blob/7bd80d5f800480042e404d1d49e5a6d20377127e/server.go#L68). This means that all client allocations made via that listener will share the same CPU thread and there is no way to load-balance client allocations across CPUs. This only affects TURN/UDP: for TCP, TLS and DTLS the TURN sockets are connected back to the client and therefore [a separate CPU go-routine is created for each allocation](https://github.com/l7mp/turn/blob/7bd80d5f800480042e404d1d49e5a6d20377127e/server.go#L96).

**Proposed solution:** Create a separate `net.PacketConn` per each UDP client-allocation, by (1) sharing the same listener server socket using `SO_REUSEADDR`, (2) connecting each per-allocation connection back to the client, and (3) firing up a separate read-loop/go-routine per each client socket.

**Security:** Care must be taken in implementing this plan: if we blindly create a new socket per received UDP packet then a simple UDP portscan will DoS the TURN listener. In the proposed solution the per-client socket is created only after a client has made a successful allocation, which rules out the blind port-scan problem since the attacker must at least have  a set of valid TURN credentials. It is still not completely safe against DoS attacks though, in that an attacker in possession of valid credentials can still open thousands of server sockets, but this is at least the same level of security as provided by the TURN/TCP implementation.

**Implementation:** Some fairly intrusive changes are required to support this. The patch set in particular:

- moves readLoop() into internal/server/readLoop.go,
- splits server.Request struct into server.State (stuff needed by the readLoop) and server.Request (the rest) that embeds server.State,
- lets the server invoke the Connect callback once it successfully created an TURN allocation for a client to obtain a per-client socket and spawn the readloop go-routine for the new socket,
- adds a WrapConn implementation that wraps the net.Conn returned by the DiapUDP as a net.PacketConn,
- adds an example ( examples/turn-server/udp-connect/main.go) to demonstrate the use of the new feature.

**Performance:** Attached is a super-simple script to benchmark a naive TURN server with (`udp-connect`) and without (`simple`) the patch. Requires the `turncat` TURN client (you can obtain from [here](https://github.com/l7mp/stunner/tree/main/cmd/turncat)) in the source dir, plus iperfv2 in the PATH. The script opens 4 client connections and runs a UDP iperf benchmark in each, then in every 5 seconds it reports the cumulative packet rate through the tested server.  On a 24-core Intel server, the built-in `simple` server (`./test.sh simple 30000000`) produced 34816 pps packet rate and used 141.1% CPU (recall, there are 4 clients connected to the same listener so theoretically the server could scale out to 4 CPUs), while the server with the patches (`./test.sh udp-connect 30000000`) produced 140194 pps with 472% CPU usage.

Feedback appreciated. 

[test.sh.gz](https://github.com/pion/turn/files/10458750/test.sh.gz)
