### PR TITLE
If ConnectionBind closes don't hold open socket

### DIFF
--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -381,3 +381,14 @@ func (m *Manager) GetTCPConnection(username string, connectionID proto.Connectio
 
 	return nil
 }
+
+func (m *Manager) RemoveTCPConnection(connectionID proto.ConnectionID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	for _, a := range m.allocations {
+		if _, ok := a.tcpConnections[connectionID]; ok {
+			a.removeTCPConnection(connectionID)
+		}
+	}
+}


### PR DESCRIPTION
Currently we don't properly close the connection all the way through. This means we hold open TCP sockets created by clients until the Allocation is closed.
