### PR TITLE
Use multi-stage docker build for examples/turn-server/simple to reduce container image size

### DIFF
--- a/examples/turn-server/simple/Dockerfile
+++ b/examples/turn-server/simple/Dockerfile
@@ -1,7 +1,28 @@
 # SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
 # SPDX-License-Identifier: MIT
 
-FROM golang:latest
+FROM golang:alpine as builder
+
+ARG VERSION=master
+
+RUN apk add --no-cache git
+
+WORKDIR /build
+# Clone Source using GIT
+RUN git clone --branch=$VERSION --depth=1 https://github.com/pion/turn.git turn && rm -rf turn/.git
+
+WORKDIR /build/turn/examples/turn-server/simple
+
+# Download all the dependencies
+RUN go get -d -v ./...
+
+# Build static binary
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-w -s" -o turn-server main.go
+
+
+##### main
+FROM alpine
+
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION=master
@@ -16,38 +37,22 @@ LABEL org.label-schema.build-date="${BUILD_DATE}" \
       org.label-schema.version="${VERSION}" \
       maintainer="https://github.com/pion"
 
-ENV GOPATH /usr/local
 ENV REALM localhost
 ENV USERS username=password
 ENV UDP_PORT 3478
 ENV PUBLIC_IP 127.0.0.1
 
-# Use turn-server/simple by default
-ENV EXAMPLE_DIR examples/turn-server
-ENV EXAMPLE_BIN simple
-
-WORKDIR /usr/local/src/github.com/pions
-
-# Clone Source using GIT
-RUN git clone --branch=$VERSION --depth=1 https://github.com/pion/turn.git turn && rm -rf turn/.git
-
-WORKDIR /usr/local/src/github.com/pions/turn/$EXAMPLE_DIR
-
-# Download all the dependencies
-RUN go get -d -v ./...
-
-# Install the package
-RUN go install -v ./...
-
 EXPOSE 3478
 #EXPOSE 49152:65535/tcp
 #EXPOSE 49152:65535/udp
 
-RUN chown -R nobody:nogroup ./ && chmod -R a-w ./
 USER nobody
 
+# Copy the executable
+COPY --from=builder /build/turn/examples/turn-server/simple/turn-server /usr/bin/
+
 # Run the executable
-CMD $EXAMPLE_BIN -public-ip $PUBLIC_IP -users $USERS -realm $REALM -port $UDP_PORT
+CMD turn-server -public-ip $PUBLIC_IP -users $USERS -realm $REALM -port $UDP_PORT
 
 # docker build -t pion-turn -f Dockerfile .
-# docker run -e REALM="localhost" -e USERS="username=password" -e UDP_PORT="3478" -e PUBLIC_IP="127.0.0.1" -p 3478:3478 pion-turn
+# docker run --rm -e REALM="localhost" -e USERS="username=password" -e UDP_PORT="3478" -e PUBLIC_IP="127.0.0.1" -p 3478:3478 pion-turn


### PR DESCRIPTION
The current docker build of [examples/turn-server/simple](https://github.com/pion/turn/tree/master/examples/turn-server/simple) results a large (944MB) image.
This PR implements [multi-stage build](https://docs.docker.com/build/building/multi-stage/) that reduces image size to 10.2MB.