### PR TITLE
Fix data race in WriteTo

### DIFF
--- a/internal/client/tcp_conn_test.go
+++ b/internal/client/tcp_conn_test.go
@@ -92,7 +92,7 @@ func TestTCPConn(t *testing.T) {
 		client = &mockClient{
 			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
 				if msg.Type.Class == stun.ClassRequest && msg.Type.Method == stun.MethodConnect {
-					msg, err = stun.Build(
+					msg, err := stun.Build(
 						stun.TransactionID,
 						stun.NewType(stun.MethodConnect, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeBadRequest},
@@ -174,7 +174,7 @@ func TestTCPConn(t *testing.T) {
 					typ = stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse)
 				}
 
-				msg, err = stun.Build(
+				msg, err := stun.Build(
 					stun.TransactionID,
 					typ,
 					cid,

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -240,7 +240,7 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 		if bound.state() == bindingStateReady && time.Since(bound.refreshedAt()) > 5*time.Minute {
 			bound.setState(bindingStateRefresh)
 			go func() {
-				err = c.bind(bound)
+				err := c.bind(bound)
 				if err != nil {
 					c.log.Warnf("Failed to bind() for refresh: %s", err)
 					bound.setState(bindingStateFailed)


### PR DESCRIPTION
#### Description
There is no harm in shadowing `err` in the goroutine since we do not need it outside of the routine.

I also discovered data races in tcp_conn_test.go while fixing this bug and have included them in this PR.

#### Reference issue
Fixes [#438 ](https://github.com/pion/turn/issues/438)
