### PR TITLE
fix: Remove trailing newlines from log messages

### DIFF
--- a/lt_cred.go
+++ b/lt_cred.go
@@ -79,7 +79,7 @@ func LongTermTURNRESTAuthHandler(sharedSecret string, l logging.LeveledLogger) A
 		l = logging.NewDefaultLoggerFactory().NewLogger("turn")
 	}
 	return func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
-		l.Tracef("Authentication username=%q realm=%q srcAddr=%v\n", username, realm, srcAddr)
+		l.Tracef("Authentication username=%q realm=%q srcAddr=%v", username, realm, srcAddr)
 		timestamp := strings.Split(username, ":")[0]
 		t, err := strconv.Atoi(timestamp)
 		if err != nil {


### PR DESCRIPTION
#### Description
This PR fixes a recent linter error that breaks recent PR checks ([an example](https://github.com/pion/turn/actions/runs/12559678074/job/35015821842?pr=429#step:7:5))
