### PR TITLE
Update lint rules, use testify/assert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/client_test.go
+++ b/client_test.go
@@ -108,15 +108,11 @@ func TestClientWithSTUN(t *testing.T) {
 		// Block until go routine is started to make two almost parallel requests
 		<-started
 
-		if _, err = client.SendBindingRequestTo(to); err != nil {
-			t.Fatal(err)
-		}
+		_, err = client.SendBindingRequestTo(to)
+		assert.NoError(t, err)
 
 		<-finished
-		if err1 != nil {
-			t.Fatal(err)
-		}
-
+		assert.NoErrorf(t, err1, "should succeed: %v", err)
 		assert.NoError(t, pc.Close())
 	})
 
@@ -244,8 +240,7 @@ func TestTCPClient(t *testing.T) {
 
 	peerAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:12345")
 	require.NoError(t, err)
-	err = client.CreatePermission(peerAddr)
-	require.NoError(t, err)
+	require.NoError(t, client.CreatePermission(peerAddr))
 
 	var cid proto.ConnectionID = 5
 	transactionID := [stun.TransactionIDSize]byte{1, 2, 3}
@@ -259,8 +254,7 @@ func TestTCPClient(t *testing.T) {
 	msg, err := stun.Build(attrs...)
 	require.NoError(t, err)
 
-	err = client.handleSTUNMessage(msg.Raw, peerAddr)
-	require.NoError(t, err)
+	require.NoError(t, client.handleSTUNMessage(msg.Raw, peerAddr))
 
 	// Shutdown
 	require.NoError(t, allocation.Close())

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -51,19 +51,13 @@ func subTestGetPermission(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	addr2, err := net.ResolveUDPAddr("udp", "127.0.0.1:3479")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	addr3, err := net.ResolveUDPAddr("udp", "127.0.0.2:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	perms := &Permission{
 		Addr: addr,
@@ -95,9 +89,7 @@ func subTestAddPermission(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	p := &Permission{
 		Addr: addr,
@@ -116,9 +108,7 @@ func subTestRemovePermission(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	p := &Permission{
 		Addr: addr,
@@ -141,9 +131,7 @@ func subTestAddChannelBind(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	c := NewChannelBind(proto.MinChannelNumber, addr, nil)
 
@@ -167,9 +155,7 @@ func subTestGetChannelByNumber(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	c := NewChannelBind(proto.MinChannelNumber, addr, nil)
 
@@ -188,9 +174,7 @@ func subTestGetChannelByAddr(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	c := NewChannelBind(proto.MinChannelNumber, addr, nil)
 
@@ -210,9 +194,7 @@ func subTestRemoveChannelBind(t *testing.T) {
 	alloc := NewAllocation(nil, nil, nil)
 
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	c := NewChannelBind(proto.MinChannelNumber, addr, nil)
 
@@ -250,9 +232,7 @@ func subTestAllocationClose(t *testing.T) {
 	network := "udp"
 
 	l, err := net.ListenPacket(network, "0.0.0.0:0")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
 	alloc := NewAllocation(nil, nil, nil)
 	alloc.RelaySocket = l
@@ -261,9 +241,7 @@ func subTestAllocationClose(t *testing.T) {
 
 	// Add channel
 	addr, err := net.ResolveUDPAddr(network, "127.0.0.1:3478")
-	if err != nil {
-		t.Fatalf("failed to resolve: %s", err)
-	}
+	assert.NoError(t, err)
 
 	c := NewChannelBind(proto.MinChannelNumber, addr, nil)
 	_ = alloc.AddChannelBind(c, proto.DefaultLifetime)
@@ -271,8 +249,7 @@ func subTestAllocationClose(t *testing.T) {
 	// Add permission
 	alloc.AddPermission(NewPermission(addr, nil))
 
-	err = alloc.Close()
-	assert.Nil(t, err, "should succeed")
+	assert.Nil(t, alloc.Close(), "should succeed")
 	assert.True(t, isClose(alloc.RelaySocket), "should be closed")
 }
 
@@ -285,15 +262,11 @@ func subTestPacketHandler(t *testing.T) {
 
 	// TURN server initialization
 	turnSocket, err := net.ListenPacket(network, "127.0.0.1:0")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
 	// Client listener initialization
 	clientListener, err := net.ListenPacket(network, "127.0.0.1:0")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
 	dataCh := make(chan []byte)
 	// Client listener read data
@@ -314,17 +287,13 @@ func subTestPacketHandler(t *testing.T) {
 		DstAddr: turnSocket.LocalAddr(),
 	}, turnSocket, 0, proto.DefaultLifetime)
 
-	assert.Nil(t, err, "should succeed")
+	assert.NoError(t, err, "should succeed")
 
 	peerListener1, err := net.ListenPacket(network, "127.0.0.1:0")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
 	peerListener2, err := net.ListenPacket(network, "127.0.0.1:0")
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(t, err)
 
 	// Add permission with peer1 address
 	alloc.AddPermission(NewPermission(peerListener1.LocalAddr(), manager.log))
@@ -345,12 +314,10 @@ func subTestPacketHandler(t *testing.T) {
 	assert.True(t, stun.IsMessage(data), "should be stun message")
 
 	var msg stun.Message
-	err = stun.Decode(data, &msg)
-	assert.Nil(t, err, "decode data to stun message failed")
+	assert.NoError(t, stun.Decode(data, &msg), "decode data to stun message failed")
 
 	var msgData proto.Data
-	err = msgData.GetFrom(&msg)
-	assert.Nil(t, err, "get data from stun message failed")
+	assert.NoError(t, msgData.GetFrom(&msg), "get data from stun message failed")
 	assert.Equal(t, targetText, string(msgData), "get message doesn't equal the target text")
 
 	// Test for channel bind and channel data
@@ -364,8 +331,7 @@ func subTestPacketHandler(t *testing.T) {
 	channelData := proto.ChannelData{
 		Raw: data,
 	}
-	err = channelData.Decode()
-	assert.Nil(t, err, fmt.Sprintf("channel data decode with error: %v", err))
+	assert.NoError(t, channelData.Decode(), fmt.Sprintf("channel data decode with error: %v", err))
 	assert.Equal(t, channelBind.Number, channelData.Number, "get channel data's number is invalid")
 	assert.Equal(t, targetText2, string(channelData.Data), "get data doesn't equal the target text.")
 

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -9,24 +9,21 @@ import (
 	"time"
 
 	"github.com/pion/turn/v4/internal/proto"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChannelBind(t *testing.T) {
 	c := newChannelBind(2 * time.Second)
-
-	if c.allocation.GetChannelByNumber(c.Number) != c {
-		t.Errorf("GetChannelByNumber(%d) shouldn't be nil after added to allocation", c.Number)
-	}
+	assert.Equalf(t, c, c.allocation.GetChannelByNumber(c.Number),
+		"GetChannelByNumber(%d) shouldn't be nil after added to allocation", c.Number)
 }
 
 func TestChannelBindStart(t *testing.T) {
 	c := newChannelBind(2 * time.Second)
 
 	time.Sleep(3 * time.Second)
-
-	if c.allocation.GetChannelByNumber(c.Number) != nil {
-		t.Errorf("GetChannelByNumber(%d) should be nil if timeout", c.Number)
-	}
+	assert.Nil(t, c.allocation.GetChannelByNumber(c.Number),
+		"GetChannelByNumber(%d) should be nil after timeout", c.Number)
 }
 
 func TestChannelBindReset(t *testing.T) {
@@ -35,10 +32,8 @@ func TestChannelBindReset(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	c.refresh(3 * time.Second)
 	time.Sleep(2 * time.Second)
-
-	if c.allocation.GetChannelByNumber(c.Number) == nil {
-		t.Errorf("GetChannelByNumber(%d) shouldn't be nil after refresh", c.Number)
-	}
+	assert.NotNil(t, c.allocation.GetChannelByNumber(c.Number),
+		"GetChannelByNumber(%d) shouldn't be nil after refresh", c.Number)
 }
 
 func newChannelBind(lifetime time.Duration) *ChannelBind {

--- a/internal/allocation/five_tuple_test.go
+++ b/internal/allocation/five_tuple_test.go
@@ -6,19 +6,15 @@ package allocation
 import (
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFiveTupleProtocol(t *testing.T) {
 	udpExpect := Protocol(0)
 	tcpExpect := Protocol(1)
-
-	if udpExpect != UDP {
-		t.Errorf("Invalid UDP Protocol value, expect %d but %d", udpExpect, UDP)
-	}
-
-	if tcpExpect != TCP {
-		t.Errorf("Invalid TCP Protocol value, expect %d but %d", tcpExpect, TCP)
-	}
+	assert.Equal(t, UDP, udpExpect)
+	assert.Equal(t, TCP, tcpExpect)
 }
 
 func TestFiveTupleEqual(t *testing.T) {
@@ -67,10 +63,7 @@ func TestFiveTupleEqual(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			fact := a.Equal(b)
-
-			if expect != fact {
-				t.Errorf("%v, %v equal check should be %t, but %t", a, b, expect, fact)
-			}
+			assert.Equalf(t, expect, fact, "%v, %v equal check should be %t, but %t", a, b, expect, fact)
 		})
 	}
 }

--- a/internal/proto/addr_test.go
+++ b/internal/proto/addr_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddr_FromUDPAddr(t *testing.T) {
@@ -16,12 +18,10 @@ func TestAddr_FromUDPAddr(t *testing.T) {
 	}
 	a := new(Addr)
 	a.FromUDPAddr(u)
-	if !u.IP.Equal(a.IP) || u.Port != a.Port || u.String() != a.String() {
-		t.Error("not equal")
-	}
-	if a.Network() != "turn" {
-		t.Error("unexpected network")
-	}
+	assert.True(t, u.IP.Equal(a.IP))
+	assert.Equal(t, u.Port, a.Port)
+	assert.Equal(t, u.String(), a.String())
+	assert.Equal(t, "turn", a.Network())
 }
 
 func TestAddr_EqualIP(t *testing.T) {
@@ -33,12 +33,8 @@ func TestAddr_EqualIP(t *testing.T) {
 		IP:   net.IPv4(127, 0, 0, 1),
 		Port: 1338,
 	}
-	if a.Equal(b) {
-		t.Error("a != b")
-	}
-	if !a.EqualIP(b) {
-		t.Error("a.IP should equal to b.IP")
-	}
+	assert.False(t, a.Equal(b))
+	assert.True(t, a.EqualIP(b))
 }
 
 func TestFiveTuple_Equal(t *testing.T) {
@@ -74,11 +70,7 @@ func TestFiveTuple_Equal(t *testing.T) {
 			},
 		},
 	} {
-		if v := tc.a.Equal(tc.b); v != tc.v {
-			t.Errorf("(%s) %s [%v!=%v] %s",
-				tc.name, tc.a, v, tc.v, tc.b,
-			)
-		}
+		assert.Equal(t, tc.v, tc.a.Equal(tc.b), "(%s) %s [%v!=%v] %s", tc.name, tc.a, tc.v, tc.b, tc.b)
 	}
 }
 
@@ -94,7 +86,5 @@ func TestFiveTuple_String(t *testing.T) {
 			IP:   net.IPv4(127, 0, 0, 1),
 		},
 	})
-	if s != "127.0.0.1:200->127.0.0.1:100 (UDP)" {
-		t.Error("unexpected stringer output")
-	}
+	assert.Equal(t, "127.0.0.1:200->127.0.0.1:100 (UDP)", s, "unexpected stringer output")
 }

--- a/internal/proto/chrome_test.go
+++ b/internal/proto/chrome_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChromeAllocRequest(t *testing.T) {
@@ -23,21 +24,16 @@ func TestChromeAllocRequest(t *testing.T) {
 	// Decoding hex data into binary.
 	for s.Scan() {
 		b, err := hex.DecodeString(s.Text())
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NoError(t, err)
 		data = append(data, b)
 	}
 	// All hex streams decoded to raw binary format and stored in data slice.
 	// Decoding packets to messages.
 	for i, packet := range data {
 		m := new(stun.Message)
-		if _, err := m.Write(packet); err != nil {
-			t.Errorf("Packet %d: %v", i, err)
-		}
+		_, err := m.Write(packet)
+		assert.NoErrorf(t, err, "Packet %d: %v", i, err)
 		messages = append(messages, m)
 	}
-	if len(messages) != 4 {
-		t.Error("unexpected message slice list")
-	}
+	assert.Equal(t, 4, len(messages), "unexpected number of messages")
 }

--- a/internal/proto/dontfrag_test.go
+++ b/internal/proto/dontfrag_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDontFragment(t *testing.T) {
@@ -15,29 +16,23 @@ func TestDontFragment(t *testing.T) {
 	t.Run("False", func(t *testing.T) {
 		m := new(stun.Message)
 		m.WriteHeader()
-		if dontFrag.IsSet(m) {
-			t.Error("should not be set")
-		}
+		assert.False(t, dontFrag.IsSet(m))
 	})
 	t.Run("AddTo", func(t *testing.T) {
 		stunMsg := new(stun.Message)
-		if err := dontFrag.AddTo(stunMsg); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, dontFrag.AddTo(stunMsg))
+
 		stunMsg.WriteHeader()
 		t.Run("IsSet", func(t *testing.T) {
 			decoded := new(stun.Message)
-			if _, err := decoded.Write(stunMsg.Raw); err != nil {
-				t.Fatal("failed to decode message:", err)
-			}
-			if !dontFrag.IsSet(stunMsg) {
-				t.Error("should be set")
-			}
-			if wasAllocs(func() {
+			_, err := decoded.Write(stunMsg.Raw)
+			assert.NoError(t, err)
+			assert.True(t, dontFrag.IsSet(stunMsg))
+
+			allocated := wasAllocs(func() {
 				dontFrag.IsSet(stunMsg)
-			}) {
-				t.Error("unexpected allocations")
-			}
+			})
+			assert.False(t, allocated)
 		})
 	})
 }

--- a/internal/proto/evenport_test.go
+++ b/internal/proto/evenport_test.go
@@ -4,78 +4,64 @@
 package proto
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEvenPort(t *testing.T) { //nolint:cyclop
+func TestEvenPort(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
 		p := EvenPort{}
-		if p.String() != "reserve: false" {
-			t.Errorf("bad value %q for reserve: false", p.String())
-		}
+		assert.Equal(t, "reserve: false", p.String())
+
 		p.ReservePort = true
-		if p.String() != "reserve: true" {
-			t.Errorf("bad value %q for reserve: true", p.String())
-		}
+		assert.Equal(t, "reserve: true", p.String())
 	})
 	t.Run("False", func(t *testing.T) {
 		m := new(stun.Message)
 		p := EvenPort{
 			ReservePort: false,
 		}
-		if err := p.AddTo(m); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, p.AddTo(m))
+
 		m.WriteHeader()
 		decoded := new(stun.Message)
-		var port EvenPort
 		_, err := decoded.Write(m.Raw)
 		assert.NoError(t, err)
+
+		var port EvenPort
 		assert.NoError(t, port.GetFrom(m))
-		if port != p {
-			t.Fatal("not equal")
-		}
+		assert.Equal(t, p, port)
 	})
 	t.Run("AddTo", func(t *testing.T) {
 		m := new(stun.Message)
 		evenPortAttr := EvenPort{
 			ReservePort: true,
 		}
-		if err := evenPortAttr.AddTo(m); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, evenPortAttr.AddTo(m))
 		m.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
-			if _, err := decoded.Write(m.Raw); err != nil {
-				t.Fatal("failed to decode message:", err)
-			}
+			_, err := decoded.Write(m.Raw)
+			assert.NoError(t, err)
+
 			port := EvenPort{}
-			if err := port.GetFrom(decoded); err != nil {
-				t.Fatal(err)
-			}
-			if port != evenPortAttr {
-				t.Errorf("Decoded %q, expected %q", port.String(), evenPortAttr.String())
-			}
-			if wasAllocs(func() {
-				port.GetFrom(decoded) //nolint
-			}) {
-				t.Error("Unexpected allocations")
-			}
+			assert.NoError(t, port.GetFrom(decoded))
+			assert.Equalf(t, evenPortAttr, port, "Decoded %q, expected %q", port.String(), evenPortAttr.String())
+
+			allocated := wasAllocs(func() {
+				assert.NoError(t, port.GetFrom(decoded))
+			})
+			assert.False(t, allocated)
+
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle EvenPort
-				if err := handle.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-					t.Errorf("%v should be not found", err)
-				}
+				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+
 				m.Add(stun.AttrEvenPort, []byte{1, 2, 3})
-				if !stun.IsAttrSizeInvalid(handle.GetFrom(m)) {
-					t.Error("IsAttrSizeInvalid should be true")
-				}
+				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))
 			})
 		})
 	})

--- a/internal/proto/peeraddr_test.go
+++ b/internal/proto/peeraddr_test.go
@@ -18,14 +18,11 @@ func TestPeerAddress(t *testing.T) {
 		Port: 333,
 	}
 	t.Run("String", func(t *testing.T) {
-		if a.String() != "111.11.1.2:333" {
-			t.Error("invalid string")
-		}
+		assert.Equal(t, "111.11.1.2:333", a.String())
 	})
 	m := new(stun.Message)
-	if err := a.AddTo(m); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, a.AddTo(m))
+
 	m.WriteHeader()
 	decoded := new(stun.Message)
 

--- a/internal/proto/relayedaddr_test.go
+++ b/internal/proto/relayedaddr_test.go
@@ -18,14 +18,11 @@ func TestRelayedAddress(t *testing.T) {
 		Port: 333,
 	}
 	t.Run("String", func(t *testing.T) {
-		if a.String() != "111.11.1.2:333" {
-			t.Error("invalid string")
-		}
+		assert.Equal(t, "111.11.1.2:333", a.String())
 	})
 	m := new(stun.Message)
-	if err := a.AddTo(m); err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, a.AddTo(m))
+
 	m.WriteHeader()
 	decoded := new(stun.Message)
 

--- a/internal/proto/reqfamily_test.go
+++ b/internal/proto/reqfamily_test.go
@@ -4,88 +4,68 @@
 package proto
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestRequestedAddressFamily(t *testing.T) { //nolint:cyclop
+func TestRequestedAddressFamily(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
-		if RequestedFamilyIPv4.String() != "IPv4" {
-			t.Errorf("bad string %q, expected %q", RequestedFamilyIPv4,
-				"IPv4",
-			)
-		}
-		if RequestedFamilyIPv6.String() != "IPv6" {
-			t.Errorf("bad string %q, expected %q", RequestedFamilyIPv6,
-				"IPv6",
-			)
-		}
-		if RequestedAddressFamily(0x04).String() != "unknown" {
-			t.Error("should be unknown")
-		}
+		assert.Equal(t, "IPv4", RequestedFamilyIPv4.String())
+		assert.Equal(t, "IPv6", RequestedFamilyIPv6.String())
+		assert.Equal(t, "unknown", RequestedAddressFamily(0x04).String())
 	})
 	t.Run("NoAlloc", func(t *testing.T) {
 		stunMsg := &stun.Message{}
-		if wasAllocs(func() {
+		allocated := wasAllocs(func() {
 			// On stack.
 			r := RequestedFamilyIPv4
-			r.AddTo(stunMsg) //nolint
+			assert.NoError(t, r.AddTo(stunMsg))
 			stunMsg.Reset()
-		}) {
-			t.Error("Unexpected allocations")
-		}
+		})
+		assert.False(t, allocated)
 
 		requestFamilyAttr := new(RequestedAddressFamily)
 		*requestFamilyAttr = RequestedFamilyIPv4
-		if wasAllocs(func() {
+		allocated = wasAllocs(func() {
 			// On heap.
-			requestFamilyAttr.AddTo(stunMsg) //nolint
+			assert.NoError(t, requestFamilyAttr.AddTo(stunMsg))
 			stunMsg.Reset()
-		}) {
-			t.Error("Unexpected allocations")
-		}
+		})
+		assert.False(t, allocated)
 	})
 	t.Run("AddTo", func(t *testing.T) {
 		stunMsg := new(stun.Message)
 		requestFamilyAddr := RequestedFamilyIPv4
-		if err := requestFamilyAddr.AddTo(stunMsg); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, requestFamilyAddr.AddTo(stunMsg))
+
 		stunMsg.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
-			if _, err := decoded.Write(stunMsg.Raw); err != nil {
-				t.Fatal("failed to decode message:", err)
-			}
+			_, err := decoded.Write(stunMsg.Raw)
+			assert.NoError(t, err)
+
 			var req RequestedAddressFamily
-			if err := req.GetFrom(decoded); err != nil {
-				t.Fatal(err)
-			}
-			if req != requestFamilyAddr {
-				t.Errorf("Decoded %q, expected %q", req, requestFamilyAddr)
-			}
-			if wasAllocs(func() {
-				requestFamilyAddr.GetFrom(decoded) //nolint
-			}) {
-				t.Error("Unexpected allocations")
-			}
+			assert.NoError(t, req.GetFrom(decoded))
+			assert.Equal(t, requestFamilyAddr, req)
+
+			allocated := wasAllocs(func() {
+				assert.NoError(t, requestFamilyAddr.GetFrom(decoded))
+			})
+			assert.False(t, allocated)
+
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle RequestedAddressFamily
-				if err := handle.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-					t.Errorf("%v should be not found", err)
-				}
+				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+
 				m.Add(stun.AttrRequestedAddressFamily, []byte{1, 2, 3})
-				if !stun.IsAttrSizeInvalid(handle.GetFrom(m)) {
-					t.Error("IsAttrSizeInvalid should be true")
-				}
+				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))
+
 				m.Reset()
 				m.Add(stun.AttrRequestedAddressFamily, []byte{5, 0, 0, 0})
-				if handle.GetFrom(m) == nil {
-					t.Error("should error on invalid value")
-				}
+				assert.NotNil(t, handle.GetFrom(m), "should not error on unknown value")
 			})
 		})
 	})

