### PR TITLE
Check username for existing Allocations

### DIFF
--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -69,6 +69,16 @@ func (m *Manager) GetAllocation(fiveTuple *FiveTuple) *Allocation {
 	return m.allocations[fiveTuple.Fingerprint()]
 }
 
+// GetAllocationForUsername fetches the allocation matching the passed FiveTuple and Username.
+func (m *Manager) GetAllocationForUsername(fiveTuple *FiveTuple, username string) *Allocation {
+	allocation := m.GetAllocation(fiveTuple)
+	if allocation != nil && allocation.username == username {
+		return allocation
+	}
+
+	return nil
+}
+
 // AllocationCount returns the number of existing allocations.
 func (m *Manager) AllocationCount() int {
 	m.lock.RLock()

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -95,7 +95,7 @@ func TestAllocationLifeTime(t *testing.T) {
 
 		fiveTuple := &allocation.FiveTuple{SrcAddr: req.SrcAddr, DstAddr: req.Conn.LocalAddr(), Protocol: allocation.UDP}
 
-		_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, 0, time.Hour, "", "")
+		_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, 0, time.Hour, "test", "")
 		assert.NoError(t, err)
 
 		assert.NotNil(t, req.AllocationManager.GetAllocation(fiveTuple))
@@ -105,7 +105,7 @@ func TestAllocationLifeTime(t *testing.T) {
 		assert.NoError(t, (stun.MessageIntegrity(staticKey)).AddTo(m))
 		assert.NoError(t, (stun.Nonce(staticKey)).AddTo(m))
 		assert.NoError(t, (stun.Realm(staticKey)).AddTo(m))
-		assert.NoError(t, (stun.Username(staticKey)).AddTo(m))
+		assert.NoError(t, (stun.Username("test")).AddTo(m))
 
 		assert.NoError(t, handleRefreshRequest(req, m))
 		assert.Nil(t, req.AllocationManager.GetAllocation(fiveTuple))


### PR DESCRIPTION
RFC 5766 section 4 states the following

   All requests after the initial Allocate must use the same username as
   that used to create the allocation, to prevent attackers from
   hijacking the client's allocation

Resolves #120
