### PR TITLE
Initialise unknownAttributes to nil

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,7 +87,7 @@ func handleTURNPacket(req Request) error {
 		)
 	}
 
-	unknownAttributes := []stun.AttrType{}
+	unknownAttributes := []stun.AttrType(nil)
 	for _, attr := range stunMsg.Attributes {
 		if attr.Type.Required() && !attr.Type.Known() {
 			unknownAttributes = append(unknownAttributes, attr.Type)


### PR DESCRIPTION
This avoids allocating a slice header for each packet.
