### PR TITLE
Fix linting issues for IPv6 compatibility and deprecated comment

### DIFF
--- a/examples/turn-client/tcp/main.go
+++ b/examples/turn-client/tcp/main.go
@@ -33,7 +33,7 @@ func main() { //nolint:cyclop
 	}
 
 	// Dial TURN Server
-	turnServerAddr := fmt.Sprintf("%s:%d", *host, *port)
+	turnServerAddr := net.JoinHostPort(*host, fmt.Sprintf("%d", *port))
 	conn, err := net.Dial("tcp", turnServerAddr) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to connect to TURN server: %s", err)

--- a/internal/proto/dontfrag.go
+++ b/internal/proto/dontfrag.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DontFragmentAttr is a deprecated alias for DontFragment
+//
 // Deprecated: Please use DontFragment.
 type DontFragmentAttr = DontFragment
 


### PR DESCRIPTION
## Summary
This PR addresses two linting errors identified by golangci-lint v2.7.2:

- Fix IPv6 address formatting in TCP client example
- Fix deprecated comment formatting in DontFragmentAttr

## Changes

### 1. IPv6 Address Compatibility (`examples/turn-client/tcp/main.go`)
- **Issue**: `govet` linter flagged `fmt.Sprintf("%s:%d", host, port)` as incompatible with IPv6
- **Fix**: Replaced with `net.JoinHostPort()` which properly formats both IPv4 and IPv6 addresses
- **Impact**: IPv6 addresses will now be correctly formatted with brackets (e.g., `[2001:db8::1]:3478`)

### 2. Deprecated Comment Formatting (`internal/proto/dontfrag.go`)
- **Issue**: `gocritic` linter requires deprecation notices in a dedicated paragraph
- **Fix**: Added blank line to separate deprecation notice from description
- **Impact**: Follows Go documentation conventions and improves tooling compatibility

## Test Plan
- [x] All existing tests pass: `go test ./...`
- [x] Race detection passes: `go test -race ./...`
- [x] Linting passes: `golangci-lint run` (0 issues)
- [x] Code coverage maintained at 83.3%

Both changes maintain backward compatibility and improve code quality.