### PR TITLE
Improve Client TLS Turn-Server Example, Update Usage Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ Also take a look at the [Pion WebRTC FAQ](https://github.com/pion/webrtc/wiki/FA
 Yes.
 
 #### How do I implement token-based authentication?
-Replace the username with a token in the [AuthHandler](https://github.com/pion/turn/blob/6d0ff435910870eb9024b18321b93b61844fcfec/examples/turn-server/simple/main.go#L49).
-The password sent by the client can be any non-empty string, as long as it matches that used by the [GenerateAuthKey](https://github.com/pion/turn/blob/6d0ff435910870eb9024b18321b93b61844fcfec/examples/turn-server/simple/main.go#L41)
+Replace the username with a token in the [AuthHandler](examples/turn-server/simple/main.go#L53).
+The password sent by the client can be any non-empty string, as long as it matches that used by the [GenerateAuthKey](examples/turn-server/simple/main.go#L45)
 function.
+
+#### How do I implement mTLS (mutual TLS) authentication?
+You can use client certificates for authentication by checking the TLS connection state in your [AuthHandler](examples/turn-server/tls-auth/main.go#L29).
+See the [tls-auth example](examples/turn-server/tls-auth/main.go) for a complete implementation that validates client certificates
+and matches the certificate's Common Name to the TURN username.
 
 #### Will WebRTC prioritize using STUN over TURN?
 Yes.

--- a/examples/turn-server/tls-auth/main.go
+++ b/examples/turn-server/tls-auth/main.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"crypto/md5"
+	"crypto/md5" // nolint: gosec
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
@@ -52,7 +52,7 @@ func getClientTLSAuthHandler(verifyOpts x509.VerifyOptions) turn.AuthHandler {
 			// in this example, we generate the turn auth key based only on the
 			// certificate's common name, but you can use any attributes from the
 			// certificate's contents and/or request attributes.
-			hash := md5.New()
+			hash := md5.New()                                                      // nolint: gosec
 			fmt.Fprint(hash, strings.Join([]string{cert.Subject.CommonName}, ":")) // nolint: errcheck
 			key := hash.Sum(nil)
 


### PR DESCRIPTION
#### Description

- Improves the client-tls-certificates example in examples/turn-server/tls-auth (removes the static username and password map, because it should rely on the certificate being trusted for authn).
- Updates link in the README which pointed to outdated usage of AuthHandler (prior to https://github.com/pion/turn/commit/b019c6928c635eaf49e18ffcae0a5c85be435e89)
- Adds mTLS usage info to README