### PR TITLE
User-aware relay address generator

### DIFF
--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -28,6 +28,7 @@ type Allocation struct {
 	Protocol            Protocol
 	TurnSocket          net.PacketConn
 	RelaySocket         net.PacketConn
+	Username            string
 	fiveTuple           *FiveTuple
 	permissionsLock     sync.RWMutex
 	permissions         map[string]*Permission
@@ -45,10 +46,11 @@ type Allocation struct {
 }
 
 // NewAllocation creates a new instance of NewAllocation.
-func NewAllocation(turnSocket net.PacketConn, fiveTuple *FiveTuple, log logging.LeveledLogger) *Allocation {
+func NewAllocation(turnSocket net.PacketConn, fiveTuple *FiveTuple, username string, log logging.LeveledLogger) *Allocation {
 	return &Allocation{
 		TurnSocket:  turnSocket,
 		fiveTuple:   fiveTuple,
+		Username:    username,
 		permissions: make(map[string]*Permission, 64),
 		closed:      make(chan interface{}),
 		log:         log,

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -46,7 +46,7 @@ func TestAllocation(t *testing.T) {
 }
 
 func subTestGetPermission(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -88,7 +88,7 @@ func subTestGetPermission(t *testing.T) {
 }
 
 func subTestAddPermission(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -107,7 +107,7 @@ func subTestAddPermission(t *testing.T) {
 }
 
 func subTestRemovePermission(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -130,7 +130,7 @@ func subTestRemovePermission(t *testing.T) {
 }
 
 func subTestAddChannelBind(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -154,7 +154,7 @@ func subTestAddChannelBind(t *testing.T) {
 }
 
 func subTestGetChannelByNumber(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -173,7 +173,7 @@ func subTestGetChannelByNumber(t *testing.T) {
 }
 
 func subTestGetChannelByAddr(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -193,7 +193,7 @@ func subTestGetChannelByAddr(t *testing.T) {
 }
 
 func subTestRemoveChannelBind(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	if err != nil {
@@ -214,7 +214,7 @@ func subTestRemoveChannelBind(t *testing.T) {
 }
 
 func subTestAllocationRefresh(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -236,7 +236,7 @@ func subTestAllocationClose(t *testing.T) {
 		panic(err)
 	}
 
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 	a.RelaySocket = l
 	// Add mock lifetimeTimer
 	a.lifetimeTimer = time.AfterFunc(proto.DefaultLifetime, func() {})
@@ -261,7 +261,7 @@ func subTestAllocationClose(t *testing.T) {
 func subTestPacketHandler(t *testing.T) {
 	network := "udp"
 
-	m, _ := newTestManager()
+	m, _ := newTestManager(testManagerModeUseAllocatePacketConnForUser)
 
 	// TURN server initialization
 	turnSocket, err := net.ListenPacket(network, "127.0.0.1:0")
@@ -292,7 +292,7 @@ func subTestPacketHandler(t *testing.T) {
 	a, err := m.CreateAllocation(&FiveTuple{
 		SrcAddr: clientListener.LocalAddr(),
 		DstAddr: turnSocket.LocalAddr(),
-	}, turnSocket, 0, proto.DefaultLifetime)
+	}, turnSocket, 0, proto.DefaultLifetime, testUsername)
 
 	assert.Nil(t, err, "should succeed")
 
@@ -357,7 +357,7 @@ func subTestPacketHandler(t *testing.T) {
 }
 
 func subTestResponseCache(t *testing.T) {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 	transactionID := [stun.TransactionIDSize]byte{1, 2, 3}
 	responseAttrs := []stun.Setter{
 		&proto.Lifetime{

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -42,7 +42,7 @@ func TestChannelBindReset(t *testing.T) {
 }
 
 func newChannelBind(lifetime time.Duration) *ChannelBind {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, "", nil)
 
 	addr, _ := net.ResolveUDPAddr("udp", "0.0.0.0:0")
 	c := &ChannelBind{

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -97,7 +97,7 @@ func TestAllocationLifeTime(t *testing.T) {
 
 		fiveTuple := &allocation.FiveTuple{SrcAddr: r.SrcAddr, DstAddr: r.Conn.LocalAddr(), Protocol: allocation.UDP}
 
-		_, err = r.AllocationManager.CreateAllocation(fiveTuple, r.Conn, 0, time.Hour)
+		_, err = r.AllocationManager.CreateAllocation(fiveTuple, r.Conn, 0, time.Hour, "")
 		assert.NoError(t, err)
 
 		assert.NotNil(t, r.AllocationManager.GetAllocation(fiveTuple))

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -42,14 +42,14 @@ func buildMsg(transactionID [stun.TransactionIDSize]byte, msgType stun.MessageTy
 	return append([]stun.Setter{&stun.Message{TransactionID: transactionID}, msgType}, additional...)
 }
 
-func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) (stun.MessageIntegrity, bool, error) {
-	respondWithNonce := func(responseCode stun.ErrorCode) (stun.MessageIntegrity, bool, error) {
+func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) (stun.MessageIntegrity, string, bool, error) {
+	respondWithNonce := func(responseCode stun.ErrorCode) (stun.MessageIntegrity, string, bool, error) {
 		nonce, err := r.NonceHash.Generate()
 		if err != nil {
-			return nil, false, err
+			return nil, "", false, err
 		}
 
-		return nil, false, buildAndSend(r.Conn, r.SrcAddr, buildMsg(m.TransactionID,
+		return nil, "", false, buildAndSend(r.Conn, r.SrcAddr, buildMsg(m.TransactionID,
 			stun.NewType(callingMethod, stun.ClassErrorResponse),
 			&stun.ErrorCodeAttribute{Code: responseCode},
 			stun.NewNonce(nonce),
@@ -70,11 +70,11 @@ func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) 
 	// Respond with 400 so clients don't retry
 	if r.AuthHandler == nil {
 		sendErr := buildAndSend(r.Conn, r.SrcAddr, badRequestMsg...)
-		return nil, false, sendErr
+		return nil, "", false, sendErr
 	}
 
 	if err := nonceAttr.GetFrom(m); err != nil {
-		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
+		return nil, "", false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
 	}
 
 	// Assert Nonce is signed and is not expired
@@ -83,21 +83,21 @@ func authenticateRequest(r Request, m *stun.Message, callingMethod stun.Method) 
 	}
 
 	if err := realmAttr.GetFrom(m); err != nil {
-		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
+		return nil, "", false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
 	} else if err := usernameAttr.GetFrom(m); err != nil {
-		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
+		return nil, "", false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
 	}
 
 	ourKey, ok := r.AuthHandler(usernameAttr.String(), realmAttr.String(), r.SrcAddr)
 	if !ok {
-		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("%w %s", errNoSuchUser, usernameAttr.String()), badRequestMsg...)
+		return nil, "", false, buildAndSendErr(r.Conn, r.SrcAddr, fmt.Errorf("%w %s", errNoSuchUser, usernameAttr.String()), badRequestMsg...)
 	}
 
 	if err := stun.MessageIntegrity(ourKey).Check(m); err != nil {
-		return nil, false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
+		return nil, "", false, buildAndSendErr(r.Conn, r.SrcAddr, err, badRequestMsg...)
 	}
 
-	return stun.MessageIntegrity(ourKey), true, nil
+	return stun.MessageIntegrity(ourKey), usernameAttr.String(), true, nil
 }
 
 func allocationLifeTime(m *stun.Message) time.Duration {

--- a/relay_address_generator_none.go
+++ b/relay_address_generator_none.go
@@ -52,3 +52,18 @@ func (r *RelayAddressGeneratorNone) AllocatePacketConn(network string, requested
 func (r *RelayAddressGeneratorNone) AllocateConn(string, int) (net.Conn, net.Addr, error) {
 	return nil, nil, errTODO
 }
+
+// AllocatePacketConnForUser generates a new PacketConn to receive traffic on and the IP/Port to populate the allocation response with
+func (r *RelayAddressGeneratorNone) AllocatePacketConnForUser(network string, requestedPort int, _ string) (net.PacketConn, net.Addr, error) {
+	conn, err := r.Net.ListenPacket(network, r.Address+":"+strconv.Itoa(requestedPort))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return conn, conn.LocalAddr(), nil
+}
+
+// AllocateConnForUser generates a new Conn to receive traffic on and the IP/Port to populate the allocation response with
+func (r *RelayAddressGeneratorNone) AllocateConnForUser(string, int, string) (net.Conn, net.Addr, error) {
+	return nil, nil, errTODO
+}

--- a/relay_address_generator_static.go
+++ b/relay_address_generator_static.go
@@ -66,3 +66,26 @@ func (r *RelayAddressGeneratorStatic) AllocatePacketConn(network string, request
 func (r *RelayAddressGeneratorStatic) AllocateConn(string, int) (net.Conn, net.Addr, error) {
 	return nil, nil, errTODO
 }
+
+// AllocatePacketConnForUser generates a new PacketConn to receive traffic on and the IP/Port to populate the allocation response with
+func (r *RelayAddressGeneratorStatic) AllocatePacketConnForUser(network string, requestedPort int, _ string) (net.PacketConn, net.Addr, error) {
+	conn, err := r.Net.ListenPacket(network, r.Address+":"+strconv.Itoa(requestedPort))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Replace actual listening IP with the user requested one of RelayAddressGeneratorStatic
+	relayAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return nil, nil, errNilConn
+	}
+
+	relayAddr.IP = r.RelayAddress
+
+	return conn, relayAddr, nil
+}
+
+// AllocateConnForUser generates a new Conn to receive traffic on and the IP/Port to populate the allocation response with
+func (r *RelayAddressGeneratorStatic) AllocateConnForUser(string, int, string) (net.Conn, net.Addr, error) {
+	return nil, nil, errTODO
+}

--- a/server.go
+++ b/server.go
@@ -179,6 +179,14 @@ func (n *nilAddressGenerator) AllocateConn(string, int) (net.Conn, net.Addr, err
 	return nil, nil, errRelayAddressGeneratorNil
 }
 
+func (n *nilAddressGenerator) AllocatePacketConnForUser(string, int, string) (net.PacketConn, net.Addr, error) {
+	return nil, nil, errRelayAddressGeneratorNil
+}
+
+func (n *nilAddressGenerator) AllocateConnForUser(string, int, string) (net.Conn, net.Addr, error) {
+	return nil, nil, errRelayAddressGeneratorNil
+}
+
 func (s *Server) createAllocationManager(addrGenerator RelayAddressGenerator, handler PermissionHandler) (*allocation.Manager, error) {
 	if handler == nil {
 		handler = DefaultPermissionHandler

--- a/server_config.go
+++ b/server_config.go
@@ -24,6 +24,12 @@ type RelayAddressGenerator interface {
 
 	// Allocate a Conn (TCP) RelayAddress
 	AllocateConn(network string, requestedPort int) (net.Conn, net.Addr, error)
+
+	// Allocate a PacketConn (UDP) RelayAddress with a user name
+	AllocatePacketConnForUser(network string, requestedPort int, username string) (net.PacketConn, net.Addr, error)
+
+	// Allocate a Conn (TCP) RelayAddress with a user name
+	AllocateConnForUser(network string, requestedPort int, username string) (net.Conn, net.Addr, error)
 }
 
 // PermissionHandler is a callback to filter incoming CreatePermission and ChannelBindRequest


### PR DESCRIPTION
Resolves #420

#### Description
Details of this feature are described in #420.
This PR make following changes:
* Adds AllocatePacketConnForUser and AllocateConnForUser methods to RelayAddressGenerator interfaces
    * These methods deprecates AllocatePacketConn and AllocateConn respectively.
* Changes to internal packages:
    * NewAllocation
    * ManagerConfig
    * CreateAllocation
    * authenticateRequest - to pass "username" to CreateAllocation method

#### Reference issue
Fixes #420 
