### PR TITLE
Consistent Joining of Host + Port

### DIFF
--- a/examples/mutual-tls-auth/turn-client/main.go
+++ b/examples/mutual-tls-auth/turn-client/main.go
@@ -9,10 +9,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/pion/logging"
@@ -70,7 +70,7 @@ func main() { //nolint:cyclop
 	}
 
 	// Dial TURN Server with TLS
-	turnServerAddr := net.JoinHostPort(*host, fmt.Sprintf("%d", *port))
+	turnServerAddr := net.JoinHostPort(*host, strconv.Itoa(*port))
 	dialer := &tls.Dialer{Config: tlsConfig}
 	conn, err := dialer.DialContext(context.Background(), "tcp", turnServerAddr)
 	if err != nil {

--- a/examples/mutual-tls-auth/turn-server/main.go
+++ b/examples/mutual-tls-auth/turn-server/main.go
@@ -8,11 +8,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/pion/turn/v4"
@@ -120,7 +120,7 @@ func main() {
 	}
 
 	// Listen on all IPv4 interfaces.
-	tlsListener, err := tls.Listen("tcp4", fmt.Sprintf("0.0.0.0:%d", *port), tlsConfig)
+	tlsListener, err := tls.Listen("tcp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port)), tlsConfig)
 	if err != nil {
 		log.Fatalf("Failed to create TLS listener: %v", err)
 	}

--- a/examples/stun-only-server/main.go
+++ b/examples/stun-only-server/main.go
@@ -28,7 +28,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create STUN server listener: %s", err)
 	}

--- a/examples/turn-client/tcp-alloc/main.go
+++ b/examples/turn-client/tcp-alloc/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/pion/logging"
@@ -79,7 +80,7 @@ func main() { //nolint:cyclop
 	}
 
 	// Dial TURN Server
-	turnServerAddrStr := fmt.Sprintf("%s:%d", *host, *port)
+	turnServerAddrStr := net.JoinHostPort(*host, strconv.Itoa(*port))
 
 	turnServerAddr, err := net.ResolveTCPAddr("tcp", turnServerAddrStr)
 	if err != nil {

--- a/examples/turn-client/tcp/main.go
+++ b/examples/turn-client/tcp/main.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,7 +33,7 @@ func main() { //nolint:cyclop
 	}
 
 	// Dial TURN Server
-	turnServerAddr := net.JoinHostPort(*host, fmt.Sprintf("%d", *port))
+	turnServerAddr := net.JoinHostPort(*host, strconv.Itoa(*port))
 	conn, err := net.Dial("tcp", turnServerAddr) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to connect to TURN server: %s", err)

--- a/examples/turn-client/udp/main.go
+++ b/examples/turn-client/udp/main.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,7 +45,7 @@ func main() { //nolint:cyclop
 		}
 	}()
 
-	turnServerAddr := fmt.Sprintf("%s:%d", *host, *port)
+	turnServerAddr := net.JoinHostPort(*host, strconv.Itoa(*port))
 
 	cfg := &turn.ClientConfig{
 		STUNServerAddr: turnServerAddr,

--- a/examples/turn-server/add-software-attribute/main.go
+++ b/examples/turn-server/add-software-attribute/main.go
@@ -59,7 +59,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/log/main.go
+++ b/examples/turn-server/log/main.go
@@ -67,7 +67,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/lt-cred-turn-rest/main.go
+++ b/examples/turn-server/lt-cred-turn-rest/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/lt-cred/main.go
+++ b/examples/turn-server/lt-cred/main.go
@@ -37,7 +37,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/perm-filter/main.go
+++ b/examples/turn-server/perm-filter/main.go
@@ -36,7 +36,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/port-range/main.go
+++ b/examples/turn-server/port-range/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/simple-multithreaded/main.go
+++ b/examples/turn-server/simple-multithreaded/main.go
@@ -35,7 +35,7 @@ func main() { //nolint:cyclop
 		log.Fatalf("'users' is required")
 	}
 
-	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:"+strconv.Itoa(*port))
+	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port)))
 	if err != nil {
 		log.Fatalf("Failed to parse server address: %s", err)
 	}

