### PR TITLE
Allow Go tracing to be added without degrading production speed

### DIFF
--- a/internal/profiling/production_stub.go
+++ b/internal/profiling/production_stub.go
@@ -4,22 +4,26 @@ package profiling
 
 import (
 	"fmt"
-
 	"runtime/trace"
 
 	"github.com/pion/logging"
 )
 
+// SayHello just provides easy indication of which version has been included
 func SayHello() {
 	fmt.Println("welcome to production")
 }
 
+// NewProfiling provides a stub function when in production, giving back an empty struct
 func NewProfiling(filename string, mLogger logging.LeveledLogger) *Profiling {
 	return &Profiling{}
 }
 
+// OpenTracing provides a stub function when in production
 func (p *Profiling) OpenTracing(filename string, topLevel string) {}
 
+// CloseTracing provides a stub function when in production
 func (p *Profiling) CloseTracing() {}
 
-func (p *Profiling) SetRegion(regionname string) *trace.Region {}
+// SetRegion provides a stub  function when in production
+func (p *Profiling) SetRegion(regionname string) *trace.Region { return &trace.Region{} }

--- a/internal/profiling/production_stub.go
+++ b/internal/profiling/production_stub.go
@@ -1,0 +1,25 @@
+//go:build !debug
+
+package profiling
+
+import (
+	"fmt"
+
+	"runtime/trace"
+
+	"github.com/pion/logging"
+)
+
+func SayHello() {
+	fmt.Println("welcome to production")
+}
+
+func NewProfiling(filename string, mLogger logging.LeveledLogger) *Profiling {
+	return &Profiling{}
+}
+
+func (p *Profiling) OpenTracing(filename string, topLevel string) {}
+
+func (p *Profiling) CloseTracing() {}
+
+func (p *Profiling) SetRegion(regionname string) *trace.Region {}

--- a/internal/profiling/production_stub.go
+++ b/internal/profiling/production_stub.go
@@ -4,7 +4,6 @@ package profiling
 
 import (
 	"fmt"
-	"runtime/trace"
 
 	"github.com/pion/logging"
 )
@@ -26,4 +25,7 @@ func (p *Profiling) OpenTracing(filename string, topLevel string) {}
 func (p *Profiling) CloseTracing() {}
 
 // SetRegion provides a stub  function when in production
-func (p *Profiling) SetRegion(regionname string) *trace.Region { return &trace.Region{} }
+func (p *Profiling) SetRegion(regionname string) {}
+
+// EndRegion provides a stub function when in production
+func (p *Profiling) EndRegion() {}

--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -10,6 +10,7 @@ import (
 	"runtime/trace"
 )
 
+// SayHello just provides easy indication of which version has been included
 func SayHello() {
 	fmt.Println("welcome to debug")
 }

--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -1,0 +1,54 @@
+//go:build debug
+
+package profiling
+
+import (
+	"context"
+	"fmt"
+	"github.com/pion/logging"
+	"os"
+	"runtime/trace"
+)
+
+func SayHello() {
+	fmt.Println("welcome to debug")
+}
+
+// Open the tracing file - using a supplied or default file
+// the top level tracing context is also supplied.
+func (p *Profiling) OpenTracing(filename string, topLevel string) {
+	var err error
+	if len(filename) == 0 {
+		filename = "trace.out"
+	}
+	p.tracefile, err = os.Create(filename)
+	if err != nil {
+		panic("unable to open trace file")
+	}
+	trace.Start(p.tracefile)
+	p.basectx = context.TODO()
+	_, p.task = trace.NewTask(p.basectx, topLevel)
+	//p.mLogger.Debugf("Opened task, with output to file")
+	fmt.Printf("Opened task, with output to file %s\n", filename)
+}
+
+func (p *Profiling) SetRegion(regionname string) *trace.Region {
+	return trace.StartRegion(p.basectx, regionname)
+}
+
+// End the task, Stop tracing and close the tracing file.
+// This is essential to make sure pprof can deal with it..
+func (p *Profiling) CloseTracing() {
+	p.task.End()
+	trace.Stop()
+	p.tracefile.Close()
+	//p.mLogger.Debugf("Closed task, stopped trace and closed file")
+	fmt.Println("Closed task, stopped trace and closed file")
+}
+
+func NewProfiling(filename string, mLogger logging.LeveledLogger) *Profiling {
+	mProfiling := Profiling{}
+	mProfiling.mLogger = mLogger
+	mProfiling.OpenTracing(filename, "Request")
+	return &mProfiling
+}

--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -33,8 +33,18 @@ func (p *Profiling) OpenTracing(filename string, topLevel string) {
 	fmt.Printf("Opened task, with output to file %s\n", filename)
 }
 
