### PR TITLE
Return errFake in mockClient used for tests

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -26,7 +26,7 @@ func (c *mockClient) PerformTransaction(msg *stun.Message, to net.Addr, dontWait
 	if c.performTransaction != nil {
 		return c.performTransaction(msg, to, dontWait)
 	}
-	return TransactionResult{}, nil
+	return TransactionResult{}, errFake
 }
 
 func (c *mockClient) OnDeallocated(relayedAddr net.Addr) {


### PR DESCRIPTION
If the test runs long enough then the RTX timer will send a Transaction and return a empty TransactionResult + nil err resulted in a crash