### PR TITLE
Support stand alone STUN server mode

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,4 +28,5 @@ var (
 	errNonSTUNMessage                = errors.New("non-STUN message from STUN server")
 	errFailedToDecodeSTUN            = errors.New("failed to decode STUN message")
 	errUnexpectedSTUNRequestMessage  = errors.New("unexpected STUN request message")
+	errRelayAddressGeneratorNil      = errors.New("RelayAddressGenerator is nil")
 )

--- a/examples/stun-only-server/main.go
+++ b/examples/stun-only-server/main.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package main implements a simple TURN server
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/pion/turn/v3"
+)
+
+func main() {
+	publicIP := flag.String("public-ip", "", "IP Address that STUN can be contacted by.")
+	port := flag.Int("port", 3478, "Listening port.")
+	flag.Parse()
+
+	if len(*publicIP) == 0 {
+		log.Fatalf("'public-ip' is required")
+	}
+
+	// Create a UDP listener to pass into pion/turn
+	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
+	// this allows us to add logging, storage or modify inbound/outbound traffic
+	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port))
+	if err != nil {
+		log.Panicf("Failed to create STUN server listener: %s", err)
+	}
+
+	s, err := turn.NewServer(turn.ServerConfig{
+		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
+		PacketConnConfigs: []turn.PacketConnConfig{
+			{
+				PacketConn: udpListener,
+			},
+		},
+	})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Block until user sends SIGINT or SIGTERM
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	if err = s.Close(); err != nil {
+		log.Panic(err)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -167,9 +167,24 @@ func (s *Server) readListener(l net.Listener, am *allocation.Manager) {
 	}
 }
 
+type nilAddressGenerator struct{}
+
+func (n *nilAddressGenerator) Validate() error { return errRelayAddressGeneratorNil }
+
+func (n *nilAddressGenerator) AllocatePacketConn(string, int) (net.PacketConn, net.Addr, error) {
+	return nil, nil, errRelayAddressGeneratorNil
+}
+
+func (n *nilAddressGenerator) AllocateConn(string, int) (net.Conn, net.Addr, error) {
+	return nil, nil, errRelayAddressGeneratorNil
+}
+
 func (s *Server) createAllocationManager(addrGenerator RelayAddressGenerator, handler PermissionHandler) (*allocation.Manager, error) {
 	if handler == nil {
 		handler = DefaultPermissionHandler
+	}
+	if addrGenerator == nil {
+		addrGenerator = &nilAddressGenerator{}
 	}
 
 	am, err := allocation.NewManager(allocation.ManagerConfig{

--- a/server_config.go
+++ b/server_config.go
@@ -57,11 +57,14 @@ func (c *PacketConnConfig) validate() error {
 	if c.PacketConn == nil {
 		return errConnUnset
 	}
-	if c.RelayAddressGenerator == nil {
-		return errRelayAddressGeneratorUnset
+
+	if c.RelayAddressGenerator != nil {
+		if err := c.RelayAddressGenerator.Validate(); err != nil {
+			return err
+		}
 	}
 
-	return c.RelayAddressGenerator.Validate()
+	return nil
 }
 
 // ListenerConfig is a single net.Listener to accept connections on. This will be used for TCP, TLS and DTLS listeners


### PR DESCRIPTION
Running in stand alone STUN server does not start
due to packet conn config requiring relay address config during validation.

To enable that mode, bypass validation if relay address config in packet conn config is nil.

Note that it is still validated in `ListenerConfig`.
