### PR TITLE
Use signed timestamp for nonce

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -177,11 +177,6 @@ func TestClientNonceExpiration(t *testing.T) {
 	allocation, err := client.Allocate()
 	assert.NoError(t, err)
 
-	server.nonces.Range(func(key, value interface{}) bool {
-		server.nonces.Delete(key)
-		return true
-	})
-
 	_, err = allocation.WriteTo([]byte{0x00}, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080})
 	assert.NoError(t, err)
 

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -7,8 +7,8 @@ import "errors"
 
 var (
 	errFailedToGenerateNonce                  = errors.New("failed to generate nonce")
+	errInvalidNonce                           = errors.New("invalid nonce")
 	errFailedToSendError                      = errors.New("failed to send error message")
-	errDuplicatedNonce                        = errors.New("duplicated Nonce generated, discarding request")
 	errNoSuchUser                             = errors.New("no such user exists")
 	errUnexpectedClass                        = errors.New("unexpected class")
 	errUnexpectedMethod                       = errors.New("unexpected method")

--- a/internal/server/nonce.go
+++ b/internal/server/nonce.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const (
+	nonceLifetime  = time.Hour // See: https://tools.ietf.org/html/rfc5766#section-4
+	nonceLength    = 40
+	nonceKeyLength = 64
+)
+
+// NewNonceHash creates a NonceHash
+func NewNonceHash() (*NonceHash, error) {
+	key := make([]byte, nonceKeyLength)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+
+	return &NonceHash{key}, nil
+}
+
+// NonceHash is used to create and verify nonces
+type NonceHash struct {
+	key []byte
+}
+
+// Generate a nonce
+func (n *NonceHash) Generate() (string, error) {
+	nonce := make([]byte, 8, nonceLength)
+	binary.BigEndian.PutUint64(nonce, uint64(time.Now().UnixMilli()))
+
+	hash := hmac.New(sha256.New, n.key)
+	if _, err := hash.Write(nonce[:8]); err != nil {
+		return "", fmt.Errorf("%w: %v", errFailedToGenerateNonce, err) //nolint:errorlint
+	}
+	nonce = hash.Sum(nonce)
+
+	return hex.EncodeToString(nonce), nil
+}
+
+// Validate checks that nonce is signed and is not expired
+func (n *NonceHash) Validate(nonce string) error {
+	b, err := hex.DecodeString(nonce)
+	if err != nil || len(b) != nonceLength {
+		return fmt.Errorf("%w: %v", errInvalidNonce, err) //nolint:errorlint
+	}
+
+	if ts := time.UnixMilli(int64(binary.BigEndian.Uint64(b))); time.Since(ts) > nonceLifetime {
+		return errInvalidNonce
+	}
+
+	hash := hmac.New(sha256.New, n.key)
+	if _, err = hash.Write(b[:8]); err != nil {
+		return fmt.Errorf("%w: %v", errInvalidNonce, err) //nolint:errorlint
+	}
+	if !hmac.Equal(b[8:], hash.Sum(nil)) {
+		return errInvalidNonce
+	}
+
+	return nil
+}

--- a/internal/server/nonce_test.go
+++ b/internal/server/nonce_test.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNonceHash(t *testing.T) {
+	t.Run("generated hashes validate", func(t *testing.T) {
+		h, err := NewNonceHash()
+		assert.NoError(t, err)
+		nonce, err := h.Generate()
+		assert.NoError(t, err)
+		assert.NoError(t, h.Validate(nonce))
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,6 @@ package server
 import (
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/pion/logging"
@@ -25,7 +24,7 @@ type Request struct {
 
 	// Server State
 	AllocationManager *allocation.Manager
-	Nonces            *sync.Map
+	NonceHash         *NonceHash
 
 	// User Configuration
 	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)

--- a/server.go
+++ b/server.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/pion/logging"
@@ -27,7 +26,7 @@ type Server struct {
 	authHandler        AuthHandler
 	realm              string
 	channelBindTimeout time.Duration
-	nonces             *sync.Map
+	nonceHash          *server.NonceHash
 
 	packetConnConfigs  []PacketConnConfig
 	listenerConfigs    []ListenerConfig
@@ -53,6 +52,11 @@ func NewServer(config ServerConfig) (*Server, error) {
 		mtu = config.InboundMTU
 	}
 
+	nonceHash, err := server.NewNonceHash()
+	if err != nil {
+		return nil, err
+	}
+
 	s := &Server{
 		log:                loggerFactory.NewLogger("turn"),
 		authHandler:        config.AuthHandler,
@@ -60,7 +64,7 @@ func NewServer(config ServerConfig) (*Server, error) {
 		channelBindTimeout: config.ChannelBindTimeout,
 		packetConnConfigs:  config.PacketConnConfigs,
 		listenerConfigs:    config.ListenerConfigs,
-		nonces:             &sync.Map{},
+		nonceHash:          nonceHash,
 		inboundMTU:         mtu,
 	}
 
@@ -205,7 +209,7 @@ func (s *Server) readLoop(p net.PacketConn, allocationManager *allocation.Manage
 			Realm:              s.realm,
 			AllocationManager:  allocationManager,
 			ChannelBindTimeout: s.channelBindTimeout,
-			Nonces:             s.nonces,
+			NonceHash:          s.nonceHash,
 		}); err != nil {
 			s.log.Errorf("Failed to handle datagram: %v", err)
 		}


### PR DESCRIPTION
#### Description
implements nonce generation using the method from chromium (https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/p2p/base/turn_server.cc;l=385;drc=8e78783dc1f7007bad46d657c9f332614e240fd8?q=turn_server.cc). create a random hmac and use it to hash the timestamp of the authentication request. validate by checking the hash and time elapsed since the nonce was generated.

#### Reference issue
Fixes #361 
