### PR TITLE
Bind relay connections to the relay address for TCP allocations

### DIFF
--- a/internal/allocation/errors.go
+++ b/internal/allocation/errors.go
@@ -11,6 +11,7 @@ var (
 
 	errAllocatePacketConnMustBeSet  = errors.New("AllocatePacketConn must be set")
 	errAllocateListenerMustBeSet    = errors.New("AllocateListener must be set")
+	errAllocateConnMustBeSet        = errors.New("AllocateConn must be set")
 	errLeveledLoggerMustBeSet       = errors.New("LeveledLogger must be set")
 	errSameChannelDifferentPeer     = errors.New("you cannot use the same channel number with different peer")
 	errNilFiveTuple                 = errors.New("allocations must not be created with nil FivTuple")

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -72,6 +72,9 @@ func TestAllocationLifeTime(t *testing.T) {
 			AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
 				return nil, nil, nil
 			},
+			AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+				return nil, nil //nolint:nilnil
+			},
 			LeveledLogger: logger,
 		})
 		assert.NoError(t, err)
@@ -131,6 +134,9 @@ func TestRequestedTransport(t *testing.T) {
 		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
+		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+			return nil, nil //nolint:nilnil
+		},
 		LeveledLogger: logger,
 	})
 	assert.NoError(t, err)
@@ -182,6 +188,9 @@ func TestConnectRequest(t *testing.T) {
 		},
 		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
+		},
+		AllocateConn: func(network string, _, raddr net.Addr) (net.Conn, error) {
+			return net.Dial("tcp4", raddr.String()) // nolint: noctx
 		},
 		LeveledLogger: logger,
 	})
@@ -265,6 +274,9 @@ func TestConnectionBindRequest(t *testing.T) {
 		},
 		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
+		},
+		AllocateConn: func(network string, _, raddr net.Addr) (net.Conn, error) {
+			return net.Dial("tcp4", raddr.String()) // nolint: noctx
 		},
 		LeveledLogger: logger,
 	})

--- a/relay_address_generator_none.go
+++ b/relay_address_generator_none.go
@@ -4,11 +4,13 @@
 package turn
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
 
 	"github.com/pion/transport/v4"
+	"github.com/pion/transport/v4/reuseport"
 	"github.com/pion/transport/v4/stdnet"
 )
 
@@ -68,10 +70,27 @@ func (r *RelayAddressGeneratorNone) AllocateListener(network string, requestedPo
 		return nil, nil, err
 	}
 
-	ln, err := r.Net.ListenTCP(network, tcpAddr) // nolint: noctx
+	listenConfig := r.Net.CreateListenConfig(&net.ListenConfig{
+		// Enable SO_REUSEADDR and SO_REUSEPORT where needed to let multiple connnections
+		// bind to the same relay address.
+		Control: reuseport.Control,
+	})
+	ln, err := listenConfig.Listen(context.TODO(), network, tcpAddr.String())
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return ln, ln.Addr(), nil
+}
+
+// AllocateConn creates a new outgoing TCP connection bound to the relay address to send traffic to a peer.
+func (r *RelayAddressGeneratorNone) AllocateConn(network string, laddr, raddr net.Addr) (net.Conn, error) {
+	dialer := r.Net.CreateDialer(&net.Dialer{
+		LocalAddr: laddr,
+		// Enable SO_REUSEADDR and SO_REUSEPORT where needed to let multiple connnections
+		// bind to the same relay address.
+		Control: reuseport.Control,
+	})
+
+	return dialer.Dial(network, raddr.String())
 }

--- a/server.go
+++ b/server.go
@@ -205,6 +205,10 @@ func (n *nilAddressGenerator) AllocateListener(string, int) (net.Listener, net.A
 	return nil, nil, errRelayAddressGeneratorNil
 }
 
+func (n *nilAddressGenerator) AllocateConn(network string, laddr, raddr net.Addr) (net.Conn, error) {
+	return nil, errRelayAddressGeneratorNil
+}
+
 func (s *Server) createAllocationManager(
 	addrGenerator RelayAddressGenerator,
 	handler PermissionHandler,
@@ -219,6 +223,7 @@ func (s *Server) createAllocationManager(
 	am, err := allocation.NewManager(allocation.ManagerConfig{
 		AllocatePacketConn: addrGenerator.AllocatePacketConn,
 		AllocateListener:   addrGenerator.AllocateListener,
+		AllocateConn:       addrGenerator.AllocateConn,
 		PermissionHandler:  handler,
 		EventHandler:       s.eventHandler,
 		LeveledLogger:      s.log,

--- a/server_config.go
+++ b/server_config.go
@@ -26,6 +26,9 @@ type RelayAddressGenerator interface {
 
 	// Allocate a Listener (TCP) RelayAddress
 	AllocateListener(network string, requestedPort int) (net.Listener, net.Addr, error)
+
+	// Allocate a Conn (TCP) RelayAddress
+	AllocateConn(network string, laddr, raddr net.Addr) (net.Conn, error)
 }
 
 // PermissionHandler is a callback to filter incoming CreatePermission and ChannelBindRequest


### PR DESCRIPTION
This is a humble attempt to fix #512

The trick is to use the proper sockopts to create the TCP relay listener and the relay connections (`SO_REUSEADDR` and wherever needed, `SO_REUSEPORT`). 

Caveats:
- We import a battle-tested [external module](https://github.com/libp2p/go-reuseport) to hide the OS-dependent "reuseport" sockopts. Let me know if adding new imports is discouraged, we can easily reproduce the required functionality for the GOARCHs supported by pion (which would be those?).
- `RelayGenerator.AllocateConn` is back for generating the outbound TCP relay connections, so no more hardcoded `net.DialTCP` in the server. I think this is for the better: now we can abstract away all network-related functions the server invokes (e.g., to wrap OTel telemetry on top of TCP connections). This sort of fixes the API worries I mentioned in an earlier thread. 
- Unfortunately ATM we cannot abstract the TCP listener creation in `RelayGenerator.AllocateListener` via pion/transport. The reason is that `transport.Net` does not (yet?) support `net.ListenerConfig`, which we would need to enforce the reuseport semantics. Note that both `AllocateListener` and `AllocateConn` must enforce reuseport, otherwise either of them will fail with "Address already in use". Currently we hard-code the `net.ListenerConfig` in `AllocateListener` instead of going through `transport.Net`, which is on the one hand ugly and on the other hand requires adding an even uglier `context.TODO()` in `Listen`. We can easily implement something like `CreateListenerConfig` in `transport.Net` (just like we already have `CreateDialer`) and hope someone jumps in to implement TCP in pion/transport, let me know if you want be to send a PR. 