### PR TITLE
Add callback API to track allocation lifeycle

### DIFF
--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -52,15 +52,15 @@ func subTestCreateInvalidAllocation(t *testing.T, turnSocket net.PacketConn) {
 	m, err := newTestManager()
 	assert.NoError(t, err)
 
-	a, err := m.CreateAllocation(nil, turnSocket, 0, proto.DefaultLifetime)
+	a, err := m.CreateAllocation(nil, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.Nil(t, a, "Illegally created allocation with nil FiveTuple")
 	assert.Error(t, err, "Illegally created allocation with nil FiveTuple")
 
-	a, err = m.CreateAllocation(randomFiveTuple(), nil, 0, proto.DefaultLifetime)
+	a, err = m.CreateAllocation(randomFiveTuple(), nil, 0, proto.DefaultLifetime, "", "")
 	assert.Nil(t, a, "Illegally created allocation with nil turnSocket")
 	assert.Error(t, err, "Illegally created allocation with nil turnSocket")
 
-	a, err = m.CreateAllocation(randomFiveTuple(), turnSocket, 0, 0)
+	a, err = m.CreateAllocation(randomFiveTuple(), turnSocket, 0, 0, "", "")
 	assert.Nil(t, a, "Illegally created allocation with 0 lifetime")
 	assert.Error(t, err, "Illegally created allocation with 0 lifetime")
 }
@@ -73,7 +73,7 @@ func subTestCreateAllocation(t *testing.T, turnSocket net.PacketConn) {
 	assert.NoError(t, err)
 
 	fiveTuple := randomFiveTuple()
-	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.NotNil(t, a, "Failed to create allocation")
 	assert.NoError(t, err, "Failed to create allocation")
 
@@ -89,11 +89,11 @@ func subTestCreateAllocationDuplicateFiveTuple(t *testing.T, turnSocket net.Pack
 	assert.NoError(t, err)
 
 	fiveTuple := randomFiveTuple()
-	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.NotNil(t, a, "Failed to create allocation")
 	assert.NoError(t, err, "Failed to create allocation")
 
-	a, err = m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err = m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.Nil(t, a, "Was able to create allocation with same FiveTuple twice")
 	assert.Error(t, err, "Was able to create allocation with same FiveTuple twice")
 }
@@ -105,7 +105,7 @@ func subTestDeleteAllocation(t *testing.T, turnSocket net.PacketConn) {
 	assert.NoError(t, err)
 
 	fiveTuple := randomFiveTuple()
-	a, err := manager.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err := manager.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.NotNil(t, a, "Failed to create allocation")
 	assert.NoError(t, err, "Failed to create allocation")
 
@@ -130,7 +130,7 @@ func subTestAllocationTimeout(t *testing.T, turnSocket net.PacketConn) {
 	for index := range allocations {
 		fiveTuple := randomFiveTuple()
 
-		a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, lifetime)
+		a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, lifetime, "", "")
 		assert.NoErrorf(t, err, "Failed to create allocation with %v", fiveTuple)
 
 		allocations[index] = a
@@ -152,9 +152,9 @@ func subTestManagerClose(t *testing.T, turnSocket net.PacketConn) {
 
 	allocations := make([]*Allocation, 2)
 
-	a1, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Second)
+	a1, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Second, "", "")
 	allocations[0] = a1
-	a2, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Minute)
+	a2, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Minute, "", "")
 	allocations[1] = a2
 
 	// Make a1 timeout

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -48,7 +48,7 @@ func TestAllocation(t *testing.T) {
 func subTestGetPermission(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func subTestGetPermission(t *testing.T) {
 func subTestAddPermission(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -105,7 +105,7 @@ func subTestAddPermission(t *testing.T) {
 func subTestRemovePermission(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -128,7 +128,7 @@ func subTestRemovePermission(t *testing.T) {
 func subTestAddChannelBind(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -152,7 +152,7 @@ func subTestAddChannelBind(t *testing.T) {
 func subTestGetChannelByNumber(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -171,7 +171,7 @@ func subTestGetChannelByNumber(t *testing.T) {
 func subTestGetChannelByAddr(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -191,7 +191,7 @@ func subTestGetChannelByAddr(t *testing.T) {
 func subTestRemoveChannelBind(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -212,7 +212,7 @@ func subTestRemoveChannelBind(t *testing.T) {
 func subTestAllocationRefresh(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -234,7 +234,7 @@ func subTestAllocationClose(t *testing.T) {
 	l, err := net.ListenPacket(network, "0.0.0.0:0")
 	assert.NoError(t, err)
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 	alloc.RelaySocket = l
 	// Add mock lifetimeTimer
 	alloc.lifetimeTimer = time.AfterFunc(proto.DefaultLifetime, func() {})
@@ -285,7 +285,7 @@ func subTestPacketHandler(t *testing.T) {
 	alloc, err := manager.CreateAllocation(&FiveTuple{
 		SrcAddr: clientListener.LocalAddr(),
 		DstAddr: turnSocket.LocalAddr(),
-	}, turnSocket, 0, proto.DefaultLifetime)
+	}, turnSocket, 0, proto.DefaultLifetime, "", "")
 
 	assert.NoError(t, err, "should succeed")
 
@@ -345,16 +345,16 @@ func subTestPacketHandler(t *testing.T) {
 func subTestResponseCache(t *testing.T) {
 	t.Helper()
 
-	a := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 	transactionID := [stun.TransactionIDSize]byte{1, 2, 3}
 	responseAttrs := []stun.Setter{
 		&proto.Lifetime{
 			Duration: proto.DefaultLifetime,
 		},
 	}
-	a.SetResponseCache(transactionID, responseAttrs)
+	alloc.SetResponseCache(transactionID, responseAttrs)
 
-	cacheID, cacheAttr := a.GetResponseCache()
+	cacheID, cacheAttr := alloc.GetResponseCache()
 	assert.Equal(t, transactionID, cacheID)
 	assert.Equal(t, responseAttrs, cacheAttr)
 }

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -37,7 +37,7 @@ func TestChannelBindReset(t *testing.T) {
 }
 
 func newChannelBind(lifetime time.Duration) *ChannelBind {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, _ := net.ResolveUDPAddr("udp", "0.0.0.0:0")
 	c := &ChannelBind{

--- a/internal/allocation/event_handler.go
+++ b/internal/allocation/event_handler.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package allocation
+
+import (
+	"net"
+)
+
+// EventHandler is a set of callbacks that the server will call at certain hook points during an
+// allocation's lifecycle. All events are reported with the context that identifies the allocation
+// triggering the event (source and destination address, protocol, username and realm used for
+// authenticating the allocation), plus additional callback specific parameters. It is OK to handle
+// only a subset of the callbacks.
+type EventHandler struct {
+	// OnAuth is called after an authentication request has been processed with the TURN method
+	// triggering the authentication request (either "Allocate", "Refresh" "CreatePermission",
+	// or "ChannelBind"), and the verdict is the authentication result.
+	OnAuth func(srcAddr, dstAddr net.Addr, protocol, username, realm string, method string, verdict bool)
+	// OnAllocationCreated is called after a new allocation has been made. The relayAddr
+	// argument specifies the relay address and requestedPort is the port requested by the
+	// client (if any).
+	OnAllocationCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr net.Addr, requestedPort int)
+	// OnAllocationDeleted is called after an allocation has been removed.
+	OnAllocationDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string)
+	// OnAllocationError is called when the readloop hdndling an allocation exits with an
+	// error with an error message.
+	OnAllocationError func(srcAddr, dstAddr net.Addr, protocol, message string)
+	// OnPermissionCreated is called after a new permission has been made to an IP address.
+	OnPermissionCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr net.Addr, peer net.IP)
+	// OnPermissionDeleted is called after a permission for a given IP address has been
+	// removed.
+	OnPermissionDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr net.Addr, peer net.IP)
+	// OnChannelCreated is called after a new channel has been made. The relay address, the
+	// peer address and the channel number can be used to uniquely identify the channel
+	// created.
+	OnChannelCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr, peer net.Addr, channelNumber uint16)
+	// OnChannelDeleted is called after a channel has been removed from the server. The relay
+	// address, the peer address and the channel number can be used to uniquely identify the
+	// channel deleted.
+	OnChannelDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr, peer net.Addr, channelNumber uint16)
+}

--- a/internal/allocation/five_tuple.go
+++ b/internal/allocation/five_tuple.go
@@ -16,6 +16,17 @@ const (
 	TCP
 )
 
+func (p Protocol) String() string {
+	switch p {
+	case UDP:
+		return "UDP"
+	case TCP:
+		return "TCP"
+	default:
+		return ""
+	}
+}
+
 // FiveTuple is the combination (client IP address and port, server IP
 // address and port, and transport protocol (currently one of UDP,
 // TCP, or TLS)) used to communicate between the client and the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,7 +27,8 @@ type Request struct {
 	NonceHash         *NonceHash
 
 	// User Configuration
-	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+	AuthHandler func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+
 	Log                logging.LeveledLogger
 	Realm              string
 	ChannelBindTimeout time.Duration

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -145,6 +145,12 @@ func handleAllocateRequest(req Request, stunMsg *stun.Message) error { //nolint:
 		}
 	}
 
+	// Parse realm and username (already checked in authenticateRequest)
+	realmAttr := &stun.Realm{}
+	_ = realmAttr.GetFrom(stunMsg)
+	usernameAttr := &stun.Username{}
+	_ = usernameAttr.GetFrom(stunMsg)
+
 	// 7. At any point, the server MAY choose to reject the request with a
 	//    486 (Allocation Quota Reached) error if it feels the client is
 	//    trying to exceed some locally defined allocation quota.  The
@@ -161,7 +167,10 @@ func handleAllocateRequest(req Request, stunMsg *stun.Message) error { //nolint:
 		fiveTuple,
 		req.Conn,
 		requestedPort,
-		lifetimeDuration)
+		lifetimeDuration,
+		usernameAttr.String(),
+		realmAttr.String(),
+	)
 	if err != nil {
 		return buildAndSendErr(req.Conn, req.SrcAddr, err, insufficientCapacityMsg...)
 	}

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -91,7 +91,7 @@ func TestAllocationLifeTime(t *testing.T) {
 
 		fiveTuple := &allocation.FiveTuple{SrcAddr: req.SrcAddr, DstAddr: req.Conn.LocalAddr(), Protocol: allocation.UDP}
 
-		_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, 0, time.Hour)
+		_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, 0, time.Hour, "", "")
 		assert.NoError(t, err)
 
 		assert.NotNil(t, req.AllocationManager.GetAllocation(fiveTuple))

--- a/server_config.go
+++ b/server_config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/pion/turn/v4/internal/allocation"
 )
 
 // RelayAddressGenerator is used to generate a RelayAddress when creating an allocation.
@@ -108,6 +109,10 @@ func GenerateAuthKey(username, realm, password string) []byte {
 	return h.Sum(nil)
 }
 
+// EventHandler is a set of callbacks that the server will call at certain hook points during an
+// allocation's lifecycle.
+type EventHandler = allocation.EventHandler
+
 // ServerConfig configures the Pion TURN Server.
 type ServerConfig struct {
 	// PacketConnConfigs and ListenerConfigs are a list of all the turn listeners
@@ -124,6 +129,9 @@ type ServerConfig struct {
 	// AuthHandler is a callback used to handle incoming auth requests,
 	// allowing users to customize Pion TURN with custom behavior
 	AuthHandler AuthHandler
+
+	// EventHandlers is a set of callbacks for tracking allocation lifecycle.
+	EventHandler EventHandler
 
 	// ChannelBindTimeout sets the lifetime of channel binding. Defaults to 10 minutes.
 	ChannelBindTimeout time.Duration


### PR DESCRIPTION
Fixes https://github.com/pion/turn/issues/324, https://github.com/pion/turn/pull/325, and https://github.com/pion/turn/pull/402

This PR adds a set of callbacks that can be used to track the lifecycle of TURN allocations in the server. This allows user code to be called whenever an authentication request has been processed (this can be used to mitigate DoS attacks against a server, see https://github.com/pion/turn/pull/402), when an allocation has been created/removed (e.g., to implement user tracking for adding quota support, see https://github.com/pion/turn/issues/324), when a permission has been created/removed (e.g., to log the peers a user tries to reach via the server), a channel has been created/removed (this will simplify integrating external TURN accelerators, see https://github.com/pion/turn/pull/360), or when an allocation ends with an error.

The implementation adds a new `EventHandlers` struct to the `ServerConfig`, defined as follows:

```
type EventHandlers struct {
  OnAuth func(srcAddr, dstAddr net.Addr, protocol, username, realm string, method string, verdict bool)
  OnAllocationCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string, requestedPort int)
  OnAllocationDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string)
  OnAllocationError func(srcAddr, dstAddr net.Addr, protocol, message string)
  OnPermissionCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string, peer net.IP)
  OnPermissionDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string, peer net.IP)
  OnChannelCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string, peer net.Addr, channelNumber uint16)
  OnChannelDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string, peer net.Addr, channelNumber uint16)
}
```

It is OK to handle only a subset of the events.

Caveats:
- Event handlers are called synchronously, so long-running callbacks will block the server.
- Theoretically, allocations are allowed to change credentials during their lifetime, in that any `Refresh`, `CreatePermission` or `ChannelBind` message may use a different credential. Since this does not seem to be easy to implement with the `PeerConnection` API, credential swaps are currently no tracked.