### PR TITLE
RFC: Add a configurable sized nonce generator

### DIFF
--- a/internal/server/base36.go
+++ b/internal/server/base36.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"math/big"
+	"strings"
+)
+
+// Base36 alphabet for encoding.
+const base36Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// EncodeBase36 converts bytes to base36 string using big.Int for arbitrary length.
+func encodeBase36(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	num := new(big.Int).SetBytes(data)
+	if num.Cmp(big.NewInt(0)) == 0 {
+		return "0"
+	}
+
+	base := big.NewInt(36)
+	buf := make([]byte, 0, len(data)*2)
+	remainder := new(big.Int)
+	for num.Cmp(big.NewInt(0)) > 0 {
+		num.DivMod(num, base, remainder)
+		buf = append(buf, base36Alphabet[remainder.Int64()])
+	}
+
+	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
+		buf[i], buf[j] = buf[j], buf[i]
+	}
+
+	return string(buf)
+}
+
+// DecodeBase36 converts base36 string back to bytes using big.Int for arbitrary length.
+func decodeBase36(encoded string) []byte {
+	if encoded == "" {
+		return []byte{}
+	}
+
+	if encoded == "0" {
+		return []byte{0}
+	}
+
+	num := big.NewInt(0)
+	base := big.NewInt(36)
+
+	for _, char := range strings.ToUpper(encoded) {
+		digit := strings.IndexRune(base36Alphabet, char)
+		if digit == -1 {
+			return nil
+		}
+		num.Mul(num, base)
+		num.Add(num, big.NewInt(int64(digit)))
+	}
+
+	return num.Bytes()
+}

--- a/internal/server/base36_test.go
+++ b/internal/server/base36_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBase36(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    []byte{},
+			expected: "",
+		},
+		{
+			name:     "zero byte",
+			input:    []byte{0},
+			expected: "0",
+		},
+		{
+			name:     "single byte - 1",
+			input:    []byte{1},
+			expected: "1",
+		},
+		{
+			name:     "single byte - 35",
+			input:    []byte{35},
+			expected: "Z",
+		},
+		{
+			name:     "single byte - 36",
+			input:    []byte{36},
+			expected: "10",
+		},
+		{
+			name:     "single byte - 255",
+			input:    []byte{255},
+			expected: "73",
+		},
+		{
+			name:     "multiple bytes - hello",
+			input:    []byte("hello"),
+			expected: "5PZCSZU7",
+		},
+		{
+			name:     "multiple bytes - test",
+			input:    []byte("test"),
+			expected: "WANEK4",
+		},
+		{
+			name:     "complex text",
+			input:    []byte("long_complexTeXT wITH_space"),
+			expected: "6XMY2Y5EIZEF867E5LXYHH2OVVURC1A852VPOAZP0L",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := encodeBase36(tt.input)
+			assert.Equal(t, tt.expected, encoded)
+			decoded := decodeBase36(encoded)
+			assert.Equal(t, tt.input, decoded)
+			decoded = decodeBase36(strings.ToLower(encoded))
+			assert.Equal(t, tt.input, decoded)
+		})
+	}
+}

--- a/internal/server/nonce.go
+++ b/internal/server/nonce.go
@@ -20,7 +20,7 @@ const (
 )
 
 // NewNonceHash creates a NonceHash.
