### PR TITLE
[RFC] Simplified Client API

### DIFF
--- a/allocation.go
+++ b/allocation.go
@@ -1,0 +1,385 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package turn contains the public API for pion/turn, a toolkit for building TURN clients and servers.
+package turn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/pion/transport/v4"
+	"github.com/pion/transport/v4/deadline"
+	"github.com/pion/transport/v4/packetio"
+	"github.com/pion/turn/v5/internal/client"
+)
+
+const defaultAcceptBacklog = 128
+
+var (
+	_ transport.Dialer = &turnAllocation{}
+	_ net.Listener     = &turnAllocation{}
+	_ Allocation       = &turnAllocation{}
+)
+
+// Typed errors.
+var (
+	ErrAllocationClosed = errors.New("allocation: closed")
+	errFailedToAlloc    = errors.New("allocation: failed to create allocation")
+	errFailedToDial     = errors.New("allocation: failed to dial")
+	errInvalidNetwork   = errors.New("allocation: invalid network")
+)
+
+// Allocation represents a TURN allocation that provides bidirectional communication with peers
+// through a TURN relay server. It combines dialer and listener semantics: use Dial to establish
+// outgoing connections to peers, and Accept to receive incoming connections from peers. The
+// allocation is bound to a specific transport protocol (UDP or TCP) specified when created via
+// NewAllocation. All connections through this allocation use that protocol.
+type Allocation interface {
+	// Dial establishes a connection to the specified peer address through the TURN relay.
+	// The network parameter must match the allocation's protocol ("udp" or "tcp").
+	// Dial automatically creates a TURN permission for the peer, allowing the peer to
+	// send data back to this allocation's relay address.
+	Dial(network, address string) (net.Conn, error)
+
+	// Accept waits for the next incoming connection from a peer.  The peer must have a valid
+	// permission (created via Dial or CreatePermission) to send data to this allocation's
+	// relay address.
+	Accept() (net.Conn, error)
+
+	// Addr returns the relay transport address of the allocation.
+	Addr() net.Addr
+
+	// Close releases the TURN allocation and closes all associated connections.
+	// Any blocked Accept or Dial calls will return ErrAllocationClosed.
+	Close() error
+
+	// CreatePermission installs a TURN permission for the specified peer address,
+	// allowing that peer to send data to this allocation's relay address.
+	CreatePermission(addr net.Addr) error
+}
+
+type turnAllocation struct {
+	*Client    // TURN client
+	network    string
+	tcpAlloc   *client.TCPAllocation // for TCP allocations
+	dispatcher *packetDispatcher     // for UDP allocations
+	closeCh    chan struct{}
+	closeOnce  sync.Once
+	mu         sync.RWMutex
+	closed     bool
+}
+
+// NewAllocation creates a TURN allocation that can dial peers and accept incoming connections.
+func NewAllocation(network string, conf *ClientConfig) (Allocation, error) {
+	turnClient, err := NewClient(conf)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToAlloc, err)
+	}
+
+	if err = turnClient.Listen(); err != nil {
+		turnClient.Close()
+
+		return nil, fmt.Errorf("%w: %w", errFailedToAlloc, err)
+	}
+
+	turnAlloc := &turnAllocation{
+		Client:  turnClient,
+		network: network,
+		closeCh: make(chan struct{}),
+	}
+
+	switch network {
+	case "udp", "udp4", "udp6": //nolint:goconst
+		pconn, err := turnClient.Allocate()
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errFailedToAlloc, err)
+		}
+		turnAlloc.dispatcher = newPacketDispatcher(pconn, turnAlloc.closeCh)
+	case "tcp", "tcp4", "tcp6": //nolint:goconst
+		tcpAlloc, err := turnClient.AllocateTCP()
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errFailedToAlloc, err)
+		}
+		turnAlloc.tcpAlloc = tcpAlloc
+	default:
+		return nil, errInvalidNetwork
+	}
+
+	return turnAlloc, nil
+}
+
+// Dial establishes a connection to the address through TURN.  Network must be "udp", "udp4",
+// "udp6" or "tcp", "tcp4", "tcp6".
+func (a *turnAllocation) Dial(network, address string) (net.Conn, error) {
+	a.mu.RLock()
+	if a.closed {
+		a.mu.RUnlock()
+
+		return nil, ErrAllocationClosed
+	}
+	a.mu.RUnlock()
+
+	switch a.network {
+	case "udp", "udp4", "udp6": //nolint:goconst
+		return a.dialUDP(network, address)
+	case "tcp", "tcp4", "tcp6": //nolint:goconst
+		return a.dialTCP(network, address)
+	default:
+		return nil, errInvalidNetwork
+	}
+}
+
+func (a *turnAllocation) dialUDP(network, address string) (net.Conn, error) {
+	if network != a.network {
+		return nil, errInvalidNetwork
+	}
+
+	peerAddr, err := net.ResolveUDPAddr(network, address)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToDial, err)
+	}
+
+	if err = a.CreatePermission(peerAddr); err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToDial, err)
+	}
+
+	return a.dispatcher.register(peerAddr), nil
+}
+
+func (a *turnAllocation) dialTCP(network, address string) (net.Conn, error) {
+	if network != a.network {
+		return nil, errInvalidNetwork
+	}
+
+	peerAddr, err := net.ResolveTCPAddr(network, address)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToDial, err)
+	}
+
+	if err = a.CreatePermission(peerAddr); err != nil {
+		return nil, fmt.Errorf("%w: %w", errFailedToDial, err)
+	}
+
+	return a.tcpAlloc.DialTCP(network, nil, peerAddr)
+}
+
+// Accept returns the next incoming connection from a permitted peer.
+func (a *turnAllocation) Accept() (net.Conn, error) {
+	switch a.network {
+	case "udp", "udp4", "udp6": //nolint:goconst
+		select {
+		case <-a.closeCh:
+			return nil, ErrAllocationClosed
+		case conn := <-a.dispatcher.acceptCh:
+			return conn, nil
+		}
+	case "tcp", "tcp4", "tcp6": //nolint:goconst
+		return a.tcpAlloc.Accept()
+	default:
+		return nil, errInvalidNetwork
+	}
+}
+
+// Addr returns the transport relay address of the allocation.
+func (a *turnAllocation) Addr() net.Addr {
+	switch a.network {
+	case "udp", "udp4", "udp6": //nolint:goconst
+		return a.dispatcher.pconn.LocalAddr()
+	case "tcp", "tcp4", "tcp6": //nolint:goconst
+		return a.tcpAlloc.RelayAddr()
+	default:
+		return nil
+	}
+}
+
+// Close closes the allocation and all associated connections.
+func (a *turnAllocation) Close() error {
+	var err error
+	a.closeOnce.Do(func() {
+		switch a.network {
+		case "udp", "udp4", "udp6": //nolint:goconst
+			err = a.dispatcher.pconn.Close()
+		case "tcp", "tcp4", "tcp6": //nolint:goconst
+			err = a.tcpAlloc.Close()
+		default:
+			err = errInvalidNetwork
+		}
+		a.Client.Close()
+		a.mu.Lock()
+		a.closed = true
+		a.mu.Unlock()
+		close(a.closeCh)
+	})
+
+	return err
+}
+
+// CreatePermission admits a peer on the allocation. Note that Dial automatically creates a
+// permission for the peer.
+func (a *turnAllocation) CreatePermission(addr net.Addr) error {
+	return a.Client.CreatePermission(addr)
+}
+
+const receiveMTU = 8192
+
+// packetDispatcher demultiplexes packets from a single PacketConn to multiple Conns.
+type packetDispatcher struct {
+	pconn    net.PacketConn
+	mu       sync.Mutex
+	conns    map[string]*dispatchedConn
+	acceptCh chan *dispatchedConn
+	closeCh  chan struct{}
+}
+
+// newPacketDispatcher creates a dispatcher and starts its read loop.
+func newPacketDispatcher(pconn net.PacketConn, closeCh chan struct{}) *packetDispatcher {
+	d := &packetDispatcher{
+		pconn:    pconn,
+		conns:    make(map[string]*dispatchedConn),
+		acceptCh: make(chan *dispatchedConn, defaultAcceptBacklog),
+		closeCh:  closeCh,
+	}
+
+	go d.readLoop()
+
+	return d
+}
+
+func (d *packetDispatcher) readLoop() {
+	buf := make([]byte, receiveMTU)
+	for {
+		n, raddr, err := d.pconn.ReadFrom(buf)
+		if err != nil {
+			// Close all conn buffers on read error.
+			d.mu.Lock()
+			for _, c := range d.conns {
+				_ = c.buffer.Close()
+			}
+			d.mu.Unlock()
+
+			return
+		}
+		d.dispatch(raddr, buf[:n])
+	}
+}
+
+func (d *packetDispatcher) dispatch(raddr net.Addr, buf []byte) {
+	d.mu.Lock()
+	conn, ok := d.conns[raddr.String()]
+	if !ok {
+		// New peer - create conn and send to accept channel.
+		conn = d.newConn(raddr)
+		d.conns[raddr.String()] = conn
+		select {
+		case d.acceptCh <- conn:
+			// Sent to accept queue.
+		default:
+			// Accept queue full: unreg and drop connection
+			delete(d.conns, raddr.String())
+		}
+	}
+	d.mu.Unlock()
+	_, _ = conn.buffer.Write(buf)
+}
+
+// register adds a conn for the given peer address (used by Dial).
+func (d *packetDispatcher) register(raddr net.Addr) *dispatchedConn {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if conn, ok := d.conns[raddr.String()]; ok {
+		return conn
+	}
+
+	conn := d.newConn(raddr)
+	d.conns[raddr.String()] = conn
+
+	return conn
+}
+
+// newConn creates a new dispatchedConn (must be called with lock held).
+func (d *packetDispatcher) newConn(raddr net.Addr) *dispatchedConn {
+	return &dispatchedConn{
+		dispatcher:    d,
+		rAddr:         raddr,
+		buffer:        packetio.NewBuffer(),
+		writeDeadline: deadline.New(),
+	}
+}
+
+// unregister removes a conn from the dispatcher.
+func (d *packetDispatcher) unregister(raddr net.Addr) {
+	d.mu.Lock()
+	delete(d.conns, raddr.String())
+	d.mu.Unlock()
+}
+
+// dispatchedConn is a net.Conn bound to a specific peer, receiving via the dispatcher.
+type dispatchedConn struct {
+	dispatcher    *packetDispatcher
+	rAddr         net.Addr
+	buffer        *packetio.Buffer
+	writeDeadline *deadline.Deadline
+	closeOnce     sync.Once
+}
+
+// Read reads data from the buffer (dispatched by the read loop).
+func (c *dispatchedConn) Read(b []byte) (int, error) {
+	return c.buffer.Read(b)
+}
+
+// Write sends data to the bound peer.
+func (c *dispatchedConn) Write(b []byte) (int, error) {
+	select {
+	case <-c.writeDeadline.Done():
+		return 0, context.DeadlineExceeded
+	default:
+	}
+
+	return c.dispatcher.pconn.WriteTo(b, c.rAddr)
+}
+
+// Close unregisters from dispatcher and closes the buffer.
+func (c *dispatchedConn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		c.dispatcher.unregister(c.rAddr)
+		err = c.buffer.Close()
+	})
+
+	return err
+}
+
+// LocalAddr returns the local address (relay address).
+func (c *dispatchedConn) LocalAddr() net.Addr {
+	return c.dispatcher.pconn.LocalAddr()
+}
+
+// RemoteAddr returns the bound peer address.
+func (c *dispatchedConn) RemoteAddr() net.Addr {
+	return c.rAddr
+}
+
+// SetDeadline sets both read and write deadlines.
+func (c *dispatchedConn) SetDeadline(t time.Time) error {
+	c.writeDeadline.Set(t)
+
+	return c.buffer.SetReadDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline.
+func (c *dispatchedConn) SetReadDeadline(t time.Time) error {
+	return c.buffer.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline.
+func (c *dispatchedConn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline.Set(t)
+
+	return nil
+}

--- a/allocation_test.go
+++ b/allocation_test.go
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+// +build !js
+
+package turn
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocationDispatcher(t *testing.T) { //nolint:maintidx
+	t.Run("BasicDispatch", func(t *testing.T) {
+		// Create two UDP sockets to simulate PacketConn and a peer.
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		// Create dispatcher on pconn.
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+
+		// Register a conn for the peer's address.
+		conn := dispatcher.register(peer.LocalAddr())
+
+		// Peer sends data to pconn.
+		testData := []byte("hello dispatcher")
+		_, err = peer.WriteTo(testData, pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Read from conn should receive the dispatched data.
+		buf := make([]byte, 100)
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, testData, buf[:n])
+
+		// Close conn.
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("MultipleConns", func(t *testing.T) {
+		// Create pconn and two peers.
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer1, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer1.Close() }()
+
+		peer2, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer2.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+
+		conn1 := dispatcher.register(peer1.LocalAddr())
+		conn2 := dispatcher.register(peer2.LocalAddr())
+
+		// Peer1 sends data.
+		data1 := []byte("from peer1")
+		_, err = peer1.WriteTo(data1, pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Peer2 sends data.
+		data2 := []byte("from peer2")
+		_, err = peer2.WriteTo(data2, pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Each conn should only receive its peer's data.
+		buf := make([]byte, 100)
+
+		_ = conn1.SetReadDeadline(time.Now().Add(time.Second))
+		n, err := conn1.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, data1, buf[:n])
+
+		_ = conn2.SetReadDeadline(time.Now().Add(time.Second))
+		n, err = conn2.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, data2, buf[:n])
+
+		assert.NoError(t, conn1.Close())
+		assert.NoError(t, conn2.Close())
+	})
+
+	t.Run("UnknownPeerToAcceptChannel", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		knownPeer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = knownPeer.Close() }()
+
+		unknownPeer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = unknownPeer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+
+		// Only register knownPeer.
+		conn := dispatcher.register(knownPeer.LocalAddr())
+
+		// Unknown peer sends data - creates conn and sends to acceptCh.
+		_, err = unknownPeer.WriteTo([]byte("unknown"), pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Known peer sends data.
+		_, err = knownPeer.WriteTo([]byte("known"), pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Registered conn should only receive from known peer.
+		buf := make([]byte, 100)
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("known"), buf[:n])
+
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("Accept", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+
+		// Peer sends data without being registered - should create conn in acceptCh.
+		testData := []byte("hello from unregistered peer")
+		_, err = peer.WriteTo(testData, pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Accept should return the new conn.
+		select {
+		case acceptedConn := <-dispatcher.acceptCh:
+			require.NotNil(t, acceptedConn)
+			assert.Equal(t, peer.LocalAddr().String(), acceptedConn.RemoteAddr().String())
+
+			// Read data from accepted conn.
+			buf := make([]byte, 100)
+			_ = acceptedConn.SetReadDeadline(time.Now().Add(time.Second))
+			n, err := acceptedConn.Read(buf)
+			require.NoError(t, err)
+			assert.Equal(t, testData, buf[:n])
+
+			assert.NoError(t, acceptedConn.Close())
+		case <-time.After(time.Second):
+			assert.Fail(t, "timeout waiting for accepted conn")
+		}
+	})
+
+	t.Run("AcceptMultiplePeers", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer1, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer1.Close() }()
+
+		peer2, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer2.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+
+		// Both peers send data.
+		_, err = peer1.WriteTo([]byte("peer1"), pconn.LocalAddr())
+		require.NoError(t, err)
+		_, err = peer2.WriteTo([]byte("peer2"), pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Accept both conns.
+		accepted := make(map[string]*dispatchedConn)
+		for i := 0; i < 2; i++ {
+			select {
+			case conn := <-dispatcher.acceptCh:
+				accepted[conn.RemoteAddr().String()] = conn
+			case <-time.After(time.Second):
+				assert.Fail(t, "timeout waiting for accepted conn")
+			}
+		}
+
+		// Verify both peers have conns.
+		assert.Contains(t, accepted, peer1.LocalAddr().String())
+		assert.Contains(t, accepted, peer2.LocalAddr().String())
+
+		// Read from each conn.
+		buf := make([]byte, 100)
+
+		conn1 := accepted[peer1.LocalAddr().String()]
+		_ = conn1.SetReadDeadline(time.Now().Add(time.Second))
+		n, err := conn1.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("peer1"), buf[:n])
+
+		conn2 := accepted[peer2.LocalAddr().String()]
+		_ = conn2.SetReadDeadline(time.Now().Add(time.Second))
+		n, err = conn2.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("peer2"), buf[:n])
+
+		assert.NoError(t, conn1.Close())
+		assert.NoError(t, conn2.Close())
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+		conn := dispatcher.register(peer.LocalAddr())
+
+		// Peer sends multiple packets.
+		_, err = peer.WriteTo([]byte("packet1"), pconn.LocalAddr())
+		require.NoError(t, err)
+		_, err = peer.WriteTo([]byte("packet2"), pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Read both packets in order.
+		buf := make([]byte, 100)
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+
+		n, err := conn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("packet1"), buf[:n])
+
+		n, err = conn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("packet2"), buf[:n])
+
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("AcceptedConnCanReply", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+
+		// Peer sends data to trigger accept.
+		_, err = peer.WriteTo([]byte("hello"), pconn.LocalAddr())
+		require.NoError(t, err)
+
+		// Accept the conn.
+		var acceptedConn *dispatchedConn
+		select {
+		case acceptedConn = <-dispatcher.acceptCh:
+		case <-time.After(time.Second):
+			assert.Fail(t, "timeout waiting for accepted conn")
+		}
+
+		// Accepted conn can write back to peer.
+		replyData := []byte("reply from server")
+		n, err := acceptedConn.Write(replyData)
+		require.NoError(t, err)
+		assert.Equal(t, len(replyData), n)
+
+		// Peer receives reply.
+		buf := make([]byte, 100)
+		_ = peer.SetReadDeadline(time.Now().Add(time.Second))
+		n, from, err := peer.ReadFrom(buf)
+		require.NoError(t, err)
+		assert.Equal(t, replyData, buf[:n])
+		assert.Equal(t, pconn.LocalAddr().String(), from.String())
+
+		assert.NoError(t, acceptedConn.Close())
+	})
+}
+
+func TestAllocationDispatchedConn(t *testing.T) {
+	t.Run("Write", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+		conn := dispatcher.register(peer.LocalAddr())
+
+		// Write to conn should send to peer.
+		testData := []byte("outgoing data")
+		n, err := conn.Write(testData)
+		require.NoError(t, err)
+		assert.Equal(t, len(testData), n)
+
+		// Peer should receive the data.
+		buf := make([]byte, 100)
+		_ = peer.SetReadDeadline(time.Now().Add(time.Second))
+		n, from, err := peer.ReadFrom(buf)
+		require.NoError(t, err)
+		assert.Equal(t, testData, buf[:n])
+		assert.Equal(t, pconn.LocalAddr().String(), from.String())
+
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("LocalAddr", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+		conn := dispatcher.register(peer.LocalAddr())
+
+		assert.Equal(t, pconn.LocalAddr(), conn.LocalAddr())
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("RemoteAddr", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+		conn := dispatcher.register(peer.LocalAddr())
+
+		assert.Equal(t, peer.LocalAddr().String(), conn.RemoteAddr().String())
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("DoubleClose", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+		conn := dispatcher.register(peer.LocalAddr())
+
+		// Double close should not panic.
+		assert.NoError(t, conn.Close())
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("ReadDeadline", func(t *testing.T) {
+		pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = pconn.Close() }()
+
+		peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+		require.NoError(t, err)
+		defer func() { _ = peer.Close() }()
+
+		dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+		conn := dispatcher.register(peer.LocalAddr())
+
+		// Set a short deadline and try to read (no data sent).
+		_ = conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		buf := make([]byte, 100)
+		_, err = conn.Read(buf)
+		assert.Error(t, err, "read should timeout")
+
+		assert.NoError(t, conn.Close())
+	})
+}
+
+func TestAllocationDispatcherUnregister(t *testing.T) {
+	pconn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+	defer func() { _ = pconn.Close() }()
+
+	peer, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+	defer func() { _ = peer.Close() }()
+
+	dispatcher := newPacketDispatcher(pconn, make(chan struct{}))
+	conn := dispatcher.register(peer.LocalAddr())
+
+	// Verify conn is registered.
+	dispatcher.mu.Lock()
+	_, exists := dispatcher.conns[peer.LocalAddr().String()]
+	dispatcher.mu.Unlock()
+	assert.True(t, exists, "conn should be registered")
+
+	// Close conn (which unregisters).
+	assert.NoError(t, conn.Close())
+
+	// Verify conn is unregistered.
+	dispatcher.mu.Lock()
+	_, exists = dispatcher.conns[peer.LocalAddr().String()]
+	dispatcher.mu.Unlock()
+	assert.False(t, exists, "conn should be unregistered after close")
+}
+
+func TestAllocationDialUDP(t *testing.T) {
+	// Create a TURN server.
+	udpListener, err := net.ListenPacket("udp4", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+
+	server, err := NewServer(ServerConfig{
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		},
+		PacketConnConfigs: []PacketConnConfig{
+			{
+				PacketConn: udpListener,
+				RelayAddressGenerator: &RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP("127.0.0.1"),
+					Address:      "0.0.0.0",
+				},
+			},
+		},
+		Realm: "pion.ly",
+	})
+	require.NoError(t, err)
+	defer func() { _ = server.Close() }()
+
+	serverAddr := udpListener.LocalAddr().String()
+
+	// Create a sink to receive data.
+	sink, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+	defer func() { _ = sink.Close() }()
+
+	// Create connection to TURN server.
+	turnConn, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+
+	// Create dialer.
+	dialer, err := NewAllocation("udp", &ClientConfig{
+		Conn:           turnConn,
+		TURNServerAddr: serverAddr,
+		Username:       "user",
+		Password:       "pass",
+		Realm:          "pion.ly",
+	})
+	require.NoError(t, err)
+
+	// TCP dialer should fail.
+	_, err = dialer.Dial("tcp", "127.0.0.1:0")
+	require.Error(t, err)
+
+	// Dial the sink.
+	conn, err := dialer.Dial("udp", sink.LocalAddr().String())
+	require.NoError(t, err)
+
+	// Addr() should return the relay address.
+	relayAddr := dialer.Addr()
+	require.NotNil(t, relayAddr)
+	assert.Equal(t, conn.LocalAddr().String(), relayAddr.String())
+
+	// Write data through TURN.
+	testData := []byte("hello via TURN UDP")
+	_, err = conn.Write(testData)
+	require.NoError(t, err)
+
+	// Read at sink.
+	buf := make([]byte, 100)
+	_ = sink.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n, _, err := sink.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, testData, buf[:n])
+
+	// Cleanup.
+	assert.NoError(t, conn.Close())
+	assert.NoError(t, dialer.Close())
+	_ = turnConn.Close()
+}
+
+func TestAllocationDialTCP(t *testing.T) {
+	// Create a TURN server with TCP listener.
+	tcpListener, err := net.Listen("tcp4", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+
+	server, err := NewServer(ServerConfig{
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		},
+		ListenerConfigs: []ListenerConfig{
+			{
+				Listener: tcpListener,
+				RelayAddressGenerator: &RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP("127.0.0.1"),
+					Address:      "0.0.0.0",
+				},
+			},
+		},
+		Realm: "pion.ly",
+	})
+	require.NoError(t, err)
+	defer func() { _ = server.Close() }()
+
+	serverAddr := tcpListener.Addr().String()
+
+	// Create a UDP sink.
+	sink, err := net.ListenPacket("udp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+	defer func() { _ = sink.Close() }()
+
+	// Create a TCP sink to receive connections.
+	sinkListener, err := net.Listen("tcp", "127.0.0.1:0") //nolint:noctx
+	require.NoError(t, err)
+	defer func() { _ = sinkListener.Close() }()
+
+	// Accept in background.
+	sinkConnCh := make(chan net.Conn, 1)
+	go func() {
+		conn, listenErr := sinkListener.Accept()
+		if listenErr == nil {
+			sinkConnCh <- conn
+		}
+	}()
+
+	// Create connection to TURN server.
+	turnConn, err := net.Dial("tcp", serverAddr) //nolint:noctx
+	require.NoError(t, err)
+
+	// Create dialer.
+	dialer, err := NewAllocation("tcp", &ClientConfig{
+		Conn:           NewSTUNConn(turnConn),
+		TURNServerAddr: serverAddr,
+		Username:       "user",
+		Password:       "pass",
+		Realm:          "pion.ly",
+	})
+	require.NoError(t, err)
+
+	// A TCP allocation should fail when dialing UDP.
+	_, err = dialer.Dial("udp", sink.LocalAddr().String())
+	require.Error(t, err)
+
+	// Dial the TCP sink.
+	conn, err := dialer.Dial("tcp", sinkListener.Addr().String())
+	require.NoError(t, err)
+
+	// Wait for sink to accept.
+	var sinkConn net.Conn
+	select {
+	case sinkConn = <-sinkConnCh:
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timeout waiting for accepted conn")
+	}
+	defer func() { _ = sinkConn.Close() }()
+
+	// Addr() should return the relay address.
+	relayAddr := dialer.Addr()
+	require.NotNil(t, relayAddr)
+	assert.Equal(t, conn.LocalAddr().String(), relayAddr.String())
+
+	// Write data through TURN.
+	testData := []byte("hello via TURN TCP")
+	_, err = conn.Write(testData)
+	require.NoError(t, err)
+
+	// Read at sink.
+	buf := make([]byte, 100)
+	_ = sinkConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n, err := sinkConn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, testData, buf[:n])
+
+	// Cleanup.
+	assert.NoError(t, conn.Close())
+	assert.NoError(t, dialer.Close())
+	_ = turnConn.Close()
+}

--- a/internal/client/tcp_alloc.go
+++ b/internal/client/tcp_alloc.go
@@ -83,6 +83,11 @@ func NewTCPAllocation(config *AllocationConfig) *TCPAllocation {
 	return alloc
 }
 
+// RelayAddr returns the relay address of the allocation.
+func (a *TCPAllocation) RelayAddr() net.Addr {
+	return a.relayedAddr
+}
+
 // Connect sends a Connect request to the turn server and returns a chosen connection ID.
 func (a *TCPAllocation) Connect(peer net.Addr) (proto.ConnectionID, error) {
 	setters := []stun.Setter{


### PR DESCRIPTION
With the upcoming addition of TURN/TCP allocations, the mental complexity of working with the client API is becoming unwieldy. As pion/turn gains adoption in areas beyond WebRTC (VPNs, P2P networks, tunneling), this complexity may become a barrier to entry. This PR proposes a simplified client API that mimics the familiar `Dialer` and `Listener` interfaces, even at the cost of hiding some TURN complexity. For simple use cases this API should be easier to pick up, while the current client API remains available for users that want full control.

This is just a humble PR to raise some discussion, definitely not production ready.

## The Problem

With TCP allocations, we now have two fundamentally different workflows for connecting to peers:

- **UDP**: Call `client.Allocate()` -> returns `net.PacketConn` -> use `WriteTo`/`ReadFrom`
- **TCP**: Call `client.AllocateTCP()` -> returns `*client.TCPAllocation` -> call `DialTCP()` -> returns `net.Conn`

Likewise for "accepting" peer connections:

- **UDP**: `ReadFrom` on the `net.PacketConn` returned by `client.Allocate()`
- **TCP**: `Accept` on the `*client.TCPAllocation` returned from `client.AllocateTCP()`

Plus there's the complexity of managing peer permissions and `client.Listen()` that users often forget to call.

## Proposal

A unified `Allocation` interface that works like a combined `Dialer` + `Listener`:

```go
type Allocation interface {
    Dial(network, address string) (net.Conn, error)
    Accept() (net.Conn, error)
    Addr() net.Addr
    Close() error
    CreatePermission(addr net.Addr) error
}
```

Key simplifications:
- Single constructor (`NewAllocation`) for both UDP and TCP
- `Dial()` handles permission creation internally
- `Accept()` works uniformly across both transport types
- Returns standard `net.Conn` instead of protocol-specific types

## Usage

### Create UDP allocation:
```
alloc, _ := turn.NewAllocation("udp", &turn.ClientConfig{
    Conn:           turnConn,
    TURNServerAddr: "turn.example.com:3478",
    Username:       "user",
    Password:       "pass",
    Realm:          "example.com",
})
defer alloc.Close()
```

For TCP, just set the network type to "tcp" and pass in a TCP TURN socket.

### Dial a peer

`Dial` creates permission automatically and returns a `net.Conn` bound to the peer both for UDP and TCP.
```
conn, _ := alloc.Dial("udp", "192.0.2.1:5000")
conn.Write([]byte("hello"))
```

### Accept incoming connections from permitted peers

Note that `Dial` automatically calls `CreatePermission`, but for listeners `CreatePermission` must be called explicitly.
```
_ = alloc.CreatePermission(peer)
incoming, _ := alloc.Accept()
// handle incoming...
```