### PR TITLE
Fix order dependent test in server_test.go

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -633,6 +633,8 @@ func TestSTUNOnly(t *testing.T) {
 
 	_, err = client.Allocate()
 	assert.Equal(t, err.Error(), "Allocate error response (error 400: )")
+
+	assert.NoError(t, conn.Close())
 }
 
 func RunBenchmarkServer(b *testing.B, clientNum int) { //nolint:cyclop


### PR DESCRIPTION
`go test -shuffle=1738872331488754809` now passes

#### Description

#### Reference issue
Fixes #...
