### PR TITLE
Handle nil TURN addresses in retransmissions

### DIFF
--- a/client.go
+++ b/client.go
@@ -662,7 +662,7 @@ func (c *Client) onRtxTimeout(trKey string, nRtx int) {
 	}
 
 	c.log.Tracef("Retransmitting transaction %s to %s (nRtx=%d)",
-		trKey, tr.To.String(), nRtx)
+		trKey, tr.To, nRtx)
 	_, err := c.conn.WriteTo(tr.Raw, tr.To)
 	if err != nil {
 		c.trMap.Delete(trKey)


### PR DESCRIPTION
#### Description
Handle nil TURN addresses in retransmissions

In certain scenarios, the `To` field of a transaction can be nil (nil TURN address of the `Client`).