### PR TITLE
Implementation of per-client UDP readloops, take 2

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,9 @@ You could also intercept these reads/writes if you want to filter traffic going 
 #### simple
 This example is the most minimal invocation of a Pion TURN instance possible. It has no custom behavior, and could be a good starting place for running your own TURN server.
 
+#### simple-multithreaded
+A multithreaded version of the `simple` Pion TURN server, demonstrating how to scale a Pion UDP TURN server to multiple CPU cores. By default, Pion TURN servers use a single UDP socket that is shared across all clients, which limits Pion UDP/TURN servers to a single CPU thread. This example passes a configurable number of UDP sockets to the TURN server, which share the same local `address:port` pair using the `SO_REUSEPORT` socket option. This then lets the server to create a separate readloop to drain each socket. The OS kernel will distribute packets received on the `address:port` pair across the sockets by the IP 5-tuple, which makes sure that all packets of a TURN allocation will be correctly processed in a single readloop.
+
 #### tcp
 This example demonstrates listening on TCP. You could combine this example with `simple` and you will have a Pion TURN instance that is available via TCP and UDP.
 

--- a/examples/turn-server/simple-multithreaded/main.go
+++ b/examples/turn-server/simple-multithreaded/main.go
@@ -1,0 +1,111 @@
+//go:build !wasm
+
+// Package main implements a multi-threaded TURN server
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"syscall"
+
+	"github.com/pion/turn/v2"
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	publicIP := flag.String("public-ip", "", "IP Address that TURN can be contacted by.")
+	port := flag.Int("port", 3478, "Listening port.")
+	users := flag.String("users", "", "List of username and password (e.g. \"user=pass,user=pass\")")
+	realm := flag.String("realm", "pion.ly", "Realm (defaults to \"pion.ly\")")
+	threadNum := flag.Int("thread-num", 1, "Number of server threads (defaults to 1)")
+	flag.Parse()
+
+	if len(*publicIP) == 0 {
+		log.Fatalf("'public-ip' is required")
+	} else if len(*users) == 0 {
+		log.Fatalf("'users' is required")
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:"+strconv.Itoa(*port))
+	if err != nil {
+		log.Fatalf("Failed to parse server address: %s", err)
+	}
+
+	// Cache -users flag for easy lookup later
+	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
+	usersMap := map[string][]byte{}
+	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
+		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	}
+
+	// Create `numThreads` UDP listeners to pass into pion/turn
+	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
+	// this allows us to add logging, storage or modify inbound/outbound traffic
+	// UDP listeners share the same local address:port with setting SO_REUSEPORT and the kernel
+	// will load-balance received packets per the IP 5-tuple
+	listenerConfig := &net.ListenConfig{
+		Control: func(network, address string, conn syscall.RawConn) error {
+			var operr error
+			if err = conn.Control(func(fd uintptr) {
+				operr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+			}); err != nil {
+				return err
+			}
+
+			return operr
+		},
+	}
+
+	relayAddressGenerator := &turn.RelayAddressGeneratorStatic{
+		RelayAddress: net.ParseIP(*publicIP), // Claim that we are listening on IP passed by user
+		Address:      "0.0.0.0",              // But actually be listening on every interface
+	}
+
+	packetConnConfigs := make([]turn.PacketConnConfig, *threadNum)
+	for i := 0; i < *threadNum; i++ {
+		conn, listErr := listenerConfig.ListenPacket(context.Background(), addr.Network(), addr.String())
+		if listErr != nil {
+			log.Fatalf("Failed to allocate UDP listener at %s:%s", addr.Network(), addr.String())
+		}
+
+		packetConnConfigs[i] = turn.PacketConnConfig{
+			PacketConn:            conn,
+			RelayAddressGenerator: relayAddressGenerator,
+		}
+
+		log.Printf("Server %d listening on %s\n", i, conn.LocalAddr().String())
+	}
+
+	s, err := turn.NewServer(turn.ServerConfig{
+		Realm: *realm,
+		// Set AuthHandler callback
+		// This is called every time a user tries to authenticate with the TURN server
+		// Return the key for that user, or false when no user is found
+		AuthHandler: func(username string, realm string, srcAddr net.Addr) ([]byte, bool) {
+			if key, ok := usersMap[username]; ok {
+				return key, true
+			}
+			return nil, false
+		},
+		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
+		PacketConnConfigs: packetConnConfigs,
+	})
+	if err != nil {
+		log.Panicf("Failed to create TURN server: %s", err)
+	}
+
+	// Block until user sends SIGINT or SIGTERM
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	if err = s.Close(); err != nil {
+		log.Panicf("Failed to close TURN server: %s", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/pion/stun v0.4.0
 	github.com/pion/transport/v2 v2.0.2
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/sys v0.5.0
 )


### PR DESCRIPTION
This is the second attempt to address #287, see also #288

**Problem:** The specific problem we are trying to address is to scale TURN/UDP server listeners beyond a single CPU. Currently we allocate a single global net.PacketConn per TURN/UDP listener that is shared across all clients. Since there is only a single readLoop to drain the global PacketConn, TURN/UDP listeners are practically limited to a single CPU. See more on this [here](https://github.com/l7mp/stunner/issues/60).

**Prior attempts:** The first draft PR #288 addresses this issue by forking off a separate readloop thread per each client, which allows the server to drain each client connection on a separate CPU thread. In order to implement this in a secure way #288 introduces some fairly intrusive changes to the main TURN server implementation: there is an API change where the user must provide a `Connect` callback that the server calls after a new TURN allocation is created to make the per-client connection, and there is some major refactoring in `internal/server` as well to make this possible. Meanwhile, a security problem is still lurking in the background: without the implementation of per-user allocation quotas it is still possible for a single high-bandwidth attacker to starve the rest of the clients by creating multiple TURN allocations and consuming excess CPU.

**Goal:** This PR takes a completely different approach: the aim is to scale UDP/TURN listeners beyond the single-CPU limit but meanwhile (1) minimize the changes required in the existing pion/turn implementation (the PR requires absolutely no change to the server code) and (2) allow the operator to tightly control the number of CPUs allocated to each TURN/UDP listener.

**Implementation:** The idea is that the caller creates a fixed number of UDP listener sockets that share the same local addr:port by using the `SO_REUSEPORT` socket option and then initializes a separate TURN listener per each socket. Note that when multiple sockets share the same local address with `SO_REUSEPORT` then the kernel will load-balance packets across the sockets by the IP five-tuple hash (see  [here](https://elixir.bootlin.com/linux/latest/source/net/ipv4/udp.c#L415)), which makes sure that each packet of a TURN allocation will be processed by the same readLoop and so the allocation manager doesn't need to be shared across CPU threads. By controlling the number of sockets, the caller can control the number of CPUs allocated to each listener. Since this requires no change at all in the TURN server code (every socket will be handled by pion/turn as a separate UDP/TURN listener), the PR contains only a simple extension of the example server (see `examples/turn-server/mult-threaded-udp/main.go`) to implement the caller-side changes.

The pros are simplicity and control over CPU consumption. The cons are (1) that `SO_REUSEPORT` is not portable (we don't see this as a problem: recall that nothing in the server knows anything about whether `SO_REUSEPORT` is in use, all required changes are on the caller side) and (2) performance is slightly smaller than with #288. This is because hash-based load-balancing used by the kernel to distribute TURN allocations across the CPU threads is prone to an unequal distribution of load across worker threads: this can be taken care of by implementing an adaptive load-balancing algorithm [with eBPF](https://www.kernel.org/doc/html/latest/bpf/prog_sk_lookup.html) (say, using the [power-of-two choices algorithm](https://ieeexplore.ieee.org/document/963420)).

**Performance:** Attached is a script to benchmark the naive TURN server with (`mult-threaded-udp`) and without (`simple`) the patch. Requires the turncat TURN client (you can obtain from  [here](https://github.com/l7mp/stunner/tree/main/cmd/turncat)) in the source dir, plus iperfv2 in the PATH. On a 24-core Intel server and 8 iperf threads, the built-in simple server (`./test2.sh simple 16000000`) produces roughly 41 kpps (thousand packets per second) packet rate and uses about 141% CPU, while the server using 4 `SO_REUSEPORT` sockets and so 4 readLoop threads (`./test.sh mult-threaded-udp 16000000`) produces 121 kpps with 390% CPU usage. Observe that both the performance and the CPU usage is smaller than with #288, this is because of the uneven load-distribution (the difference between the least-loaded thread and the most-loaded thread can be more than 50% in our benchmarks).

Feedback appreciated.
[test2.sh.gz](https://github.com/pion/turn/files/10535074/test2.sh.gz)