### PR TITLE
Add a quota handler callback

### DIFF
--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -52,15 +52,15 @@ func subTestCreateInvalidAllocation(t *testing.T, turnSocket net.PacketConn) {
 	m, err := newTestManager()
 	assert.NoError(t, err)
 
-	a, err := m.CreateAllocation(nil, turnSocket, 0, proto.DefaultLifetime)
+	a, err := m.CreateAllocation(nil, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.Nil(t, a, "Illegally created allocation with nil FiveTuple")
 	assert.Error(t, err, "Illegally created allocation with nil FiveTuple")
 
-	a, err = m.CreateAllocation(randomFiveTuple(), nil, 0, proto.DefaultLifetime)
+	a, err = m.CreateAllocation(randomFiveTuple(), nil, 0, proto.DefaultLifetime, "", "")
 	assert.Nil(t, a, "Illegally created allocation with nil turnSocket")
 	assert.Error(t, err, "Illegally created allocation with nil turnSocket")
 
-	a, err = m.CreateAllocation(randomFiveTuple(), turnSocket, 0, 0)
+	a, err = m.CreateAllocation(randomFiveTuple(), turnSocket, 0, 0, "", "")
 	assert.Nil(t, a, "Illegally created allocation with 0 lifetime")
 	assert.Error(t, err, "Illegally created allocation with 0 lifetime")
 }
@@ -73,7 +73,7 @@ func subTestCreateAllocation(t *testing.T, turnSocket net.PacketConn) {
 	assert.NoError(t, err)
 
 	fiveTuple := randomFiveTuple()
-	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.NotNil(t, a, "Failed to create allocation")
 	assert.NoError(t, err, "Failed to create allocation")
 
@@ -89,11 +89,11 @@ func subTestCreateAllocationDuplicateFiveTuple(t *testing.T, turnSocket net.Pack
 	assert.NoError(t, err)
 
 	fiveTuple := randomFiveTuple()
-	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.NotNil(t, a, "Failed to create allocation")
 	assert.NoError(t, err, "Failed to create allocation")
 
-	a, err = m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err = m.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.Nil(t, a, "Was able to create allocation with same FiveTuple twice")
 	assert.Error(t, err, "Was able to create allocation with same FiveTuple twice")
 }
@@ -105,7 +105,7 @@ func subTestDeleteAllocation(t *testing.T, turnSocket net.PacketConn) {
 	assert.NoError(t, err)
 
 	fiveTuple := randomFiveTuple()
-	a, err := manager.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime)
+	a, err := manager.CreateAllocation(fiveTuple, turnSocket, 0, proto.DefaultLifetime, "", "")
 	assert.NotNil(t, a, "Failed to create allocation")
 	assert.NoError(t, err, "Failed to create allocation")
 
@@ -130,7 +130,7 @@ func subTestAllocationTimeout(t *testing.T, turnSocket net.PacketConn) {
 	for index := range allocations {
 		fiveTuple := randomFiveTuple()
 
-		a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, lifetime)
+		a, err := m.CreateAllocation(fiveTuple, turnSocket, 0, lifetime, "", "")
 		assert.NoErrorf(t, err, "Failed to create allocation with %v", fiveTuple)
 
 		allocations[index] = a
@@ -152,9 +152,9 @@ func subTestManagerClose(t *testing.T, turnSocket net.PacketConn) {
 
 	allocations := make([]*Allocation, 2)
 
-	a1, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Second)
+	a1, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Second, "", "")
 	allocations[0] = a1
-	a2, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Minute)
+	a2, _ := manager.CreateAllocation(randomFiveTuple(), turnSocket, 0, time.Minute, "", "")
 	allocations[1] = a2
 
 	// Make a1 timeout

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -48,7 +48,7 @@ func TestAllocation(t *testing.T) {
 func subTestGetPermission(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func subTestGetPermission(t *testing.T) {
 func subTestAddPermission(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -105,7 +105,7 @@ func subTestAddPermission(t *testing.T) {
 func subTestRemovePermission(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -128,7 +128,7 @@ func subTestRemovePermission(t *testing.T) {
 func subTestAddChannelBind(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -152,7 +152,7 @@ func subTestAddChannelBind(t *testing.T) {
 func subTestGetChannelByNumber(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -171,7 +171,7 @@ func subTestGetChannelByNumber(t *testing.T) {
 func subTestGetChannelByAddr(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -191,7 +191,7 @@ func subTestGetChannelByAddr(t *testing.T) {
 func subTestRemoveChannelBind(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
 	assert.NoError(t, err)
@@ -212,7 +212,7 @@ func subTestRemoveChannelBind(t *testing.T) {
 func subTestAllocationRefresh(t *testing.T) {
 	t.Helper()
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -234,7 +234,7 @@ func subTestAllocationClose(t *testing.T) {
 	l, err := net.ListenPacket(network, "0.0.0.0:0")
 	assert.NoError(t, err)
 
-	alloc := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 	alloc.RelaySocket = l
 	// Add mock lifetimeTimer
 	alloc.lifetimeTimer = time.AfterFunc(proto.DefaultLifetime, func() {})
@@ -285,7 +285,7 @@ func subTestPacketHandler(t *testing.T) {
 	alloc, err := manager.CreateAllocation(&FiveTuple{
 		SrcAddr: clientListener.LocalAddr(),
 		DstAddr: turnSocket.LocalAddr(),
-	}, turnSocket, 0, proto.DefaultLifetime)
+	}, turnSocket, 0, proto.DefaultLifetime, "", "")
 
 	assert.NoError(t, err, "should succeed")
 
@@ -345,16 +345,16 @@ func subTestPacketHandler(t *testing.T) {
 func subTestResponseCache(t *testing.T) {
 	t.Helper()
 
-	a := NewAllocation(nil, nil, nil)
+	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
 	transactionID := [stun.TransactionIDSize]byte{1, 2, 3}
 	responseAttrs := []stun.Setter{
 		&proto.Lifetime{
 			Duration: proto.DefaultLifetime,
 		},
 	}
-	a.SetResponseCache(transactionID, responseAttrs)
+	alloc.SetResponseCache(transactionID, responseAttrs)
 
-	cacheID, cacheAttr := a.GetResponseCache()
+	cacheID, cacheAttr := alloc.GetResponseCache()
 	assert.Equal(t, transactionID, cacheID)
 	assert.Equal(t, responseAttrs, cacheAttr)
 }

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -37,7 +37,7 @@ func TestChannelBindReset(t *testing.T) {
 }
 
 func newChannelBind(lifetime time.Duration) *ChannelBind {
-	a := NewAllocation(nil, nil, nil)
+	a := NewAllocation(nil, nil, EventHandler{}, nil)
 
 	addr, _ := net.ResolveUDPAddr("udp", "0.0.0.0:0")
 	c := &ChannelBind{

--- a/internal/allocation/event_handler.go
+++ b/internal/allocation/event_handler.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package allocation
+
+import (
+	"net"
+)
+
+// EventHandler is a set of callbacks that the server will call at certain hook points during an
+// allocation's lifecycle. All events are reported with the context that identifies the allocation
+// triggering the event (source and destination address, protocol, username and realm used for
+// authenticating the allocation), plus additional callback specific parameters. It is OK to handle
+// only a subset of the callbacks.
+type EventHandler struct {
+	// OnAuth is called after an authentication request has been processed with the TURN method
+	// triggering the authentication request (either "Allocate", "Refresh" "CreatePermission",
+	// or "ChannelBind"), and the verdict is the authentication result.
+	OnAuth func(srcAddr, dstAddr net.Addr, protocol, username, realm string, method string, verdict bool)
+	// OnAllocationCreated is called after a new allocation has been made. The relayAddr
+	// argument specifies the relay address and requestedPort is the port requested by the
+	// client (if any).
+	OnAllocationCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr net.Addr, requestedPort int)
+	// OnAllocationDeleted is called after an allocation has been removed.
+	OnAllocationDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string)
+	// OnAllocationError is called when the readloop hdndling an allocation exits with an
+	// error with an error message.
+	OnAllocationError func(srcAddr, dstAddr net.Addr, protocol, message string)
+	// OnPermissionCreated is called after a new permission has been made to an IP address.
+	OnPermissionCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr net.Addr, peer net.IP)
+	// OnPermissionDeleted is called after a permission for a given IP address has been
+	// removed.
+	OnPermissionDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr net.Addr, peer net.IP)
+	// OnChannelCreated is called after a new channel has been made. The relay address, the
+	// peer address and the channel number can be used to uniquely identify the channel
+	// created.
+	OnChannelCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr, peer net.Addr, channelNumber uint16)
+	// OnChannelDeleted is called after a channel has been removed from the server. The relay
+	// address, the peer address and the channel number can be used to uniquely identify the
+	// channel deleted.
+	OnChannelDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+		relayAddr, peer net.Addr, channelNumber uint16)
+}

--- a/internal/allocation/five_tuple.go
+++ b/internal/allocation/five_tuple.go
@@ -16,6 +16,17 @@ const (
 	TCP
 )
 
+func (p Protocol) String() string {
+	switch p {
+	case UDP:
+		return "UDP"
+	case TCP:
+		return "TCP"
+	default:
+		return ""
+	}
+}
+
 // FiveTuple is the combination (client IP address and port, server IP
 // address and port, and transport protocol (currently one of UDP,
 // TCP, or TLS)) used to communicate between the client and the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,9 @@ type Request struct {
 	// User Configuration
 	AuthHandler func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
 
+	// Quota Handler
+	QuotaHandler func(username string, realm string, srcAddr net.Addr) (ok bool)
+
 	Log                logging.LeveledLogger
 	Realm              string
 	ChannelBindTimeout time.Duration

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,7 +27,8 @@ type Request struct {
 	NonceHash         *NonceHash
 
 	// User Configuration
-	AuthHandler        func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+	AuthHandler func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)
+
 	Log                logging.LeveledLogger
 	Realm              string
 	ChannelBindTimeout time.Duration

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -145,6 +145,12 @@ func handleAllocateRequest(req Request, stunMsg *stun.Message) error { //nolint:
 		}
 	}
 
+	// Parse realm and username (already checked in authenticateRequest)
+	realmAttr := &stun.Realm{}
+	_ = realmAttr.GetFrom(stunMsg)
+	usernameAttr := &stun.Username{}
+	_ = usernameAttr.GetFrom(stunMsg)
+
 	// 7. At any point, the server MAY choose to reject the request with a
 	//    486 (Allocation Quota Reached) error if it feels the client is
 	//    trying to exceed some locally defined allocation quota.  The
@@ -161,7 +167,10 @@ func handleAllocateRequest(req Request, stunMsg *stun.Message) error { //nolint:
 		fiveTuple,
 		req.Conn,
 		requestedPort,
-		lifetimeDuration)
+		lifetimeDuration,
+		usernameAttr.String(),
+		realmAttr.String(),
+	)
 	if err != nil {
 		return buildAndSendErr(req.Conn, req.SrcAddr, err, insufficientCapacityMsg...)
 	}

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -91,7 +91,7 @@ func TestAllocationLifeTime(t *testing.T) {
 
 		fiveTuple := &allocation.FiveTuple{SrcAddr: req.SrcAddr, DstAddr: req.Conn.LocalAddr(), Protocol: allocation.UDP}
 
-		_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, 0, time.Hour)
+		_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, 0, time.Hour, "", "")
 		assert.NoError(t, err)
 
 		assert.NotNil(t, req.AllocationManager.GetAllocation(fiveTuple))

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ const (
 type Server struct {
 	log                logging.LeveledLogger
 	authHandler        AuthHandler
+	quotaHandler       QuotaHandler
 	realm              string
 	channelBindTimeout time.Duration
 	nonceHash          *server.NonceHash
@@ -59,6 +60,7 @@ func NewServer(config ServerConfig) (*Server, error) { //nolint:gocognit,cyclop
 	server := &Server{
 		log:                loggerFactory.NewLogger("turn"),
 		authHandler:        config.AuthHandler,
+		quotaHandler:       config.QuotaHandler,
 		realm:              config.Realm,
 		channelBindTimeout: config.ChannelBindTimeout,
 		packetConnConfigs:  config.PacketConnConfigs,
@@ -231,6 +233,7 @@ func (s *Server) readLoop(conn net.PacketConn, allocationManager *allocation.Man
 			Buff:               buf[:n],
 			Log:                s.log,
 			AuthHandler:        s.authHandler,
+			QuotaHandler:       s.quotaHandler,
 			Realm:              s.realm,
 			AllocationManager:  allocationManager,
 			ChannelBindTimeout: s.channelBindTimeout,

--- a/server_config.go
+++ b/server_config.go
@@ -113,6 +113,11 @@ func GenerateAuthKey(username, realm, password string) []byte {
 // allocation's lifecycle.
 type EventHandler = allocation.EventHandler
 
+// QuotaHandler is a callback allows allocations to be rejected when a per-user quota is
+// exceeded. If the callback returns true the allocation request is accepted, otherwise it is
+// rejected and a 486 (Allocation Quota Reached) error is returned to the user.
+type QuotaHandler func(username, realm string, srcAddr net.Addr) (ok bool)
+
 // ServerConfig configures the Pion TURN Server.
 type ServerConfig struct {
 	// PacketConnConfigs and ListenerConfigs are a list of all the turn listeners
@@ -129,6 +134,10 @@ type ServerConfig struct {
 	// AuthHandler is a callback used to handle incoming auth requests,
 	// allowing users to customize Pion TURN with custom behavior
 	AuthHandler AuthHandler
+
+	// QuotaHandler is a callback used to reject new allocations when a
+	// per-user quota is exceeded.
+	QuotaHandler QuotaHandler
 
 	// EventHandlers is a set of callbacks for tracking allocation lifecycle.
 	EventHandler EventHandler

--- a/server_config.go
+++ b/server_config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/pion/turn/v4/internal/allocation"
 )
 
 // RelayAddressGenerator is used to generate a RelayAddress when creating an allocation.
@@ -108,6 +109,10 @@ func GenerateAuthKey(username, realm, password string) []byte {
 	return h.Sum(nil)
 }
 
+// EventHandler is a set of callbacks that the server will call at certain hook points during an
+// allocation's lifecycle.
+type EventHandler = allocation.EventHandler
+
 // ServerConfig configures the Pion TURN Server.
 type ServerConfig struct {
 	// PacketConnConfigs and ListenerConfigs are a list of all the turn listeners
@@ -124,6 +129,9 @@ type ServerConfig struct {
 	// AuthHandler is a callback used to handle incoming auth requests,
 	// allowing users to customize Pion TURN with custom behavior
 	AuthHandler AuthHandler
+
+	// EventHandlers is a set of callbacks for tracking allocation lifecycle.
+	EventHandler EventHandler
 
 	// ChannelBindTimeout sets the lifetime of channel binding. Defaults to 10 minutes.
 	ChannelBindTimeout time.Duration


### PR DESCRIPTION
Note: the PR is on top of https://github.com/pion/turn/pull/419, see the changes on top of that PR [here](https://github.com/l7mp/turn/pull/3/files).

RFC 8656 includes the following text:

> To mitigate either intentional or unintentional denial-of-service attacks against the server by clients with valid usernames and passwords, it is RECOMMENDED that the server impose limits on both the number of allocations active at one time for a given username and on the amount of bandwidth those allocations can use. The server should reject new allocations that would exceed the limit on the allowed number of allocations active at one time with a 486 (Allocation Quota Exceeded [sic!]) [error].

(Note the mistake in the text: the name of the error is in fact "Allocation Quota Reached", not "Allocation Quota Exceeded".)

This PR adds a quota handler callback function which, if specified, is called by the server just before making an allocation for a user. The handler should return a single bool: if true then the allocation request can proceed, otherwise the request is rejected with the 486 (Allocation Quota Reached) error. Then, the [lifecycle API](https://github.com/pion/turn/pull/419/) can be used to track the number of active allocations per user and this callback can be leveraged to reject allocation requests that would exceed the user's quota.

Note that the other DoS mitigation recommendation given in the RFC (limiting the amount of bandwidth a single user can use) is not targeted by this PR.