--- a/internal/proto/rsrvtoken_test.go
+++ b/internal/proto/rsrvtoken_test.go
@@ -4,77 +4,64 @@
 package proto
 
 import (
-	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestReservationToken(t *testing.T) { //nolint:cyclop
+func TestReservationToken(t *testing.T) {
 	t.Run("NoAlloc", func(t *testing.T) {
 		stunMsg := &stun.Message{}
 		tok := make([]byte, 8)
-		if wasAllocs(func() {
+		allocated := wasAllocs(func() {
 			// On stack.
 			tk := ReservationToken(tok)
-			tk.AddTo(stunMsg) //nolint
+			assert.NoError(t, tk.AddTo(stunMsg))
 			stunMsg.Reset()
-		}) {
-			t.Error("Unexpected allocations")
-		}
+		})
+		assert.False(t, allocated)
 
 		tk := make(ReservationToken, 8)
-		if wasAllocs(func() {
+		allocated = wasAllocs(func() {
 			// On heap.
-			tk.AddTo(stunMsg) //nolint
+			assert.NoError(t, tk.AddTo(stunMsg))
 			stunMsg.Reset()
-		}) {
-			t.Error("Unexpected allocations")
-		}
+		})
+		assert.False(t, allocated)
 	})
 	t.Run("AddTo", func(t *testing.T) {
 		stunMsg := new(stun.Message)
 		tk := make(ReservationToken, 8)
 		tk[2] = 33
 		tk[7] = 1
-		if err := tk.AddTo(stunMsg); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, tk.AddTo(stunMsg))
+
 		stunMsg.WriteHeader()
 		t.Run("HandleErr", func(t *testing.T) {
 			badTk := ReservationToken{34, 45}
-			if !stun.IsAttrSizeInvalid(badTk.AddTo(stunMsg)) {
-				t.Error("IsAttrSizeInvalid should be true")
-			}
+			assert.True(t, stun.IsAttrSizeInvalid(badTk.AddTo(stunMsg)))
 		})
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
-			if _, err := decoded.Write(stunMsg.Raw); err != nil {
-				t.Fatal("failed to decode message:", err)
-			}
+			_, err := decoded.Write(stunMsg.Raw)
+			assert.NoError(t, err)
+
 			var tok ReservationToken
-			if err := tok.GetFrom(decoded); err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(tok, tk) {
-				t.Errorf("Decoded %v, expected %v", tok, tk)
-			}
-			if wasAllocs(func() {
-				tok.GetFrom(decoded) //nolint
-			}) {
-				t.Error("Unexpected allocations")
-			}
+			assert.NoError(t, tok.GetFrom(decoded))
+			assert.Equal(t, tk, tok)
+			allocated := wasAllocs(func() {
+				assert.NoError(t, tok.GetFrom(decoded))
+			})
+			assert.False(t, allocated)
+
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle ReservationToken
-				if err := handle.GetFrom(m); !errors.Is(err, stun.ErrAttributeNotFound) {
-					t.Errorf("%v should be not found", err)
-				}
+				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+
 				m.Add(stun.AttrReservationToken, []byte{1, 2, 3})
-				if !stun.IsAttrSizeInvalid(handle.GetFrom(m)) {
-					t.Error("IsAttrSizeInvalid should be true")
-				}
+				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))
 			})
 		})
 	})

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -26,17 +26,13 @@ func TestAllocationLifeTime(t *testing.T) {
 
 		m := &stun.Message{}
 		lifetimeDuration := allocationLifeTime(m)
-
-		if lifetimeDuration != proto.DefaultLifetime {
-			t.Errorf("Allocation lifetime should be default time duration")
-		}
-
+		assert.Equal(t, proto.DefaultLifetime, lifetimeDuration,
+			"Allocation lifetime should be default time duration")
 		assert.NoError(t, lifetime.AddTo(m))
 
 		lifetimeDuration = allocationLifeTime(m)
-		if lifetimeDuration != lifetime.Duration {
-			t.Errorf("Expect lifetimeDuration is %s, but %s", lifetime.Duration, lifetimeDuration)
-		}
+		assert.Equal(t, lifetime.Duration, lifetimeDuration,
+			"Allocation lifetime should be equal to the one set in the message")
 	})
 
 	// If lifetime is bigger than maximumLifetime
