### PR TITLE
Fix reused loop counter in the server benchmark

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -654,7 +654,7 @@ func RunBenchmarkServer(b *testing.B, clientNum int) {
 	}
 
 	// Run benchmark
-	for i := 0; i < b.N; i++ {
+	for j := 0; j < b.N; j++ {
 		for i := 0; i < clientNum; i++ {
 			if _, err := clients[i].WriteTo(testSeq, sinkAddr); err != nil {
 				b.Fatalf("Client %d cannot send to TURN server: %s", i+1, err)


### PR DESCRIPTION
RunBenchmarkServer uses two embedded loops to stress-test the server: an outer loop to make just as many iterations as required for the requested benchmark runtime, and an inner loop that walks through the clients and sends one package from each. Formerly, both loops used the same loop counter variable which led to incorrect results. This change fixes this issue.
