### PR TITLE
Fix error reporting in SendIndication handler

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -363,8 +363,10 @@ func handleSendIndication(req Request, stunMsg *stun.Message) error {
 	}
 
 	l, err := alloc.RelaySocket.WriteTo(dataAttr, msgDst)
-	if l != len(dataAttr) {
-		return fmt.Errorf("%w %d != %d (expected) err: %v", errShortWrite, l, len(dataAttr), err) //nolint:errorlint
+	if err != nil {
+		return fmt.Errorf("%w: %s", errFailedWriteSocket, err.Error())
+	} else if l != len(dataAttr) {
+		return fmt.Errorf("%w %d != %d (expected)", errShortWrite, l, len(dataAttr))
 	}
 
 	return err


### PR DESCRIPTION
Fix misleading error reporting when a SendIndication message cannot be relayed. Same pattern also used [here](https://github.com/pion/turn/blob/189f4304be550e7cd0aeab443539f7ba6c13a2ad/internal/server/turn.go#L451).