@@ -49,9 +45,7 @@ func TestAllocationLifeTime(t *testing.T) {
 		_ = lifetime.AddTo(m2)
 
 		lifetimeDuration := allocationLifeTime(m2)
-		if lifetimeDuration != proto.DefaultLifetime {
-			t.Errorf("Expect lifetimeDuration is %s, but %s", proto.DefaultLifetime, lifetimeDuration)
-		}
+		assert.Equal(t, proto.DefaultLifetime, lifetimeDuration)
 	})
 
 	t.Run("DeletionZeroLifetime", func(t *testing.T) {

--- a/lt_cred_test.go
+++ b/lt_cred_test.go
@@ -21,9 +21,7 @@ func TestLtCredMech(t *testing.T) {
 
 	expectedPassword := "Tpz/nKkyvX/vMSLKvL4sbtBt8Vs=" //nolint:gosec
 	actualPassword, _ := longTermCredentials(username, sharedSecret)
-	if expectedPassword != actualPassword {
-		t.Errorf("Expected %q, got %q", expectedPassword, actualPassword)
-	}
+	assert.Equal(t, expectedPassword, actualPassword)
 }
 
 func TestNewLongTermAuthHandler(t *testing.T) {


### PR DESCRIPTION
#### Description

Update lint rules to forbid the use of direct testing.T helpers. Removed a few `//nolint:cyclop` only by consequence of using assert. 🦆 

https://github.com/pion/.goassets/pull/222

Reference issue

N/A