-func NewNonceHash() (*NonceHash, error) {
+func NewNonceHash() (NonceManager, error) {
 	key := make([]byte, nonceKeyLength)
 	if _, err := rand.Read(key); err != nil {
 		return nil, err

--- a/internal/server/nonce_test.go
+++ b/internal/server/nonce_test.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,5 +17,15 @@ func TestNonceHash(t *testing.T) {
 		nonce, err := h.Generate()
 		assert.NoError(t, err)
 		assert.NoError(t, h.Validate(nonce))
+	})
+
+	t.Run("generated short hashes validate", func(t *testing.T) {
+		for i := 1; i <= 8; i++ {
+			h, err := NewShortNonceHash(i * 4)
+			assert.NoError(t, err, fmt.Sprintf("nonce init at size %d", i*4))
+			nonce, err := h.Generate()
+			assert.NoError(t, err, fmt.Sprintf("generate at size %d", i*4))
+			assert.NoError(t, h.Validate(nonce), fmt.Sprintf("decode at size %d", i*4))
+		}
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,7 @@ type Request struct {
 
 	// Server State
 	AllocationManager *allocation.Manager
-	NonceHash         *NonceHash
+	NonceHash         NonceManager
 
 	// User Configuration
 	AuthHandler func(username string, realm string, srcAddr net.Addr) (key []byte, ok bool)

--- a/internal/server/short_nonce.go
+++ b/internal/server/short_nonce.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// NonceManager interface that both implementations satisfy.
+type NonceManager interface {
+	Generate() (string, error)
+	Validate(nonce string) error
+}
+
+const (
+	shortNonceLifetime     = time.Hour // Same as original
+	shortNonceKeyLength    = 64        // Same as original
+	shortNonceTimestampLen = 4         // 6 bytes for timestamp (minutes) - optimal size
+	shortNonceMinHMACLen   = 2         // Minimum HMAC length for security
+	shortNonceMaxHMACLen   = 32        // Maximum HMAC length (full SHA256)
+	defaultNonceHMACLen    = 12        // Default HMAC length
+)
+
+// NewShortNonceHash creates a ShortNonceHash. The hmacLen argument specifies the number of HMAC
+// bytes to include (2-32 bytes).  The total nonce size will be 4 + hmacLen bytes, default hmaclen
+// is 12 bytes. The 4 bytes timestamp gives about ~8000 years before nonces would start to repeat
+// (safe until year 10,135).
+func NewShortNonceHash(hmacLen int) (NonceManager, error) {
+	if hmacLen == 0 {
+		hmacLen = defaultNonceHMACLen
+	}
+
+	if hmacLen < shortNonceMinHMACLen || hmacLen > shortNonceMaxHMACLen {
+		return nil, errFailedToGenerateNonce
+	}
+
+	key := make([]byte, shortNonceKeyLength)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToGenerateNonce, err)
+	}
+
+	return &ShortNonceHash{
+		key:     key,
+		hmacLen: hmacLen,
+	}, nil
+}
+
+// ShortNonceHash is used to create and verify short nonces.
+type ShortNonceHash struct {
+	key     []byte
+	hmacLen int
+}
+
+// Generate a short nonce (4 + hmacLen bytes encoded as base36).
+func (s *ShortNonceHash) Generate() (string, error) {
+	timestampMinutes := time.Now().Unix() / 60
+
+	// Convert to bytes and trim to 4 bytes.  This safely handles the conversion since we know
+	// current values fit in 4 bytes until year 10,135.
+	timestampBytes8 := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestampBytes8, uint64(timestampMinutes)) // nolint:gosec // G115
+	timestampBytes := timestampBytes8[4:]
+
+	hash := hmac.New(sha256.New, s.key)
+	if _, err := hash.Write(timestampBytes); err != nil {
+		return "", fmt.Errorf("%w: %w", errFailedToGenerateNonce, err)
+	}
+	fullHMAC := hash.Sum(nil)
+	truncatedHMAC := fullHMAC[:s.hmacLen]
+
+	totalLen := shortNonceTimestampLen + s.hmacLen
+	nonce := make([]byte, totalLen)
+	copy(nonce[:shortNonceTimestampLen], timestampBytes)
+	copy(nonce[shortNonceTimestampLen:], truncatedHMAC)
+
+	return encodeBase36(nonce), nil
+}
+
+// Validate checks that nonce is signed and is not expired.
+func (s *ShortNonceHash) Validate(nonce string) error {
+	nonceBytes := decodeBase36(nonce)
+	if nonceBytes == nil {
+		return errInvalidNonce
+	}
+
+	expectedLen := shortNonceTimestampLen + s.hmacLen
+	if len(nonceBytes) != expectedLen {
+		// Pad with leadnign zeros if leading zeros were stripped during encoding/decoding.
+		if len(nonceBytes) < expectedLen {
+			padded := make([]byte, expectedLen)
+			copy(padded[expectedLen-len(nonceBytes):], nonceBytes)
+			nonceBytes = padded
+		} else {
+			return errInvalidNonce
+		}
+	}
+
+	timestampBytes := nonceBytes[:shortNonceTimestampLen]
+	receivedHMAC := nonceBytes[shortNonceTimestampLen:]
+	timestampMinutes := int64(binary.BigEndian.Uint32(timestampBytes))
+
+	// Check if nonce is expired (older than 1 hour).
+	currentMinutes := time.Now().Unix() / 60
+	if currentMinutes < timestampMinutes {
+		return errInvalidNonce
+	}
+
+	ageMinutes := currentMinutes - timestampMinutes
+	if ageMinutes > 60 {
+		return errInvalidNonce
+	}
+
+	// Recompute HMAC and compare.
+	hash := hmac.New(sha256.New, s.key)
+	if _, err := hash.Write(timestampBytes); err != nil {
+		return fmt.Errorf("%w: %w", errInvalidNonce, err)
+	}
+
+	expectedHMAC := hash.Sum(nil)[:s.hmacLen]
+
+	if !hmac.Equal(receivedHMAC, expectedHMAC) {
+		return errInvalidNonce
+	}
+
+	return nil
+}

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -73,7 +73,7 @@ func TestAllocationLifeTime(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		nonceHash, err := NewNonceHash()
+		nonceHash, err := NewShortNonceHash(0)
 		assert.NoError(t, err)
 		staticKey, err := nonceHash.Generate()
 		assert.NoError(t, err)

--- a/server.go
+++ b/server.go
@@ -27,7 +27,7 @@ type Server struct {
 	quotaHandler       QuotaHandler
 	realm              string
 	channelBindTimeout time.Duration
-	nonceHash          *server.NonceHash
+	nonceHash          server.NonceManager
 	eventHandler       EventHandler
 
 	packetConnConfigs  []PacketConnConfig
@@ -52,7 +52,7 @@ func NewServer(config ServerConfig) (*Server, error) { //nolint:gocognit,cyclop
 		mtu = config.InboundMTU
 	}
 
-	nonceHash, err := server.NewNonceHash()
+	nonceHash, err := server.NewShortNonceHash(0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The aim of This PR is to reduce the amplification factor in reflection attacks against our TURN servers. To summarize, it seems that recently TURN servers were targeted in large-scale reflection+amplification attacks that abuse the TURN allocation request/response mechanism. See [background](https://medium.com/@ggarciabernardo/reflection-amplification-attacks-abusing-turn-servers-743803828593) and the corresponding [coturn](https://github.com/coturn/coturn/issues/1687) issue.

The default amplification factor, the ratio of the size of the initial Allocation Response message reflected by the server to the victim IP compared to the  size of the initial Allocation Request sent by the malevolent client, is currently about 2.2x for pion/turn. This makes pion TURN servers an appealing target for reflection+amplification attacks. Luckily we do not generate the SOFTWARE attribute by default and by using a 2 byte REALM we can go down to about 2.1x without touching the code. The rest, however, is mostly caused by the 80 byte nonces pion/turn uses.

This PR makes the nonce size configurable and removes some redundancy by using a shorter 4-byte timestamp at one minute precision and a more efficient base36 encoder/decoder. The default is 4 bytes timestamp + 12 byte truncated HMAC hash, which gives about 24 bytes long nonces including the overhead of base36 encoding and padding.

**Warning:** this PR has not been tested against real browsers. The pion/turn TURN client seems to handle the smaller nonces reliably though.