### PR TITLE
Add test for client and peer connection address over a TCP alloc

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -427,6 +427,9 @@ func TestTCPClientDial(t *testing.T) {
 		inboundTCPConn, inboundErr := remotePeerConn.Accept()
 		assert.NoError(t, inboundErr)
 
+		remoteAddr := inboundTCPConn.RemoteAddr()
+		assert.Equal(t, allocation.Addr().String(), remoteAddr.String(), "peer conn: remote address = relay address")
+
 		_, inboundErr = inboundTCPConn.Write(expectedMsg)
 		assert.NoError(t, inboundErr)
 
@@ -444,6 +447,9 @@ func TestTCPClientDial(t *testing.T) {
 
 	channelBindConn, err := allocation.Dial("tcp4", remotePeerAddr.String())
 	assert.NoError(t, err)
+
+	localAddr := channelBindConn.LocalAddr()
+	assert.Equal(t, allocation.Addr().String(), localAddr.String(), "client conn: local address = relay address")
 
 	channelBindConnBuffer := make([]byte, len(expectedMsg))
 	_, err = channelBindConn.Read(channelBindConnBuffer)


### PR DESCRIPTION
#### Description

For client-initiated connection requests over a TCP allocation the outbound connections made by the server MUST be locally bound to the relay transport address for the allocation. In particular, [RFC 6062 Section 5.2](https://datatracker.ietf.org/doc/html/rfc6062#section-5.2) contains the following text:

> Otherwise, the server MUST initiate an outgoing TCP connection.  The **local endpoint is the relayed transport address associated with the allocation**. 

This PR adds a check for this.

#### Reference issue
See #512
