### PR TITLE
Handle stale nonces in ChannelBind, and add timer to renew bindings

### DIFF
--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -61,6 +61,12 @@ func (b *binding) refreshedAt() time.Time {
 	return b._refreshedAt
 }
 
+func (b *binding) ok() bool {
+	state := b.state()
+
+	return state == bindingStateReady || state == bindingStateRefresh
+}
+
 // Thread-safe binding map.
 type bindingManager struct {
 	chanMap map[uint16]*binding
@@ -158,4 +164,16 @@ func (mgr *bindingManager) size() int {
 	defer mgr.mutex.RUnlock()
 
 	return len(mgr.chanMap)
+}
+
+func (mgr *bindingManager) all() []*binding {
+	mgr.mutex.RLock()
+	defer mgr.mutex.RUnlock()
+
+	list := make([]*binding, 0, len(mgr.chanMap))
+	for _, b := range mgr.chanMap {
+		list = append(list, b)
+	}
+
+	return list
 }

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -46,6 +46,13 @@ func TestBindingManager(t *testing.T) {
 			assert.Equal(t, b0, b2, "should match")
 		}
 
+		all := bm.all()
+		for _, b := range all {
+			found, ok := bm.findByNumber(b.number)
+			assert.True(t, ok, "should exist")
+			assert.Equal(t, b, found, "should match")
+		}
+		assert.Equal(t, count, len(all), "should match")
 		assert.Equal(t, count, bm.size(), "should match")
 		assert.Equal(t, count, len(bm.addrMap), "should match")
 
@@ -60,6 +67,7 @@ func TestBindingManager(t *testing.T) {
 
 		assert.Equal(t, 0, bm.size(), "should match")
 		assert.Equal(t, 0, len(bm.addrMap), "should match")
+		assert.Equal(t, 0, len(bm.all()), "should match")
 	})
 
 	t.Run("failure test", func(t *testing.T) {

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -7,36 +7,143 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
+	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUDPConn(t *testing.T) {
-	t.Run("bind()", func(t *testing.T) {
-		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
-				return TransactionResult{}, errFake
-			},
-		}
-
-		bm := newBindingManager()
-		b := bm.create(&net.UDPAddr{
-			IP:   net.ParseIP("127.0.0.1"),
-			Port: 1234,
-		})
-
-		conn := UDPConn{
+	makeConn := func(client *mockClient, bm *bindingManager) UDPConn {
+		return UDPConn{
 			allocation: allocation{
 				client: client,
+				log:    logging.NewDefaultLoggerFactory().NewLogger("test"),
 			},
 			bindingMgr: bm,
 		}
+	}
 
-		err := conn.bind(b)
-		assert.Error(t, err, "should fail")
-		assert.Equal(t, 0, len(bm.chanMap), "should be 0")
-		assert.Equal(t, 0, len(bm.addrMap), "should be 0")
+	staleNonceMsg := func() *stun.Message {
+		return stun.MustBuild(
+			stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
+			stun.CodeStaleNonce,
+			stun.NewNonce("new-nonce-123"),
+		)
+	}
+
+	t.Run("maybeBind()", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			initialState  bindingState
+			interimState  bindingState
+			finalState    bindingState
+			pastInterval  bool
+			shouldSucceed bool
+		}{
+			{"idle -> request -> ready", bindingStateIdle, bindingStateRequest, bindingStateReady, false, true},
+			{"idle -> request -> failed", bindingStateIdle, bindingStateRequest, bindingStateFailed, false, false},
+			{"ready (stale) -> refresh -> ready", bindingStateReady, bindingStateRefresh, bindingStateReady, true, true},
+			{"ready (stale) -> refresh -> failed", bindingStateReady, bindingStateRefresh, bindingStateFailed, true, false},
+
+			// Noop cases:
+			{"ready (noop)", bindingStateReady, bindingStateReady, bindingStateReady, false, true},
+			{"request (noop)", bindingStateRequest, bindingStateRequest, bindingStateRequest, false, true},
+			{"refresh (noop)", bindingStateRefresh, bindingStateRefresh, bindingStateRefresh, false, true},
+			{"failed (noop)", bindingStateFailed, bindingStateFailed, bindingStateFailed, false, true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				unblock := make(chan struct{})
+
+				bm := newBindingManager()
+				bound := bm.create(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234})
+				conn := makeConn(&mockClient{
+					performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+						<-unblock
+						if tt.shouldSucceed {
+							return TransactionResult{Msg: new(stun.Message)}, nil
+						}
+
+						return TransactionResult{Msg: staleNonceMsg()}, nil
+					},
+				}, bm)
+
+				bound.setState(tt.initialState)
+				if tt.pastInterval {
+					bound.setRefreshedAt(time.Now().Add(-(bindingRefreshInterval + 1*time.Minute)))
+				}
+
+				conn.maybeBind(bound)
+				assert.Equal(t, tt.interimState, bound.state())
+
+				// Release barrier so inner bind() can move forward.
+				close(unblock)
+
+				assert.Eventually(t, func() bool {
+					return bound.state() == tt.finalState
+				}, 5*time.Second, 10*time.Millisecond)
+			})
+		}
+	})
+
+	t.Run("bind()", func(t *testing.T) {
+		tests := []struct {
+			name                 string
+			transactionFn        func(*stun.Message, net.Addr, bool) (TransactionResult, error)
+			expectErr            error
+			expectBindingDeleted bool
+			expectNonceChanged   bool
+		}{
+			{
+				name: "PerformTransaction returns error",
+				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+					return TransactionResult{}, errFake
+				},
+				expectErr:            errFake,
+				expectBindingDeleted: true,
+			},
+			{
+				name: "ErrorResponse with CodeStaleNonce triggers nonce update",
+				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+					return TransactionResult{Msg: staleNonceMsg()}, nil
+				},
+				expectErr:          errTryAgain,
+				expectNonceChanged: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				bm := newBindingManager()
+				bound := bm.create(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234})
+				conn := makeConn(&mockClient{performTransaction: tt.transactionFn}, bm)
+
+				nonceT0 := conn.nonce()
+
+				err := conn.bind(bound)
+				if tt.expectErr == nil {
+					assert.NoError(t, err)
+				} else {
+					assert.ErrorIs(t, err, tt.expectErr)
+				}
+
+				if tt.expectBindingDeleted {
+					assert.Empty(t, bm.chanMap)
+					assert.Empty(t, bm.addrMap)
+				}
+
+				nonceT1 := conn.nonce()
+				if tt.expectNonceChanged {
+					assert.NotEqual(t, nonceT0, nonceT1, "should change")
+					assert.NotEmpty(t, nonceT1, "should be non-empty")
+				} else {
+					assert.Equal(t, nonceT0, nonceT1, "should remain unchanged")
+				}
+			})
+		}
 	})
 
 	t.Run("WriteTo()", func(t *testing.T) {


### PR DESCRIPTION
#### Description
While the issue was originally about discussing why turn would fall back to indications after a while in a long-lived connection, tracing down into the code revealed stale nonces aren't being handled whatsoever by the `bind()` method, causing channel bindings to time out and transition to failed state, forcing the connection to go 2-way over indications for the rest of its life.

This PR adds code handling stale nonce errors to ChannelBind requests. It also decouples logic related to binding lifecycle (initial binding & binding renewal) from `WriteTo` by carving out code into a timer, similar to the way perms and allocs work.

#### Reference issue
Fixes #471
