### PR TITLE
Fix: Delete allocation on TCP broken pipe

### DIFF
--- a/server.go
+++ b/server.go
@@ -149,6 +149,13 @@ func (s *Server) readListener(l net.Listener, am *allocation.Manager) {
 		go func() {
 			s.readLoop(NewSTUNConn(conn), am)
 
+			// Delete allocation
+			am.DeleteAllocation(&allocation.FiveTuple{
+				Protocol: allocation.UDP, // fixed UDP
+				SrcAddr:  conn.RemoteAddr(),
+				DstAddr:  conn.LocalAddr(),
+			})
+
 			if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 				s.log.Errorf("Failed to close conn: %s", err)
 			}


### PR DESCRIPTION
It seems many TURN/TCP clients out there implement a rather brute-force way to end TURN/TCP allocations: they spontaneously close the TCP connection underlying the allocation rather than properly closing it down by refreshing with zero lifetime. The server must delete the TURN allocation when it sees the client TCP connection has gone, otherwise the allocation will linger on and next time the client try to allocate from the same IP:port pair they receive a `relay already allocated for 5-TUPLE` error. Our users are actively being affected by this.

This PR fixes this issue and adds a test. The easiest way to understand the issue is through the test:

```
t.Run("Delete allocation on spontaneous TCP close", func(t *testing.T) {
    ...
    // Create TCP server
    server, err := NewServer(ServerConfig{ ... })

    // Create TCP client
    conn, err := net.Dial("tcp", "127.0.0.1:3478")
    client, err := NewClient(&ClientConfig{
        STUNServerAddr: serverAdddr,
        Conn:           NewSTUNConn(conn),
        ...
    })

    client.Listen()
    relayConn, err := client.Allocate()

    // if we close the relayConn, everything is fine
    relayConn.Close()

    // but if we close the underlying conn like this, the allocation lingers and the subsequent
    // tests fail
    conn.Close()
    ...
})
```

The issue is fixed by explicitly deleting the allocation in the `Server.readListener` when the `readLoop` returns.