### PR TITLE
serlization for allocation 

### DIFF
--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -7,6 +7,7 @@
 package allocation
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -27,7 +28,7 @@ func TestAllocation_MarshalUnmarshalBinary(t *testing.T) {
 			DstAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678},
 		}
 
-		turnSocket, err := net.ListenPacket("udp4", "127.0.0.1:0")
+		turnSocket, err := (&net.ListenConfig{}).ListenPacket(context.Background(), "udp4", "127.0.0.1:0")
 		assert.NoError(t, err)
 		defer func() {
 			assert.NoError(t, turnSocket.Close())
@@ -52,7 +53,10 @@ func TestAllocation_MarshalUnmarshalBinary(t *testing.T) {
 
 		chanAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3000")
 		assert.NoError(t, err)
-		err = alloc.AddChannelBind(NewChannelBind(proto.MinChannelNumber, chanAddr, log), proto.DefaultLifetime, DefaultPermissionTimeout)
+		err = alloc.AddChannelBind(NewChannelBind(proto.MinChannelNumber, chanAddr, log),
+			proto.DefaultLifetime,
+			DefaultPermissionTimeout,
+		)
 		assert.NoError(t, err)
 
 		data, err := alloc.MarshalBinary()
@@ -248,7 +252,7 @@ func TestAllocationRefresh(t *testing.T) {
 func TestAllocationClose(t *testing.T) {
 	network := "udp"
 
-	l, err := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+	l, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, "0.0.0.0:0")
 	assert.NoError(t, err)
 
 	alloc := NewAllocation(nil, nil, EventHandler{}, nil)
@@ -276,11 +280,11 @@ func TestPacketHandler(t *testing.T) {
 	manager, _ := newTestManager()
 
 	// TURN server initialization
-	turnSocket, err := net.ListenPacket(network, "127.0.0.1:0") // nolint: noctx
+	turnSocket, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, "127.0.0.1:0")
 	assert.NoError(t, err)
 
 	// Client listener initialization
-	clientListener, err := net.ListenPacket(network, "127.0.0.1:0") // nolint: noctx
+	clientListener, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, "127.0.0.1:0")
 	assert.NoError(t, err)
 
 	dataCh := make(chan []byte)
@@ -304,10 +308,10 @@ func TestPacketHandler(t *testing.T) {
 
 	assert.NoError(t, err, "should succeed")
 
-	peerListener1, err := net.ListenPacket(network, "127.0.0.1:0") // nolint: noctx
+	peerListener1, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, "127.0.0.1:0")
 	assert.NoError(t, err)
 
-	peerListener2, err := net.ListenPacket(network, "127.0.0.1:0") // nolint: noctx
+	peerListener2, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, "127.0.0.1:0")
 	assert.NoError(t, err)
 
 	// Add permission with peer1 address

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -13,11 +13,67 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/turn/v4/internal/ipnet"
 	"github.com/pion/turn/v4/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAllocation_MarshalUnmarshalBinary(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		fiveTuple := &FiveTuple{
+			SrcAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+			DstAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678},
+		}
+
+		turnSocket, err := net.ListenPacket("udp4", "127.0.0.1:0")
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, turnSocket.Close())
+		}()
+
+		loggerFactory := logging.NewDefaultLoggerFactory()
+		log := loggerFactory.NewLogger("test")
+
+		alloc := NewAllocation(turnSocket, fiveTuple, EventHandler{}, log)
+		alloc.Protocol = UDP
+		alloc.username = "user"
+		alloc.realm = "realm"
+		alloc.expiresAt = time.Now().Add(time.Minute).Round(time.Second)
+
+		relayAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:1000")
+		assert.NoError(t, err)
+		alloc.RelayAddr = relayAddr
+
+		permAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:2000")
+		assert.NoError(t, err)
+		alloc.AddPermission(NewPermission(permAddr, log, DefaultPermissionTimeout))
+
+		chanAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3000")
+		assert.NoError(t, err)
+		err = alloc.AddChannelBind(NewChannelBind(proto.MinChannelNumber, chanAddr, log), proto.DefaultLifetime, DefaultPermissionTimeout)
+		assert.NoError(t, err)
+
+		data, err := alloc.MarshalBinary()
+		assert.NoError(t, err)
+
+		newAlloc := NewAllocation(nil, &FiveTuple{}, EventHandler{}, log)
+		// Initialize lifetimeTimer before unmarshaling, as Refresh expects it.
+		// Use a dummy long-running timer so it doesn't fire during the test.
+		newAlloc.lifetimeTimer = time.AfterFunc(time.Hour, func() {})
+		err = newAlloc.UnmarshalBinary(data)
+		assert.NoError(t, err)
+		assert.Equal(t, alloc.fiveTuple.String(), newAlloc.fiveTuple.String())
+		assert.Equal(t, alloc.Protocol, newAlloc.Protocol)
+		assert.Equal(t, alloc.username, newAlloc.username)
+		assert.Equal(t, alloc.realm, newAlloc.realm)
+		assert.True(t, alloc.expiresAt.Equal(newAlloc.expiresAt))
+		assert.Equal(t, alloc.RelayAddr.String(), newAlloc.RelayAddr.String())
+		assert.Equal(t, len(alloc.permissions), len(newAlloc.permissions))
+		assert.Equal(t, len(alloc.channelBindings), len(newAlloc.channelBindings))
+	})
+}
 
 func TestGetPermission(t *testing.T) {
 	alloc := NewAllocation(nil, nil, EventHandler{}, nil)

--- a/internal/allocation/channel_bind.go
+++ b/internal/allocation/channel_bind.go
@@ -4,7 +4,11 @@
 package allocation
 
 import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/pion/logging"
@@ -20,6 +24,65 @@ type ChannelBind struct {
 	allocation    *Allocation
 	lifetimeTimer *time.Timer
 	log           logging.LeveledLogger
+	expiresAt     time.Time
+}
+type serializedChannelBind struct {
+	Peer      string
+	Number    proto.ChannelNumber
+	Protocol  Protocol
+	ExpiresAt time.Time
+}
+
+func (c *ChannelBind) serialize() *serializedChannelBind {
+	return &serializedChannelBind{
+		Peer:      c.Peer.String(),
+		Number:    c.Number,
+		Protocol:  c.allocation.Protocol,
+		ExpiresAt: c.expiresAt,
+	}
+}
+func (c *ChannelBind) deserialize(s *serializedChannelBind) error {
+	network := strings.ToLower(s.Protocol.String())
+	switch s.Protocol {
+	case UDP:
+		peerAddr, err := net.ResolveUDPAddr(network, s.Peer)
+		if err != nil {
+			return err
+		}
+		c.Peer = peerAddr
+	case TCP:
+		peerAddr, err := net.ResolveTCPAddr(network, s.Peer)
+		if err != nil {
+			return err
+		}
+		c.Peer = peerAddr
+	default:
+		return fmt.Errorf("Unsupported protocol %v", s.Protocol)
+	}
+	c.expiresAt = s.ExpiresAt
+	c.Number = s.Number
+	remaningTime := time.Until(s.ExpiresAt)
+	if remaningTime > 0 {
+		c.start(remaningTime)
+	}
+	return nil
+}
+func (c *ChannelBind) MarshalBinary() ([]byte, error) {
+	serialized := c.serialize()
+	var buf bytes.Buffer
+	var enc = gob.NewEncoder(&buf)
+	if err := enc.Encode(serialized); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+func (c *ChannelBind) UnmarshalBinary(data []byte) error {
+	var serialized serializedChannelBind
+	dec := gob.NewDecoder(bytes.NewBuffer(data))
+	if err := dec.Decode(&serialized); err != nil {
+		return err
+	}
+	return c.deserialize(&serialized)
 }
 
 // NewChannelBind creates a new ChannelBind.
@@ -32,6 +95,7 @@ func NewChannelBind(number proto.ChannelNumber, peer net.Addr, log logging.Level
 }
 
 func (c *ChannelBind) start(lifetime time.Duration) {
+	c.expiresAt = time.Now().Add(lifetime)
 	c.lifetimeTimer = time.AfterFunc(lifetime, func() {
 		if !c.allocation.RemoveChannelBind(c.Number) {
 			c.log.Errorf("Failed to remove ChannelBind for %v %x %v", c.Number, c.Peer, c.allocation.fiveTuple)
@@ -40,7 +104,14 @@ func (c *ChannelBind) start(lifetime time.Duration) {
 }
 
 func (c *ChannelBind) refresh(lifetime time.Duration) {
+	c.expiresAt = time.Now().Add(lifetime)
 	if !c.lifetimeTimer.Reset(lifetime) {
 		c.log.Errorf("Failed to reset ChannelBind timer for %v %x %v", c.Number, c.Peer, c.allocation.fiveTuple)
+	}
+}
+func (c *ChannelBind) stop() {
+	if c.lifetimeTimer != nil {
+		c.expiresAt = time.Now()
+		c.lifetimeTimer.Stop()
 	}
 }

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -57,7 +57,9 @@ func TestChannelBind_MarshalUnmarshalBinary(t *testing.T) {
 		SrcAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
 		DstAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678},
 	}
-	mockAllocation := NewAllocation(nil, mockFiveTuple, EventHandler{}, logging.NewDefaultLeveledLoggerForScope("test", logging.LogLevelTrace, nil))
+	mockAllocation := NewAllocation(nil, mockFiveTuple, EventHandler{},
+		logging.NewDefaultLeveledLoggerForScope("test", logging.LogLevelTrace, nil),
+	)
 
 	t.Run("UDP", func(t *testing.T) {
 		addr, _ := net.ResolveUDPAddr("udp", "192.168.1.100:1000")
@@ -78,7 +80,13 @@ func TestChannelBind_MarshalUnmarshalBinary(t *testing.T) {
 		assert.Equal(t, original.Peer.String(), unmarshaled.Peer.String())
 		assert.Equal(t, original.Number, unmarshaled.Number)
 		assert.NotNil(t, unmarshaled.lifetimeTimer, "lifetimeTimer should be restarted after unmarshal")
-		assert.WithinDuration(t, original.expiresAt, unmarshaled.expiresAt, 10*time.Millisecond, "expiresAt should be preserved")
+		assert.WithinDuration(
+			t,
+			original.expiresAt,
+			unmarshaled.expiresAt,
+			10*time.Millisecond,
+			"expiresAt should be preserved",
+		)
 
 		unmarshaled.lifetimeTimer.Stop()
 	})

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/logging"
 	"github.com/pion/turn/v4/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
@@ -48,4 +49,37 @@ func newChannelBind(lifetime time.Duration) *ChannelBind {
 	_ = a.AddChannelBind(c, lifetime, DefaultPermissionTimeout)
 
 	return c
+}
+
+func TestChannelBind_MarshalUnmarshalBinary(t *testing.T) {
+	mockFiveTuple := &FiveTuple{
+		Protocol: UDP,
+		SrcAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+		DstAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678},
+	}
+	mockAllocation := NewAllocation(nil, mockFiveTuple, EventHandler{}, logging.NewDefaultLeveledLoggerForScope("test", logging.LogLevelTrace, nil))
+
+	t.Run("UDP", func(t *testing.T) {
+		addr, _ := net.ResolveUDPAddr("udp", "192.168.1.100:1000")
+		original := NewChannelBind(proto.MinChannelNumber, addr, mockAllocation.log)
+		original.allocation = mockAllocation
+		original.start(5 * time.Second)
+
+		data, err := original.MarshalBinary()
+		assert.NoError(t, err)
+
+		unmarshaled := &ChannelBind{
+			allocation: mockAllocation,
+			log:        mockAllocation.log,
+		}
+		err = unmarshaled.UnmarshalBinary(data)
+		assert.NoError(t, err)
+
+		assert.Equal(t, original.Peer.String(), unmarshaled.Peer.String())
+		assert.Equal(t, original.Number, unmarshaled.Number)
+		assert.NotNil(t, unmarshaled.lifetimeTimer, "lifetimeTimer should be restarted after unmarshal")
+		assert.WithinDuration(t, original.expiresAt, unmarshaled.expiresAt, 10*time.Millisecond, "expiresAt should be preserved")
+
+		unmarshaled.lifetimeTimer.Stop()
+	})
 }

--- a/internal/allocation/errors.go
+++ b/internal/allocation/errors.go
@@ -24,4 +24,5 @@ var (
 	errAdminProhibited              = errors.New("permission request administratively prohibited")
 	errFailedToGenerateConnectionID = errors.New("failed to generate a unique connection id")
 	errInvalidPeerAddress           = errors.New("invalid peer address")
+	errUnsupportedProtocol          = errors.New("unsupported protocol")
 )

--- a/internal/allocation/five_tuple.go
+++ b/internal/allocation/five_tuple.go
@@ -4,6 +4,9 @@
 package allocation
 
 import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
 	"net"
 )
 
@@ -38,26 +41,82 @@ type FiveTuple struct {
 	SrcAddr, DstAddr net.Addr
 }
 
+type serializedFiveTuple struct {
+	SrcIP    []byte
+	SrcPort  uint16
+	DstIP    []byte
+	DstPort  uint16
+	Protocol Protocol
+}
+
 // Equal asserts if two FiveTuples are equal.
 func (f *FiveTuple) Equal(b *FiveTuple) bool {
 	return f.Fingerprint() == b.Fingerprint()
 }
+func (f *FiveTuple) serialize() (*serializedFiveTuple, error) {
+	srcIP, srcPort := netAddrIPAndPort(f.SrcAddr)
+	dstIP, dstPort := netAddrIPAndPort(f.DstAddr)
+	return &serializedFiveTuple{
+		SrcIP:    srcIP,
+		SrcPort:  srcPort,
+		DstIP:    dstIP,
+		DstPort:  dstPort,
+		Protocol: f.Protocol,
+	}, nil
+
+}
+func (f *FiveTuple) deserialize(s *serializedFiveTuple) error {
+	switch s.Protocol {
+	case UDP:
+		f.SrcAddr = &net.UDPAddr{IP: s.SrcIP, Port: int(s.SrcPort)}
+		f.DstAddr = &net.UDPAddr{IP: s.DstIP, Port: int(s.DstPort)}
+	case TCP:
+		f.SrcAddr = &net.TCPAddr{IP: s.SrcIP, Port: int(s.SrcPort)}
+		f.DstAddr = &net.TCPAddr{IP: s.DstIP, Port: int(s.DstPort)}
+	default:
+		return fmt.Errorf("Unsupported protocol %v", s.Protocol)
+
+	}
+	f.Protocol = s.Protocol
+	return nil
+}
+func (f *FiveTuple) MarshalBinary() ([]byte, error) {
+	serialized, err := f.serialize()
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(*serialized); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+func (f *FiveTuple) UnmarshalBinary(data []byte) error {
+	var serialized serializedFiveTuple
+	enc := gob.NewDecoder(bytes.NewBuffer(data))
+	if err := enc.Decode(&serialized); err != nil {
+		return err
+	}
+	return f.deserialize(&serialized)
+}
 
 // FiveTupleFingerprint is a comparable representation of a FiveTuple.
 type FiveTupleFingerprint struct {
-	srcIP, dstIP     [16]byte
-	srcPort, dstPort uint16
+	SrcIP, DstIP     [16]byte
+	SrcPort, DstPort uint16
 	protocol         Protocol
 }
 
 // Fingerprint is the identity of a FiveTuple.
 func (f *FiveTuple) Fingerprint() (fp FiveTupleFingerprint) {
 	srcIP, srcPort := netAddrIPAndPort(f.SrcAddr)
-	copy(fp.srcIP[:], srcIP)
-	fp.srcPort = srcPort
+	copy(fp.SrcIP[:], srcIP)
+	fp.SrcPort = srcPort
 	dstIP, dstPort := netAddrIPAndPort(f.DstAddr)
-	copy(fp.dstIP[:], dstIP)
-	fp.dstPort = dstPort
+	copy(fp.DstIP[:], dstIP)
+	fp.DstPort = dstPort
 	fp.protocol = f.Protocol
 
 	return

--- a/internal/allocation/five_tuple_test.go
+++ b/internal/allocation/five_tuple_test.go
@@ -67,6 +67,7 @@ func TestFiveTupleEqual(t *testing.T) {
 		})
 	}
 }
+
 func TestFiveTuple_MarshalUnmarshalBinary(t *testing.T) {
 	t.Run("UDP", func(t *testing.T) {
 		srcAddr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:1234")

--- a/internal/allocation/five_tuple_test.go
+++ b/internal/allocation/five_tuple_test.go
@@ -67,3 +67,46 @@ func TestFiveTupleEqual(t *testing.T) {
 		})
 	}
 }
+func TestFiveTuple_MarshalUnmarshalBinary(t *testing.T) {
+	t.Run("UDP", func(t *testing.T) {
+		srcAddr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:1234")
+		dstAddr, _ := net.ResolveUDPAddr("udp", "192.168.1.1:5678")
+		original := &FiveTuple{
+			Protocol: UDP,
+			SrcAddr:  srcAddr,
+			DstAddr:  dstAddr,
+		}
+
+		data, err := original.MarshalBinary()
+		assert.NoError(t, err)
+
+		unmarshaled := &FiveTuple{}
+		err = unmarshaled.UnmarshalBinary(data)
+		assert.NoError(t, err)
+
+		assert.Equal(t, original.Protocol, unmarshaled.Protocol)
+		assert.Equal(t, original.SrcAddr.String(), unmarshaled.SrcAddr.String())
+		assert.Equal(t, original.DstAddr.String(), unmarshaled.DstAddr.String())
+	})
+
+	t.Run("TCP", func(t *testing.T) {
+		srcAddr, _ := net.ResolveTCPAddr("tcp", "10.0.0.1:1111")
+		dstAddr, _ := net.ResolveTCPAddr("tcp", "10.0.0.2:2222")
+		original := &FiveTuple{
+			Protocol: TCP,
+			SrcAddr:  srcAddr,
+			DstAddr:  dstAddr,
+		}
+
+		data, err := original.MarshalBinary()
+		assert.NoError(t, err)
+
+		unmarshaled := &FiveTuple{}
+		err = unmarshaled.UnmarshalBinary(data)
+		assert.NoError(t, err)
+
+		assert.Equal(t, original.Protocol, unmarshaled.Protocol)
+		assert.Equal(t, original.SrcAddr.String(), unmarshaled.SrcAddr.String())
+		assert.Equal(t, original.DstAddr.String(), unmarshaled.DstAddr.String())
+	})
+}

--- a/internal/allocation/permission.go
+++ b/internal/allocation/permission.go
@@ -4,7 +4,10 @@
 package allocation
 
 import (
+	"bytes"
+	"encoding/gob"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/pion/logging"
@@ -21,6 +24,12 @@ type Permission struct {
 	timeout       time.Duration
 	lifetimeTimer *time.Timer
 	log           logging.LeveledLogger
+	expiresAt     time.Time
+}
+type serializedPermission struct {
+	Addr      string
+	ExpiresAt time.Time
+	Protocol  Protocol
 }
 
 // NewPermission create a new Permission.
@@ -31,15 +40,74 @@ func NewPermission(addr net.Addr, log logging.LeveledLogger, timeout time.Durati
 		timeout: timeout,
 	}
 }
+func (p *Permission) serialize() (*serializedPermission, error) {
+	return &serializedPermission{
+		Addr:      p.Addr.String(),
+		ExpiresAt: p.expiresAt,
+		Protocol:  p.allocation.Protocol,
+	}, nil
+}
+func (p *Permission) deserialize(s *serializedPermission) error {
+	network := strings.ToLower(s.Protocol.String())
+	switch s.Protocol {
+	case UDP:
+		permAddr, err := net.ResolveUDPAddr(network, s.Addr)
+		if err != nil {
+			return err
+		}
+		p.Addr = permAddr
+	case TCP:
+		permAddr, err := net.ResolveTCPAddr(network, s.Addr)
+		if err != nil {
+			return err
+		}
+		p.Addr = permAddr
+	}
+	remaningTime := time.Until(s.ExpiresAt)
+	p.expiresAt = s.ExpiresAt
+	if remaningTime > 0 {
+		p.start(remaningTime)
+	}
+	return nil
+}
+func (p *Permission) MarshalBinary() ([]byte, error) {
+	var serialized, err = p.serialize()
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	var enc = gob.NewEncoder(&buf)
+	if err := enc.Encode(*serialized); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+func (p *Permission) UnmarshalBinary(data []byte) error {
+	var serialized serializedPermission
+	var enc = gob.NewDecoder(bytes.NewBuffer(data))
+	if err := enc.Decode(&serialized); err != nil {
+		return err
+	}
+	p.deserialize(&serialized)
+	return nil
+}
 
 func (p *Permission) start(lifetime time.Duration) {
+	p.expiresAt = time.Now().Add(lifetime)
 	p.lifetimeTimer = time.AfterFunc(lifetime, func() {
 		p.allocation.RemovePermission(p.Addr)
 	})
 }
 
 func (p *Permission) refresh(lifetime time.Duration) {
+	p.expiresAt = time.Now().Add(lifetime)
 	if !p.lifetimeTimer.Reset(lifetime) {
 		p.log.Errorf("Failed to reset permission timer for %v %v", p.Addr, p.allocation.fiveTuple)
+	}
+}
+func (p *Permission) stop() {
+	if p.lifetimeTimer != nil {
+		p.expiresAt = time.Now()
+		p.lifetimeTimer.Stop()
 	}
 }

--- a/internal/allocation/permission_test.go
+++ b/internal/allocation/permission_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package allocation
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPermission_MarshalUnmarshalBinary(t *testing.T) {
+	mockFiveTuple := &FiveTuple{
+		Protocol: UDP,
+		SrcAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+		DstAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678},
+	}
+	mockAllocation := NewAllocation(nil, mockFiveTuple, EventHandler{}, logging.NewDefaultLeveledLoggerForScope("test", logging.LogLevelTrace, nil))
+
+	t.Run("UDP", func(t *testing.T) {
+		addr, _ := net.ResolveUDPAddr("udp", "192.168.1.100:1000")
+		original := NewPermission(addr, mockAllocation.log, DefaultPermissionTimeout)
+		original.allocation = mockAllocation
+		original.start(5 * time.Second)
+
+		data, err := original.MarshalBinary()
+		assert.NoError(t, err)
+
+		unmarshaled := &Permission{
+			allocation: mockAllocation,
+			log:        mockAllocation.log,
+		}
+		err = unmarshaled.UnmarshalBinary(data)
+		assert.NoError(t, err)
+
+		// Assertions
+		assert.Equal(t, original.Addr.String(), unmarshaled.Addr.String())
+		assert.NotNil(t, unmarshaled.lifetimeTimer, "lifetimeTimer should be restarted after unmarshal")
+		assert.WithinDuration(t, original.expiresAt, unmarshaled.expiresAt, 10*time.Millisecond, "expiresAt should be preserved")
+
+		// Let timer expire to ensure it was started correctly
+		unmarshaled.lifetimeTimer.Stop() // clean up timer
+	})
+
+	t.Run("TCP", func(t *testing.T) {
+		addr, _ := net.ResolveTCPAddr("tcp", "10.10.10.10:2000")
+		original := NewPermission(addr, mockAllocation.log, DefaultPermissionTimeout)
+		original.allocation = mockAllocation
+		original.start(5 * time.Second)
+
+		data, err := original.MarshalBinary()
+		assert.NoError(t, err)
+
+		unmarshaled := &Permission{
+			allocation: mockAllocation,
+			log:        mockAllocation.log,
+		}
+		err = unmarshaled.UnmarshalBinary(data)
+		assert.NoError(t, err)
+
+		// Assertions
+		assert.Equal(t, original.Addr.String(), unmarshaled.Addr.String())
+		assert.NotNil(t, unmarshaled.lifetimeTimer, "lifetimeTimer should be restarted after unmarshal")
+		assert.WithinDuration(t, original.expiresAt, unmarshaled.expiresAt, 10*time.Millisecond, "expiresAt should be preserved")
+
+		unmarshaled.lifetimeTimer.Stop()
+	})
+}

--- a/internal/allocation/permission_test.go
+++ b/internal/allocation/permission_test.go
@@ -18,7 +18,9 @@ func TestPermission_MarshalUnmarshalBinary(t *testing.T) {
 		SrcAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
 		DstAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678},
 	}
-	mockAllocation := NewAllocation(nil, mockFiveTuple, EventHandler{}, logging.NewDefaultLeveledLoggerForScope("test", logging.LogLevelTrace, nil))
+	mockAllocation := NewAllocation(nil, mockFiveTuple, EventHandler{},
+		logging.NewDefaultLeveledLoggerForScope("test", logging.LogLevelTrace, nil),
+	)
 
 	t.Run("UDP", func(t *testing.T) {
 		addr, _ := net.ResolveUDPAddr("udp", "192.168.1.100:1000")
@@ -39,7 +41,13 @@ func TestPermission_MarshalUnmarshalBinary(t *testing.T) {
 		// Assertions
 		assert.Equal(t, original.Addr.String(), unmarshaled.Addr.String())
 		assert.NotNil(t, unmarshaled.lifetimeTimer, "lifetimeTimer should be restarted after unmarshal")
-		assert.WithinDuration(t, original.expiresAt, unmarshaled.expiresAt, 10*time.Millisecond, "expiresAt should be preserved")
+		assert.WithinDuration(
+			t,
+			original.expiresAt,
+			unmarshaled.expiresAt,
+			10*time.Millisecond,
+			"expiresAt should be preserved",
+		)
 
 		// Let timer expire to ensure it was started correctly
 		unmarshaled.lifetimeTimer.Stop() // clean up timer
@@ -64,7 +72,13 @@ func TestPermission_MarshalUnmarshalBinary(t *testing.T) {
 		// Assertions
 		assert.Equal(t, original.Addr.String(), unmarshaled.Addr.String())
 		assert.NotNil(t, unmarshaled.lifetimeTimer, "lifetimeTimer should be restarted after unmarshal")
-		assert.WithinDuration(t, original.expiresAt, unmarshaled.expiresAt, 10*time.Millisecond, "expiresAt should be preserved")
+		assert.WithinDuration(
+			t,
+			original.expiresAt,
+			unmarshaled.expiresAt,
+			10*time.Millisecond,
+			"expiresAt should be preserved",
+		)
 
 		unmarshaled.lifetimeTimer.Stop()
 	})


### PR DESCRIPTION
#### Description
- Adds binary serialization support for allocation-related objects.

- Implements `MarshalBinary` and `UnmarshalBinary` for `Allocation`, `Permission`, `ChannelBind`, and `FiveTuple`

- Improves `deserialization` error handling

Adds unit tests for `serialization/deserialization`
#### Reference issue
Fixes #487 