--- a/examples/turn-server/simple-quota/main.go
+++ b/examples/turn-server/simple-quota/main.go
@@ -36,7 +36,7 @@ func main() { // nolint:cyclop
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/simple/main.go
+++ b/examples/turn-server/simple/main.go
@@ -33,7 +33,7 @@ func main() {
 	// Create a UDP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any UDP sockets, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	udpListener, err := net.ListenPacket("udp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	udpListener, err := net.ListenPacket("udp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/tcp/main.go
+++ b/examples/turn-server/tcp/main.go
@@ -33,7 +33,7 @@ func main() {
 	// Create a TCP listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any TCP listeners, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	tcpListener, err := net.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(*port)) // nolint: noctx
+	tcpListener, err := net.Listen("tcp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port))) // nolint: noctx
 	if err != nil {
 		log.Panicf("Failed to create TURN server listener: %s", err)
 	}

--- a/examples/turn-server/tls/main.go
+++ b/examples/turn-server/tls/main.go
@@ -43,7 +43,7 @@ func main() {
 	// Create a TLS listener to pass into pion/turn
 	// pion/turn itself doesn't allocate any TLS listeners, but lets the user pass them in
 	// this allows us to add logging, storage or modify inbound/outbound traffic
-	tlsListener, err := tls.Listen("tcp4", "0.0.0.0:"+strconv.Itoa(*port), &tls.Config{
+	tlsListener, err := tls.Listen("tcp4", net.JoinHostPort("0.0.0.0", strconv.Itoa(*port)), &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cer},
 	})

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -280,7 +281,7 @@ func TestPacketHandler(t *testing.T) {
 	_ = alloc.AddChannelBind(channelBind, proto.DefaultLifetime, DefaultPermissionTimeout)
 
 	_, port, _ := ipnet.AddrIPPort(alloc.relayPacketConn.LocalAddr())
-	relayAddrWithHostStr := fmt.Sprintf("127.0.0.1:%d", port)
+	relayAddrWithHostStr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 	relayAddrWithHost, _ := net.ResolveUDPAddr(network, relayAddrWithHostStr)
 
 	// Test for permission and data message

--- a/internal/proto/addr.go
+++ b/internal/proto/addr.go
@@ -6,6 +6,7 @@ package proto
 import (
 	"fmt"
 	"net"
+	"strconv"
 )
 
 // Addr is ip:port.
@@ -38,7 +39,7 @@ func (a Addr) EqualIP(b Addr) bool {
 }
 
 func (a Addr) String() string {
-	return fmt.Sprintf("%s:%d", a.IP, a.Port)
+	return net.JoinHostPort(a.IP.String(), strconv.Itoa(a.Port))
 }
 
 // FiveTuple represents 5-TUPLE value.

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 
 	"github.com/pion/randutil"
 	"github.com/pion/stun/v3"
@@ -362,8 +363,8 @@ func handleCreatePermissionRequest(req Request, stunMsg *stun.Message) error {
 			return err
 		}
 
-		req.Log.Debugf("Adding permission for %s", fmt.Sprintf("%s:%d",
-			peerAddress.IP, peerAddress.Port))
+		req.Log.Debugf("Adding permission for %s", net.JoinHostPort(
+			peerAddress.IP.String(), strconv.Itoa(peerAddress.Port)))
 
 		alloc.AddPermission(allocation.NewPermission(
 			&net.UDPAddr{

--- a/relay_address_generator_none.go
+++ b/relay_address_generator_none.go
@@ -46,7 +46,7 @@ func (r *RelayAddressGeneratorNone) AllocatePacketConn(network string, requested
 	net.Addr,
 	error,
 ) {
-	conn, err := r.Net.ListenPacket(network, r.Address+":"+strconv.Itoa(requestedPort)) // nolint: noctx
+	conn, err := r.Net.ListenPacket(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort))) // nolint: noctx
 	if err != nil {
 		return nil, nil, err
 	}
@@ -65,7 +65,7 @@ func (r *RelayAddressGeneratorNone) AllocateListener(network string, requestedPo
 		}
 	}
 
-	tcpAddr, err := r.Net.ResolveTCPAddr(network, r.Address+":"+strconv.Itoa(requestedPort))
+	tcpAddr, err := r.Net.ResolveTCPAddr(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Consistent Joining of Host + Port

Now that RFC 6156: TURN Extension for IPv6 is implemented, we should get used to using `net.JoinHostPort` which is the canonical way to join a host and port (handling the v4 and v6 cases).

This PR also standardizes on `strconv.Itoa` (instead of `fmt.Sprintf` for integer-to-string conversions of ports).