-func (p *Profiling) SetRegion(regionname string) *trace.Region {
-	return trace.StartRegion(p.basectx, regionname)
+// SetRegion starts a trace region with a specified name. Note this MUST be closed before another region is entered.
+func (p *Profiling) SetRegion(regionname string) {
+	p.mRegion = trace.StartRegion(p.basectx, regionname)
+	return
+}
+
+// EndRegion ends the open trace region .
+func (p *Profiling) EndRegion() {
+	if p.mRegion != nil {
+		p.mRegion.End()
+	}
+	return
 }
 
 // End the task, Stop tracing and close the tracing file.

--- a/internal/profiling/types.go
+++ b/internal/profiling/types.go
@@ -1,0 +1,16 @@
+package profiling
+
+import (
+	"context"
+	"os"
+	"runtime/trace"
+
+	"github.com/pion/logging"
+)
+
+type Profiling struct {
+	tracefile *os.File
+	task      *trace.Task
+	basectx   context.Context
+	mLogger   logging.LeveledLogger
+}

--- a/internal/profiling/types.go
+++ b/internal/profiling/types.go
@@ -22,4 +22,5 @@ type Profiling struct {
 	task      *trace.Task
 	basectx   context.Context
 	mLogger   logging.LeveledLogger
+	mRegion   *trace.Region
 }

--- a/internal/profiling/types.go
+++ b/internal/profiling/types.go
@@ -1,3 +1,9 @@
+/*
+Package profiling provides easy access to the Go standard tooling. It is designed to the tracing is only included when -tags debug is present at compile / run time.
+
+The production_stub.go and profiling.go mimic each other.
+This types.go provides the common struct required in both cases.
+*/
 package profiling
 
 import (
@@ -8,6 +14,9 @@ import (
 	"github.com/pion/logging"
 )
 
+// Profiling is the standard struct required for both production and debug compilation
+//
+//nolint:golint,unused
 type Profiling struct {
 	tracefile *os.File
 	task      *trace.Task

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,7 +46,7 @@ func HandleRequest(r Request) error {
 
 func handleDataPacket(r Request) error {
 	r.Log.Debugf("received DataPacket from %s", r.SrcAddr.String())
-	mRegion := r.Profiler.SetRegion("DataPacket")
+	r.Profiler.SetRegion("DataPacket")
 	c := proto.ChannelData{Raw: r.Buff}
 	if err := c.Decode(); err != nil {
 		return fmt.Errorf("%w: %v", errFailedToCreateChannelData, err)
@@ -56,13 +56,13 @@ func handleDataPacket(r Request) error {
 	if err != nil {
 		err = fmt.Errorf("%w from %v: %v", errUnableToHandleChannelData, r.SrcAddr, err)
 	}
-	mRegion.End()
+	r.Profiler.EndRegion()
 	return err
 }
 
 func handleTURNPacket(r Request) error {
 	r.Log.Debug("handleTURNPacket")
-	mRegion := r.Profiler.SetRegion("TURNPacket")
+	r.Profiler.SetRegion("TURNPacket")
 	m := &stun.Message{Raw: append([]byte{}, r.Buff...)}
 	if err := m.Decode(); err != nil {
 		return fmt.Errorf("%w: %v", errFailedToCreateSTUNPacket, err)
@@ -77,7 +77,7 @@ func handleTURNPacket(r Request) error {
 	if err != nil {
 		return fmt.Errorf("%w %v-%v from %v: %v", errFailedToHandle, m.Type.Method, m.Type.Class, r.SrcAddr, err)
 	}
-	mRegion.End()
+	r.Profiler.EndRegion()
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -18,8 +18,6 @@ const (
 	defaultInboundMTU = 1600
 )
 
-//var mProfiler *profiling.Profiling
-
 // Server is an instance of the Pion TURN Server
 type Server struct {
 	log                logging.LeveledLogger


### PR DESCRIPTION
The internal/profiling files provide an profiling interface so that code gets included if and only if -tags debug is stated at compile / test time. The server.go opens and closes the trace. It also pushes the profiling interface to areas of concern by piggybacking it inside the server & request structures 
Using the tracing interface in internal/server/server.go shows the use of user regions. This gives a developer more focused analysis of the timing and other issues occurring in practice.

#### Description
The internal profiling files (production_stub.go and profiling.go) are paired. The stub has //go:build !debug and the active profiling.go has //go:build debug. This allows conditional compilation based on a -tags debug

So if testing a benchmark with tracing the command line would be

go test -tags debug -benchmem -run=^$ -bench ^BenchmarkServer$ github.com/pion/turn/v2

If testing without tracing simply omit the -tags debug i.e.
go test -benchmem -run=^$ -bench ^BenchmarkServer$ github.com/pion/turn/v2

The standard output file is trace.out. An alternative name can be set in the OpenTracing call


The go tool trace trace.out will parse and analyse the trace file and launch a local server to display results.

The example files were generated on a older i7 8 core machine using the RunBenchmarkServer in server_test.go. My suspicion is that these aren't showing a true picture of performance because they don't represent a realistic workload for a TURN server. (lots of tiny data packets)

![TraceExample](https://user-images.githubusercontent.com/12446343/221831558-a6959f38-60d0-44dd-aba4-6f0a51f9d972.png)
![GoRoutineExample](https://user-images.githubusercontent.com/12446343/221831564-614eebae-7f42-4182-b77d-5f4463d66c7f.png)
![SchedulerExample](https://user-images.githubusercontent.com/12446343/221831565-de19c70f-e55b-4e86-906e-8027a6a6b61d.png)
![UserRegionExample](https://user-images.githubusercontent.com/12446343/221831566-1a5c984f-4824-481b-8fea-eb4f559cb9f0.png)

#### Reference issue
Fixes #...
