### PR TITLE
Remove pessimistic String calls for low level logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -425,7 +425,7 @@ func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult
 
 	c.trMap.Insert(trKey, tr)
 
-	c.log.Tracef("Start %s transaction %s to %s", msg.Type, trKey, tr.To.String())
+	c.log.Tracef("Start %s transaction %s to %s", msg.Type, trKey, tr.To)
 	_, err := c.conn.WriteTo(tr.Raw, to)
 	if err != nil {
 		return client.TransactionResult{}, err
@@ -524,7 +524,7 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error {
 				return err
 			}
 
-			c.log.Tracef("Data indication received from %s", from.String())
+			c.log.Tracef("Data indication received from %s", from)
 
 			relayedConn := c.relayedUDPConn()
 			if relayedConn == nil {
@@ -548,7 +548,7 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error {
 				return err
 			}
 
-			c.log.Debugf("Connection attempt from %s", addr.String())
+			c.log.Debugf("Connection attempt from %s", addr)
 
 			allocation := c.getTCPAllocation()
 			if allocation == nil {
@@ -575,7 +575,7 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error {
 	if !ok {
 		c.mutexTrMap.Unlock()
 		// Silently discard
-		c.log.Debugf("No transaction for %s", msg.String())
+		c.log.Debugf("No transaction for %s", msg)
 		return nil
 	}
 
@@ -589,7 +589,7 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error {
 		From:    from,
 		Retries: tr.Retries(),
 	}) {
-		c.log.Debugf("No listener for %s", msg.String())
+		c.log.Debugf("No listener for %s", msg)
 	}
 
 	return nil

--- a/client_test.go
+++ b/client_test.go
@@ -67,7 +67,7 @@ func TestClientWithSTUN(t *testing.T) {
 
 		resp, err := c.SendBindingRequest()
 		assert.NoError(t, err, "should succeed")
-		log.Debugf("mapped-addr: %s", resp.String())
+		log.Debugf("mapped-addr: %s", resp)
 		assert.Equal(t, 0, c.trMap.Size(), "should be no transaction left")
 		assert.NoError(t, pc.Close())
 	})

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -244,9 +244,9 @@ func (a *Allocation) packetHandler(m *Manager) {
 		}
 
 		a.log.Debugf("Relay socket %s received %d bytes from %s",
-			a.RelaySocket.LocalAddr().String(),
+			a.RelaySocket.LocalAddr(),
 			n,
-			srcAddr.String())
+			srcAddr)
 
 		if channel := a.GetChannelByAddr(srcAddr); channel != nil {
 			channelData := &proto.ChannelData{
@@ -274,13 +274,13 @@ func (a *Allocation) packetHandler(m *Manager) {
 				return
 			}
 			a.log.Debugf("Relaying message from %s to client at %s",
-				srcAddr.String(),
-				a.fiveTuple.SrcAddr.String())
+				srcAddr,
+				a.fiveTuple.SrcAddr)
 			if _, err = a.TurnSocket.WriteTo(msg.Raw, a.fiveTuple.SrcAddr); err != nil {
 				a.log.Errorf("Failed to send DataIndication from allocation %v %v", srcAddr, err)
 			}
 		} else {
-			a.log.Infof("No Permission or Channel exists for %v on allocation %v", srcAddr, a.RelayAddr.String())
+			a.log.Infof("No Permission or Channel exists for %v on allocation %v", srcAddr, a.RelayAddr)
 		}
 	}
 }

