### PR TITLE
Lower priority of per-packet error message

### DIFF
--- a/server.go
+++ b/server.go
@@ -233,7 +233,7 @@ func (s *Server) readLoop(conn net.PacketConn, allocationManager *allocation.Man
 			ChannelBindTimeout: s.channelBindTimeout,
 			NonceHash:          s.nonceHash,
 		}); err != nil {
-			s.log.Errorf("Failed to handle datagram: %v", err)
+			s.log.Debugf("Failed to handle datagram: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
The error message "Failed to handle datagram" is generated for
each received packet; it can therefore be used by an attacker to
fill the server's logs by sending a burst of incorrect packets.

Lower its priority to debug.

Fixes #197 and jech/galene#271.
