### PR TITLE
Fix: tcp-alloc example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -65,7 +65,9 @@ This mechanism is described in https://datatracker.ietf.org/doc/html/draft-ubert
 This example demonstrates the use of a permission handler in the PION TURN server. The example implements a filtering policy that lets clients to connect back to their own host or server-reflexive address but will drop everything else. This will let the client ping-test through but will block essentially all other peer connection attempts.
 
 ## turn-client
-The `turn-client` directory contains 2 examples that show common Pion TURN usages. All of these examples take the following arguments.
+The `turn-client` directory contains 3 examples that show common Pion TURN usages. 
+
+All of these examples except `tcp-alloc` take the following arguments.
 
 * -host      : TURN server host
 * -ping      : Run ping test
@@ -126,3 +128,41 @@ Following diagram shows what turn-client does:
 > mappedAddr and the external IP:port (*3) are the same) This process is known as
 > "UDP hole punching" and TURN server exhibits "Address-restricted" behavior. Once it is done,
 > packets coming from (*3) will be received by relayConn.
+
+
+#### tcp-alloc
+The `tcp-alloc` exemplifies how to create client TCP allocations and use them to exchange messages between peers. It simulates two clients and creates a TCP allocation for each. Then, both clients exchange their relayed addresses with each other through a signaling server. Finally, each client uses its TCP allocation and the relayed address of the other client to send and receive a single message.
+
+The `tcp-alloc` takes the following arguments:
+
+* -host      : TURN server host
+* -port      : Listening port (defaults to 3478)
+* -user      : &lt;username&gt;=&lt;password&gt; pair
+* -realm     : Realm name (defaults to "pion.ly")
+* -signaling : Run the signaling server
+
+
+To run the example:
+
+1) Start one client and the signaling server used to exchange the relayed addresses:
+
+```sh
+go build
+./tcp-alloc -host <turn-server-name> -port <port> -user=<username=password> -signaling=true
+```
+
+2) Start the other client without starting the signaling server:
+
+```sh
+./tcp-alloc -host <turn-server-name> -port <port> -user=<username=password> -signaling=false
+```
+
+A Coturn TURN server can be locally deployed and used for testing with the following command (this is a test configuration of the Coturn TURN server and should not be used for production):
+
+```sh
+/bin/turnserver -lt-cred-mech -u <username:password> -r pion.ly --allow-loopback-peers --cli-password=<clipassword>
+```
+
+>If using this Coturn TURN server deployment: 
+>* turn-server-name      : 127.0.0.1
+>* port                  : 3478

--- a/internal/client/tcp_alloc.go
+++ b/internal/client/tcp_alloc.go
@@ -151,6 +151,11 @@ func (a *TCPAllocation) DialTCP(network string, lAddr, rAddr *net.TCPAddr) (*TCP
 			IP:   addr.IP,
 			Port: addr.Port,
 		}
+	} else if addr, ok := a.serverAddr.(*net.UDPAddr); ok {
+		rAddrServer = &net.TCPAddr{
+			IP:   addr.IP,
+			Port: addr.Port,
+		}
 	} else {
 		return nil, errInvalidTURNAddress
 	}


### PR DESCRIPTION
#### Description
Hello! 

While trying out the tcp-alloc example in the turn-client examples folder, I came across an unexpected error:

`panic: Failed to dial: invalid TURN server address `

I documented this behavior in issue #391.

The error originated from line 151 of the example (`conn, err := allocation.DialTCP("tcp", nil, peerAddr)`). Inside the function DialTCP(), there is the following block of code:

```
if addr, ok := a.serverAddr.(*net.TCPAddr); ok {
	rAddrServer = &net.TCPAddr{
		IP:   addr.IP,
		Port: addr.Port,
	}
} else {
	return nil, errInvalidTURNAddress
}
```
The problem stems from the fact that `a.serverAddr` is of type `*net.UDPAddr` and not `*net.TCPAddr`, even though we are making a TCP allocation. Upon further examination of the code, we can verify that when creating a client with the function `NewClient(config *ClientConfig)`, the TURN server address is always resolved as a UDP address, from what I understand.

(client.go lines 104-134, `NewClient(config *ClientConfig)`)

```
if len(config.STUNServerAddr) > 0 {
	stunServ, err = config.Net.ResolveUDPAddr("udp4", config.STUNServerAddr)
	if err != nil {
			return nil, err
	}

	log.Debugf("Resolved STUN server %s to %s", config.STUNServerAddr, stunServ)
}

if len(config.TURNServerAddr) > 0 {
	turnServ, err = config.Net.ResolveUDPAddr("udp4", config.TURNServerAddr)
	if err != nil {
		return nil, err
	}

	log.Debugf("Resolved TURN server %s to %s", config.TURNServerAddr, turnServ)
}

c := &Client{
		conn:           config.Conn,
		stunServerAddr: stunServ,
		turnServerAddr: turnServ,
		username:       stun.NewUsername(config.Username),
		password:       config.Password,
		realm:          stun.NewRealm(config.Realm),
		software:       stun.NewSoftware(config.Software),
		trMap:          client.NewTransactionMap(),
		net:            config.Net,
		rto:            rto,
		log:            log,
}
```
Then, the turnServerAddr is used as the value for the ServerAddr of the TCP allocation (see below) when the function `AllocateTCP()` is called.

(file client.go, lines 353-390)

```
func (c *Client) AllocateTCP() (*client.TCPAllocation, error) {
	if err := c.allocTryLock.Lock(); err != nil {
		return nil, fmt.Errorf("%w: %s", errOneAllocateOnly, err.Error())
	}
	defer c.allocTryLock.Unlock()

	allocation := c.getTCPAllocation()
	if allocation != nil {
		return nil, fmt.Errorf("%w: %s", errAlreadyAllocated, allocation.Addr())
	}

	relayed, lifetime, nonce, err := c.sendAllocateRequest(proto.ProtoTCP)
	if err != nil {
		return nil, err
	}

	relayedAddr := &net.TCPAddr{
		IP:   relayed.IP,
		Port: relayed.Port,
	}

	allocation = client.NewTCPAllocation(&client.AllocationConfig{
		Client:      c,
		RelayedAddr: relayedAddr,
		ServerAddr:  c.turnServerAddr,
		Realm:       c.realm,
		Username:    c.username,
		Integrity:   c.integrity,
		Nonce:       nonce,
		Lifetime:    lifetime.Duration,
		Net:         c.net,
		Log:         c.log,
	})

	c.setTCPAllocation(allocation)

	return allocation, nil
}
```

This means the `ServerAddr` is of type `(*net.UDPAddr)` and not ` (*net.TCPAddr)`. For now, a simple solution is just to add the following code to the DialTCP function: 

```
if addr, ok := a.serverAddr.(*net.TCPAddr); ok {
	rAddrServer = &net.TCPAddr{
		IP:   addr.IP,
		Port: addr.Port,
	}
} else if addr, ok := a.serverAddr.(*net.UDPAddr); ok {
	rAddrServer = &net.TCPAddr{
		IP:   addr.IP,
		Port: addr.Port,
	}
} else {
	return nil, errInvalidTURNAddress
}
```
I added this and included some documentation about the tcp-alloc in the README of the examples, as there was none.

Thank you for reading! As this is my first PR, any feedback or corrections are more than welcome.

#### Reference issue
#391