### PR TITLE
Fix: Example Servers Users Parsing

### DIFF
--- a/examples/turn-server/add-software-attribute/main.go
+++ b/examples/turn-server/add-software-attribute/main.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/stun/v3"
@@ -67,8 +67,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{

--- a/examples/turn-server/log/main.go
+++ b/examples/turn-server/log/main.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/stun/v3"
@@ -75,8 +75,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{

--- a/examples/turn-server/perm-filter/main.go
+++ b/examples/turn-server/perm-filter/main.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -45,8 +44,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{

--- a/examples/turn-server/port-range/main.go
+++ b/examples/turn-server/port-range/main.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/turn/v4"
@@ -42,8 +42,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{

--- a/examples/turn-server/simple-multithreaded/main.go
+++ b/examples/turn-server/simple-multithreaded/main.go
@@ -13,8 +13,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/turn/v4"
@@ -43,8 +43,12 @@ func main() { //nolint:cyclop
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	// Create `numThreads` UDP listeners to pass into pion/turn

--- a/examples/turn-server/simple/main.go
+++ b/examples/turn-server/simple/main.go
@@ -10,8 +10,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/turn/v4"
@@ -41,8 +41,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{

--- a/examples/turn-server/tcp/main.go
+++ b/examples/turn-server/tcp/main.go
@@ -10,8 +10,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/turn/v4"
@@ -41,8 +41,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{

--- a/examples/turn-server/tls/main.go
+++ b/examples/turn-server/tls/main.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pion/turn/v4"
@@ -56,8 +56,12 @@ func main() {
 	// Cache -users flag for easy lookup later
 	// If passwords are stored they should be saved to your DB hashed using turn.GenerateAuthKey
 	usersMap := map[string][]byte{}
-	for _, kv := range regexp.MustCompile(`(\w+)=(\w+)`).FindAllStringSubmatch(*users, -1) {
-		usersMap[kv[1]] = turn.GenerateAuthKey(kv[1], *realm, kv[2])
+	for _, userPass := range strings.Split(*users, ",") {
+		parts := strings.SplitN(userPass, "=", 2)
+		if len(parts) != 2 {
+			log.Fatalf("Invalid user credential format '%s': expected 'username=password'", userPass)
+		}
+		usersMap[parts[0]] = turn.GenerateAuthKey(parts[0], *realm, parts[1])
 	}
 
 	server, err := turn.NewServer(turn.ServerConfig{


### PR DESCRIPTION
## Fix: Example Servers Users Parsing

Fixes https://github.com/pion/turn/issues/364

There is a bug in all server examples where usernames/passwords with non-alphanumeric characters are parsed incorrectly. We are using the regex `(\w+)=(\w+)` to parse the `-users` flag, but the `\w+` pattern only matches `[a-zA-Z0-9_]`). So for example:

  - `user-name=pass-word` --> Parses as `name:pass` (drops `user-` and `-word`)
  - `user:name=pass:word` --> Parses as `name:pass` (drops everything before colons)
  - `test@example.com=P@ssw0rd!` --> Parses as `example:P` (completely breaks)
 
This PR drops the regex based logic in favor of `strings.Split`