--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -113,7 +113,7 @@ func (m *Manager) CreateAllocation(fiveTuple *FiveTuple, turnSocket net.PacketCo
 	a.RelaySocket = conn
 	a.RelayAddr = relayAddr
 
-	m.log.Debugf("Listening on relay address: %s", a.RelayAddr.String())
+	m.log.Debugf("Listening on relay address: %s", a.RelayAddr)
 
 	a.lifetimeTimer = time.AfterFunc(lifetime, func() {
 		m.DeleteAllocation(a.fiveTuple)

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -435,7 +435,7 @@ func (c *UDPConn) bind(b *binding) error {
 		return fmt.Errorf("unexpected response type %s", res.Type) //nolint:goerr113
 	}
 
-	c.log.Debugf("Channel binding successful: %s %d", b.addr.String(), b.number)
+	c.log.Debugf("Channel binding successful: %s %d", b.addr, b.number)
 
 	// Success.
 	return nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,7 +35,7 @@ type Request struct {
 
 // HandleRequest processes the give Request
 func HandleRequest(r Request) error {
-	r.Log.Debugf("Received %d bytes of udp from %s on %s", len(r.Buff), r.SrcAddr.String(), r.Conn.LocalAddr().String())
+	r.Log.Debugf("Received %d bytes of udp from %s on %s", len(r.Buff), r.SrcAddr, r.Conn.LocalAddr())
 
 	if proto.IsChannelData(r.Buff) {
 		return handleDataPacket(r)

--- a/internal/server/stun.go
+++ b/internal/server/stun.go
@@ -9,7 +9,7 @@ import (
 )
 
 func handleBindingRequest(r Request, m *stun.Message) error {
-	r.Log.Debugf("Received BindingRequest from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received BindingRequest from %s", r.SrcAddr)
 
 	ip, port, err := ipnet.AddrIPPort(r.SrcAddr)
 	if err != nil {

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -18,7 +18,7 @@ const runesAlpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // See: https://tools.ietf.org/html/rfc5766#section-6.2
 func handleAllocateRequest(r Request, m *stun.Message) error {
-	r.Log.Debugf("Received AllocateRequest from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received AllocateRequest from %s", r.SrcAddr)
 
 	// 1. The server MUST require that the request be authenticated.  This
 	//    authentication MUST be done using the long-term credential
@@ -183,7 +183,7 @@ func handleAllocateRequest(r Request, m *stun.Message) error {
 }
 
 func handleRefreshRequest(r Request, m *stun.Message) error {
-	r.Log.Debugf("Received RefreshRequest from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received RefreshRequest from %s", r.SrcAddr)
 
 	messageIntegrity, hasAuth, err := authenticateRequest(r, m, stun.MethodRefresh)
 	if !hasAuth {
@@ -217,7 +217,7 @@ func handleRefreshRequest(r Request, m *stun.Message) error {
 }
 
 func handleCreatePermissionRequest(r Request, m *stun.Message) error {
-	r.Log.Debugf("Received CreatePermission from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received CreatePermission from %s", r.SrcAddr)
 
 	a := r.AllocationManager.GetAllocation(&allocation.FiveTuple{
 		SrcAddr:  r.SrcAddr,
@@ -242,13 +242,12 @@ func handleCreatePermissionRequest(r Request, m *stun.Message) error {
 		}
 
 		if err := r.AllocationManager.GrantPermission(r.SrcAddr, peerAddress.IP); err != nil {
-			r.Log.Infof("permission denied for client %s to peer %s", r.SrcAddr.String(),
-				peerAddress.IP.String())
+			r.Log.Infof("permission denied for client %s to peer %s", r.SrcAddr, peerAddress.IP)
 			return err
 		}
 
 		r.Log.Debugf("Adding permission for %s", fmt.Sprintf("%s:%d",
-			peerAddress.IP.String(), peerAddress.Port))
+			peerAddress.IP, peerAddress.Port))
 
 		a.AddPermission(allocation.NewPermission(
 			&net.UDPAddr{
@@ -272,7 +271,7 @@ func handleCreatePermissionRequest(r Request, m *stun.Message) error {
 }
 
 func handleSendIndication(r Request, m *stun.Message) error {
-	r.Log.Debugf("Received SendIndication from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received SendIndication from %s", r.SrcAddr)
 	a := r.AllocationManager.GetAllocation(&allocation.FiveTuple{
 		SrcAddr:  r.SrcAddr,
 		DstAddr:  r.Conn.LocalAddr(),
@@ -305,7 +304,7 @@ func handleSendIndication(r Request, m *stun.Message) error {
 }
 
 func handleChannelBindRequest(r Request, m *stun.Message) error {
-	r.Log.Debugf("Received ChannelBindRequest from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received ChannelBindRequest from %s", r.SrcAddr)
 
 	a := r.AllocationManager.GetAllocation(&allocation.FiveTuple{
 		SrcAddr:  r.SrcAddr,
@@ -334,8 +333,7 @@ func handleChannelBindRequest(r Request, m *stun.Message) error {
 	}
 
 	if err = r.AllocationManager.GrantPermission(r.SrcAddr, peerAddr.IP); err != nil {
-		r.Log.Infof("permission denied for client %s to peer %s", r.SrcAddr.String(),
-			peerAddr.IP.String())
+		r.Log.Infof("permission denied for client %s to peer %s", r.SrcAddr, peerAddr.IP)
 
 		unauthorizedRequestMsg := buildMsg(m.TransactionID,
 			stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
@@ -343,9 +341,7 @@ func handleChannelBindRequest(r Request, m *stun.Message) error {
 		return buildAndSendErr(r.Conn, r.SrcAddr, err, unauthorizedRequestMsg...)
 	}
 
-	r.Log.Debugf("Binding channel %d to %s",
-		channel,
-		fmt.Sprintf("%s:%d", peerAddr.IP.String(), peerAddr.Port))
+	r.Log.Debugf("Binding channel %d to %s", channel, peerAddr)
 	err = a.AddChannelBind(allocation.NewChannelBind(
 		channel,
 		&net.UDPAddr{IP: peerAddr.IP, Port: peerAddr.Port},
@@ -359,7 +355,7 @@ func handleChannelBindRequest(r Request, m *stun.Message) error {
 }
 
 func handleChannelData(r Request, c *proto.ChannelData) error {
-	r.Log.Debugf("Received ChannelData from %s", r.SrcAddr.String())
+	r.Log.Debugf("Received ChannelData from %s", r.SrcAddr)
 
 	a := r.AllocationManager.GetAllocation(&allocation.FiveTuple{
 		SrcAddr:  r.SrcAddr,

--- a/server_test.go
+++ b/server_test.go
@@ -536,7 +536,7 @@ func TestServerVNet(t *testing.T) {
 		log.Debug("sending a binding request.")
 		reflAddr, err := client.SendBindingRequest()
 		assert.NoError(t, err)
-		log.Debugf("mapped-address: %v", reflAddr.String())
+		log.Debugf("mapped-address: %s", reflAddr)
 		udpAddr, ok := reflAddr.(*net.UDPAddr)
 		assert.True(t, ok)
 


### PR DESCRIPTION
there is no need to manually stringify types that implement `fmt.Stringer`. if the log line is printed the formatter for `%s` will do this.