### PR TITLE
Make type assertion option in util.go

### DIFF
--- a/internal/ipnet/util.go
+++ b/internal/ipnet/util.go
@@ -2,14 +2,56 @@
 package ipnet
 
 import (
+	"encoding/hex"
 	"errors"
 	"net"
+	"strconv"
 )
 
 var errFailedToCastAddr = errors.New("failed to cast net.Addr to *net.UDPAddr or *net.TCPAddr")
 
-// AddrIPPort extracts the IP and Port from a net.Addr
+// IPv6OpenSqBracket is opening square bracket used within the string representation
+const IPv6OpenSqBracket = 0x5b
+
+// IPv6CloseSqBracket is closing square bracket used within the string representation
+const IPv6CloseSqBracket = 0x5d
+
+// IPv6Delimiter is colon - within host indicative of IPv6 - see net/ipsock.go
+const IPv6Delimiter = 0x3a
+
+// IPv4Delimiter  is dot - indicative of IPv4
+const IPv4Delimiter = 0x2e
+
+// zoneStartDelimiter is percentage - indicates start of zone
+const zoneStartDelimiter = 0x25
+
+// portStartDelimiter is colon - indicates end of zone, start of port - so note potential confusion between this and IPv6 delimiter
+const portStartDelimiter = 0x3a
+
+// SetUseTestingNetAddr sets the big switch so code can be switched from testable variant to quick non testable variant.
+func SetUseTestingNetAddr(mval bool) {
+	testingNetAddr = mval
+}
+
+// GetUseTestingNetAddr gets the value of the big switch
+func GetUseTestingNetAddr() bool {
+	return testingNetAddr
+}
+
+// TestingNetAddr creates a big switch so code can be switched from testable variant to quick non testable variant.
+var testingNetAddr = false
+
+// AddrIPPort function has the original signature and extracts the IP and Port from a net.Addr
+// But whilst the original implementation (if TestingNetAddr is false) is quick it has a serious problem.
+// The type cast attempt from the interface back into either a *net.UDPAddr or *.net.TCPAddr means that
+// Any other struct which implements the net.Addr interface can't be accepted.
+// This prevents mocking entirely. So boundary conditions for particular IP address and port combinations can't be unit tested.
+// This isn't great.
+// But despite this the type cast is extremely quick (despite much performance tuning of the alternative). So a big switch is provided - at the moment.
 func AddrIPPort(a net.Addr) (net.IP, int, error) {
+	if testingNetAddr {
+		return AddrIPPortNew(a)
+	}
 	aUDP, ok := a.(*net.UDPAddr)
 	if ok {
 		return aUDP.IP, aUDP.Port, nil
@@ -37,4 +79,178 @@ func AddrEqual(a, b net.Addr) bool {
 	}
 
 	return aUDP.IP.Equal(bUDP.IP) && aUDP.Port == bUDP.Port
+}
+
+// Assume the slice of bytes contains numbers in base 10
+func getByteForString(input []byte) byte {
+	alen := len(input)
+	mval := 0
+	base := 1
+	for i := alen - 1; i >= 0; i-- {
+		if input[i] > 0x0 {
+			mval += (int(input[i]) - 48) * base
+			base *= 10
+		} else {
+			break
+		}
+	}
+	return byte(mval)
+}
+
+// FindIPv6AddrPort decodes the string representation used in the net library and put the content into hexadecimal byte slice and int.
+// The IPv6 address is stored internally as [ffff:ffff:ffff:ffff:ffff:ffff%zone]:port number by the net.UDPAddr and net.TCPAddr structs
+func FindIPv6AddrPort(aBytes []byte, lenaBytes int, zoneStart int, portStart int) (mAddr []byte, mPort int64, merr error) {
+	var sectionindex int
+	var portEnd int
+	endIPAddress := false
+	endZone := false
+	var zIndex int
+	mAddr = make([]byte, 16)
+	mZone := make([]byte, lenaBytes)
+	for inputindex := 0; inputindex < lenaBytes; inputindex++ {
+		switch aBytes[inputindex] {
+		case IPv6OpenSqBracket:
+			continue
+		case IPv6CloseSqBracket:
+			endZone = true
+			continue
+		case IPv6Delimiter:
+			continue
+		case zoneStartDelimiter:
+			endIPAddress = true
+			continue
+		default:
+			if !endIPAddress {
+				// the +2 is safe as the IP address is never on the end of the string...
+				newVal, err := hex.DecodeString(string(aBytes[inputindex : inputindex+2]))
+				if err != nil {
+					return []byte(""), 0, errFailedToCastAddr
+				}
+				mAddr[sectionindex] = newVal[0]
+				sectionindex++
+				inputindex++
+			} else {
+				// we're dealing with the port number
+				if endZone {
+					if portStart == 0 {
+						portStart = inputindex
+					}
+					portEnd = inputindex
+					continue
+				} else {
+					// deal with the zone
+					mZone[zIndex] = aBytes[inputindex]
+					zIndex++
+				}
+			}
+		}
+	}
+	mPort, err := strconv.ParseInt(string(aBytes[portStart:portEnd+1]), 10, 0)
+	if err != nil {
+		return []byte(""), 0, errFailedToCastAddr
+	}
+	// we want an int from this so the binary.BigEndian isn't an option..
+	return mAddr, mPort, nil
+}
+
+// FindIPv4AddrPort decodes the string representation used in the net library and put the content into hexadecimal byte slice and int.
+// The IPv4 address is stored internally as nnn.nnn.nnn.nnn:port number by the net.UDPAddr and net.TCPAddr structs
+func FindIPv4AddrPort(aBytes []byte, lenaBytes int, zoneStart int, portStart int) (mAddr []byte, mPort int64, merr error) {
+	var start int
+	var octetend int
+	var portEnd int
+	mAddrStart := 12
+	octetbytes := make([]byte, 8)
+	mAddr = make([]byte, 16)
+	mAddr[10] = 0xff
+	mAddr[11] = 0xff
+	for octet := 0; octet <= 3; octet++ {
+		for i := 0; i <= 3; i++ {
+			if aBytes[octetend] != IPv4Delimiter && aBytes[octetend] != zoneStartDelimiter {
+				octetend++
+			} else {
+				// zero the buffer - without reducing the capacity.. which nil does..
+				for j := 0; j < 8; j++ {
+					octetbytes[j] = byte(0)
+				}
+				k := 0
+				for j := 8 - (octetend - start); j < 8; j++ {
+					octetbytes[j] = aBytes[start+k]
+					k++
+				}
+				// the function below is much faster the strconv.ParseInt(string([]byte))
+				mval := getByteForString(octetbytes)
+				octetend++
+				start = octetend
+				mAddr[mAddrStart+octet] = mval
+				break // force a new octet to be started
+			}
+		}
+	}
+	for i := portStart; i <= lenaBytes; i++ {
+		portEnd = i
+	}
+	// we want an int from this so the binary.BigEndian isn't an option..
+	mPort, err := strconv.ParseInt(string(aBytes[portStart:portEnd]), 10, 0)
+	if err != nil {
+		return []byte(""), 0, errFailedToCastAddr
+	}
+	return mAddr, mPort, nil
+}
+
+func findAddrStringRegions(aBytes []byte) (isIPv6 bool, isIPv4 bool, zoneStart int, portStart int, lenaBytes int) {
+	zoneStart = len(aBytes)
+	lenaBytes = zoneStart
+	for i := 0; i < lenaBytes; i++ {
+		if i <= zoneStart && !isIPv6 && !isIPv4 {
+			if aBytes[i] == IPv6Delimiter {
+				isIPv6 = true
+			}
+			if aBytes[i] == IPv4Delimiter {
+				isIPv4 = true
+			}
+		}
+		if aBytes[i] == zoneStartDelimiter {
+			zoneStart = i
+		}
+		if isIPv4 {
+			if aBytes[i] == portStartDelimiter {
+				portStart = i + 1
+				break
+			}
+		}
+	}
+	return isIPv6, isIPv4, zoneStart, portStart, lenaBytes
+}
+
+// AddrIPPortNew is a new version of the original AddrIPPort.
+// It inspects the internal string representation of IPv6 and IPv4 addresses to retrieve the IP address and port.
+// It could easily export the zone - but this isn't within the original function signature.
+func AddrIPPortNew(a net.Addr) (net.IP, int, error) {
+	var mIP []byte
+	var err error
+	var mPort int64
+	var IsIPv6 bool
+	var IsIPv4 bool
+	var zoneStart int
+	var lenaBytes int
+	var portStart int
+	if a.Network() == "udp" || a.Network() == "tcp" {
+		aBytes := []byte(a.String())
+		IsIPv6, IsIPv4, zoneStart, portStart, lenaBytes = findAddrStringRegions(aBytes)
+		switch {
+		case IsIPv6:
+			mIP, mPort, err = FindIPv6AddrPort(aBytes, lenaBytes, zoneStart, portStart)
+		case IsIPv4:
+			mIP, mPort, err = FindIPv4AddrPort(aBytes, lenaBytes, zoneStart, portStart)
+		default:
+			return nil, 0, errFailedToCastAddr
+		}
+		if err != nil {
+			return nil, 0, errFailedToCastAddr
+		}
+	} else {
+		return nil, 0, errFailedToCastAddr
+	}
+	return mIP, int(mPort), nil
 }

--- a/internal/ipnet/util_test.go
+++ b/internal/ipnet/util_test.go
@@ -1,0 +1,214 @@
+package ipnet
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+type mockNetAddrIF interface {
+	Network() string
+	String() string
+}
+type mockNetAddrImpl struct {
+	IP            net.IP
+	Port          int
+	Zone          string
+	handleString  func() string
+	handleNetwork func() string
+}
+
+func newMockNetAddr() *mockNetAddrImpl {
+	mNetAddrImpl := mockNetAddrImpl{}
+	return &mNetAddrImpl
+}
+
+func (m *mockNetAddrImpl) String() string {
+	return m.handleString()
+}
+
+func (m *mockNetAddrImpl) Network() string {
+	return m.handleNetwork()
+}
+
+func Test_getByteForString1(t *testing.T) {
+	tests := []struct {
+		supply []byte
+		want   byte
+	}{
+		{supply: []byte("135"), want: 0x87},
+		{supply: []byte{0x0, 0x32, 0x33, 0x35}, want: 0xeb}, // 235
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			if got := getByteForString(tt.supply); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIPv4UDPPort(t *testing.T) {
+	var mUDPAddrIF, mTCPAddrIF net.Addr
+	mUDPAddr := net.UDPAddr{
+		IP:   net.IPv4(byte(0xfe), byte(0x87), byte(0xd6), byte(0xc2)),
+		Port: 3456,
+		Zone: "unknown",
+	}
+	mTCPAddr := net.TCPAddr{
+		IP:   net.IPv4(byte(125), byte(154), byte(86), byte(178)),
+		Port: 26700,
+		Zone: "unknown",
+	}
+	mTCPAddrIF = &mTCPAddr
+	mUDPAddrIF = &mUDPAddr
+	tests := []struct {
+		supply      net.Addr
+		wantAddress net.IP
+		wantPort    int
+	}{
+		{supply: mUDPAddrIF, wantAddress: net.IPv4(byte(0xfe), byte(0x87), byte(0xd6), byte(0xc2)), wantPort: 3456},
+		{supply: mTCPAddrIF, wantAddress: net.IPv4(byte(125), byte(154), byte(86), byte(178)), wantPort: 26700},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			gotIP, gotPort, err := AddrIPPortNew(tt.supply)
+			if !gotIP.Equal(tt.wantAddress) {
+				t.Errorf("got %s, want %s", gotIP, tt.wantAddress)
+			}
+			if gotPort != tt.wantPort {
+				t.Errorf("got %d, want %d", gotPort, tt.wantPort)
+			}
+			if err != nil {
+				t.Errorf("got %s, ", err.Error())
+			}
+		},
+		)
+	}
+}
+
+func TestIPv6UDPPort(t *testing.T) {
+	var mUDPAddrIF net.Addr
+	var mUDPAddrIF2 net.Addr
+	// use the function from the networking library to create the net.IP variable
+	mSetIPAddr := net.ParseIP("FE87:d6c2:1020:3a30:fedd:cd20:5060:7080")
+	mUDPAddr := net.UDPAddr{
+		IP:   mSetIPAddr,
+		Port: 31781,
+		Zone: "unknown",
+	}
+	mUDPAddr2 := net.UDPAddr{
+		IP:   mSetIPAddr,
+		Port: 25,
+		Zone: "unknown",
+	}
+	mUDPAddrIF = &mUDPAddr
+	mUDPAddrIF2 = &mUDPAddr2
+	tests := []struct {
+		supply      net.Addr
+		wantAddress net.IP
+		wantPort    int
+	}{
+		{supply: mUDPAddrIF, wantAddress: net.ParseIP("FE87:d6c2:1020:3a30:fedd:cd20:5060:7080"), wantPort: 31781},
+		{supply: mUDPAddrIF2, wantAddress: net.ParseIP("FE87:d6c2:1020:3a30:fedd:cd20:5060:7080"), wantPort: 25},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			gotIP, gotPort, err := AddrIPPortNew(tt.supply)
+			if !gotIP.Equal(tt.wantAddress) {
+				t.Errorf("got %s, want %s", gotIP, tt.wantAddress)
+			}
+			if gotPort != tt.wantPort {
+				t.Errorf("got %d, want %d", gotPort, tt.wantPort)
+			}
+			if err != nil {
+				t.Errorf("got %s, ", err.Error())
+			}
+		},
+		)
+	}
+}
+
+func NoBenchmarkAddrIPv4IPPortNew(b *testing.B) {
+	var mUDPAddrIF net.Addr
+	mUDPAddr := net.UDPAddr{
+		IP:   net.IPv4(byte(0xfe), byte(0x87), byte(0xd6), byte(0xc2)),
+		Port: 3456,
+		Zone: "unknown",
+	}
+	mUDPAddrIF = &mUDPAddr
+	for n := 0; n < b.N; n++ {
+		_, _, err := AddrIPPortNew(mUDPAddrIF)
+		if err != nil {
+			break
+		}
+	}
+}
+
+func BenchmarkIPv6UDPPort(b *testing.B) {
+	var mUDPAddrIF net.Addr
+	// use the function from the networking library to create the net.IP variable
+	mSetIPAddr := net.ParseIP("FE87:d6c2:1020:3a30:fedd:cd20:5060:7080")
+	mUDPAddr := net.UDPAddr{
+		IP:   mSetIPAddr,
+		Port: 31781,
+		Zone: "unknown",
+	}
+	mUDPAddrIF = &mUDPAddr
+	for n := 0; n < b.N; n++ {
+		_, _, err := AddrIPPortNew(mUDPAddrIF)
+		if err != nil {
+			break
+		}
+	}
+}
+
+func NoBenchmarkAddrIPPortOld(b *testing.B) {
+	var mUDPAddrIF net.Addr
+	mUDPAddr := net.UDPAddr{
+		IP:   net.IPv4(byte(0xfe), byte(0x87), byte(0xd6), byte(0xc2)),
+		Port: 3456,
+		Zone: "unknown",
+	}
+	mUDPAddrIF = &mUDPAddr
+	for n := 0; n < b.N; n++ {
+		_, _, err := AddrIPPortNew(mUDPAddrIF)
+		if err != nil {
+			break
+		}
+	}
+}
+
+func TestMock(t *testing.T) {
+	var mMockAddrIF mockNetAddrIF
+	mmockAddrImpl := newMockNetAddr()
+	mMockAddrIF = mmockAddrImpl
+	mmockAddrImpl.handleNetwork = func() string {
+		return "tcp"
+	}
+	mmockAddrImpl.handleString = func() string {
+		return "192.168.0.1%no particular zone:80"
+	}
+	tests := []struct {
+		supply      net.Addr
+		wantAddress net.IP
+		wantPort    int
+	}{
+		{supply: mMockAddrIF, wantAddress: net.IPv4(byte(192), byte(168), byte(0), byte(1)), wantPort: 80},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			gotIP, gotPort, err := AddrIPPortNew(tt.supply)
+			if !gotIP.Equal(tt.wantAddress) {
+				t.Errorf("got %s, want %s", gotIP, tt.wantAddress)
+			}
+			if gotPort != tt.wantPort {
+				t.Errorf("got %d, want %d", gotPort, tt.wantPort)
+			}
+			if err != nil {
+				t.Errorf("got %s, ", err.Error())
+			}
+		},
+		)
+	}
+}


### PR DESCRIPTION
The test functions use the net library internal functions to create examples of UDPAddr and TCPAddr for interpretation.

Provide unit tests for the new functions to validate the interpretation of UDP and TCP addresses and ports

Provide an example of the mocking that now becomes possible. Whilst the "typecast" appears neat it prevents test code from providing it's own mocked contents from the Network() and String() functions that net.Addr requires.

This means testing code may not be able to easily spoof IP addresses or ports of interest. It would appear to severely limit the ability to test TURN code in isolation as the server internals rely on this function - and link them to the request packet and destination address.

The single global variable is there to provide a big switch - between the more testable variant and the existing faster code.

#### Description

#### Reference issue
Fixes #...
