### PR TITLE
Add callback for TURN authentication success

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,6 +28,7 @@ type Request struct {
 
 	// User Configuration
 	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+	AuthSuccess        func(username string, realm string, srcAddr net.Addr)
 	Log                logging.LeveledLogger
 	Realm              string
 	ChannelBindTimeout time.Duration

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -97,6 +97,10 @@ func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) 
 		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
 	}
 
+	if r.AuthSuccess != nil {
+		r.AuthSuccess(usernameAttr.String(), realmAttr.String(), r.SrcAddr)
+	}
+
 	return stun.MessageIntegrity(ourKey), true, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ const (
 type Server struct {
 	log                logging.LeveledLogger
 	authHandler        AuthHandler
+	authSuccess        AuthCallback
 	realm              string
 	channelBindTimeout time.Duration
 	nonceHash          *server.NonceHash
@@ -60,6 +61,7 @@ func NewServer(config ServerConfig) (*Server, error) {
 	s := &Server{
 		log:                loggerFactory.NewLogger("turn"),
 		authHandler:        config.AuthHandler,
+		authSuccess:        config.AuthSuccess,
 		realm:              config.Realm,
 		channelBindTimeout: config.ChannelBindTimeout,
 		packetConnConfigs:  config.PacketConnConfigs,
@@ -221,6 +223,7 @@ func (s *Server) readLoop(p net.PacketConn, allocationManager *allocation.Manage
 			Buff:               buf[:n],
 			Log:                s.log,
 			AuthHandler:        s.authHandler,
+			AuthSuccess:        s.authSuccess,
 			Realm:              s.realm,
 			AllocationManager:  allocationManager,
 			ChannelBindTimeout: s.channelBindTimeout,

--- a/server_config.go
+++ b/server_config.go
@@ -96,6 +96,9 @@ func (c *ListenerConfig) validate() error {
 // AuthHandler is a callback used to handle incoming auth requests, allowing users to customize Pion TURN with custom behavior
 type AuthHandler func(username, realm string, srcAddr net.Addr) (key []byte, ok bool)
 
+// AuthCallback is a callback used to inform users about the success of authentication events to the server
+type AuthCallback func(username, realm string, srcAddr net.Addr)
+
 // GenerateAuthKey is a convenience function to easily generate keys in the format used by AuthHandler
 func GenerateAuthKey(username, realm, password string) []byte {
 	// #nosec
@@ -119,6 +122,9 @@ type ServerConfig struct {
 
 	// AuthHandler is a callback used to handle incoming auth requests, allowing users to customize Pion TURN with custom behavior
 	AuthHandler AuthHandler
+
+	// AuthCallback is a callback used to notify users of successful authentication to the TURN server
+	AuthSuccess AuthCallback
 
 	// ChannelBindTimeout sets the lifetime of channel binding. Defaults to 10 minutes.
 	ChannelBindTimeout time.Duration


### PR DESCRIPTION
#### Description

Creates a new callback for users to be notified by successful TURN authentication. Together with the authHandler function, this can help determine the ratio of successful vs unsuccessful authentication attemps per username. This information then can be used to implement methods to prevent attacks to guess credentials similar to fail2ban.

There's been some discussion around implementing various usage quotas and limits within this package. An auth success callback can be used to implement some of these given that a succesful source IP address can be reliably linked to usernames. Together with maximum allocation time limit and permission timeouts per RFC, allocation refesh requests (requires auth) and configurable channel bind timeouts, fivetuple -> username usage can be reliably tracked outside of this package.
