### PR TITLE
TURN Client TLS Example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@
 - [turn-client](#turn-client)
 	- [tcp](#tcp-client) - Connect to TURN server via TCP
 	- [tcp-alloc](#tcp-alloc) - Create TCP allocations between peers
+	- [tls](#tls-client) - Connect to TURN server via TLS
 	- [udp](#udp) - Connect to TURN server via UDP
 - [mutual-tls-auth](#mutual-tls-auth) - Mutual TLS authentication example
 
@@ -175,6 +176,36 @@ All of these examples except `tcp-alloc` take the following arguments.
 #### tcp (client)
 
 Dials the requested TURN server via TCP
+
+#### tls (client)
+
+Dials the requested TURN server via TLS
+
+``` sh
+$ cd tls
+$ go build
+$ ./tls -host <turn-server-name> -user=user=pass
+```
+
+If the server uses certificates signed by a private CA, use `-ca` to specify the CA certificate:
+
+``` sh
+$ ./tls -host <turn-server-name> -user=user=pass -ca /path/to/ca.crt
+```
+
+Or skip verification altogether with `-insecure`:
+
+``` sh
+$ ./tls -host <turn-server-name> -user=user=pass -insecure
+```
+
+By adding `-ping`, it will perform a ping test.
+
+``` sh
+$ ./tls -host <turn-server-name> -user=user=pass -insecure -ping
+```
+
+**Note:** This example uses password-based authentication over TLS. For certificate-based authentication (mutual TLS), see the [mutual-tls-auth](#mutual-tls-auth) example.
 
 #### udp
 

--- a/examples/turn-client/tls/main.go
+++ b/examples/turn-client/tls/main.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+// Package main implements a TURN client with TLS support
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/turn/v4"
+)
+
+func main() { //nolint:cyclop
+	host := flag.String("host", "", "TURN Server name.")
+	port := flag.Int("port", 5349, "Listening port.")
+	user := flag.String("user", "", "A pair of username and password (e.g. \"user=pass\")")
+	realm := flag.String("realm", "pion.ly", "Realm (defaults to \"pion.ly\")")
+	caFile := flag.String("ca", "", "CA certificate for server verification (optional)")
+	insecure := flag.Bool("insecure", false, "Skip server certificate verification")
+	ping := flag.Bool("ping", false, "Run ping test")
+	flag.Parse()
+
+	if len(*host) == 0 {
+		log.Fatalf("'host' is required")
+	}
+
+	if len(*user) == 0 {
+		log.Fatalf("'user' is required")
+	}
+
+	// Configure TLS
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	// Load CA certificate for server verification if provided
+	// (unless insecure mode is enabled)
+	if *insecure {
+		log.Println("Warning: Server certificate verification is disabled")
+		tlsConfig.InsecureSkipVerify = true
+	} else if *caFile != "" {
+		caCert, err := os.ReadFile(*caFile)
+		if err != nil {
+			log.Fatalf("Failed to read CA certificate: %v", err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			log.Fatalf("Failed to parse CA certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+	// If neither insecure nor caFile is set, use system's default CA certificates
+
+	// Dial TURN Server with TLS
+	turnServerAddr := net.JoinHostPort(*host, fmt.Sprintf("%d", *port))
+	dialer := &tls.Dialer{Config: tlsConfig}
+	conn, err := dialer.DialContext(context.Background(), "tcp", turnServerAddr)
+	if err != nil {
+		log.Panicf("Failed to connect to TURN server: %s", err)
+	}
+
+	cred := strings.SplitN(*user, "=", 2)
+
+	// Start a new TURN Client and wrap our net.Conn in a STUNConn
+	// This allows us to simulate datagram based communication over a net.Conn
+	cfg := &turn.ClientConfig{
+		STUNServerAddr: turnServerAddr,
+		TURNServerAddr: turnServerAddr,
+		Conn:           turn.NewSTUNConn(conn),
+		Username:       cred[0],
+		Password:       cred[1],
+		Realm:          *realm,
+		LoggerFactory:  logging.NewDefaultLoggerFactory(),
+	}
+
+	client, err := turn.NewClient(cfg)
+	if err != nil {
+		log.Panicf("Failed to create TURN client: %s", err)
+	}
+	defer client.Close()
+
+	// Start listening on the conn provided.
+	err = client.Listen()
+	if err != nil {
+		log.Panicf("Failed to listen: %s", err)
+	}
+
+	// Allocate a relay socket on the TURN server. On success, it
+	// will return a net.PacketConn which represents the remote
+	// socket.
+	relayConn, err := client.Allocate()
+	if err != nil {
+		log.Panicf("Failed to allocate: %s", err)
+	}
+	defer func() {
+		if closeErr := relayConn.Close(); closeErr != nil {
+			log.Fatalf("Failed to close connection: %s", closeErr)
+		}
+	}()
+
+	// The relayConn's local address is actually the transport
+	// address assigned on the TURN server.
+	log.Printf("relayed-address=%s", relayConn.LocalAddr().String())
+
+	// If you provided `-ping`, perform a ping test against the
+	// relayConn we have just allocated.
+	if *ping {
+		err = doPingTest(client, relayConn)
+		if err != nil {
+			log.Panicf("Failed to ping: %s", err)
+		}
+	}
+}
+
+func doPingTest(client *turn.Client, relayConn net.PacketConn) error { //nolint:cyclop
+	// Send BindingRequest to learn our external IP
+	mappedAddr, err := client.SendBindingRequest()
+	if err != nil {
+		return err
+	}
+
+	// Set up pinger socket (pingerConn)
+	pingerConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
+	if err != nil {
+		log.Panicf("Failed to listen: %s", err)
+	}
+	defer func() {
+		if closeErr := pingerConn.Close(); closeErr != nil {
+			log.Panicf("Failed to close connection: %s", closeErr)
+		}
+	}()
+
+	// Punch a UDP hole for the relayConn by sending a data to the mappedAddr.
+	// This will trigger a TURN client to generate a permission request to the
+	// TURN server. After this, packets from the IP address will be accepted by
+	// the TURN server.
+	_, err = relayConn.WriteTo([]byte("Hello"), mappedAddr)
+	if err != nil {
+		return err
+	}
+
+	// Start read-loop on pingerConn
+	go func() {
+		buf := make([]byte, 1600)
+		for {
+			n, from, pingerErr := pingerConn.ReadFrom(buf)
+			if pingerErr != nil {
+				break
+			}
+
+			msg := string(buf[:n])
+			if sentAt, pingerErr := time.Parse(time.RFC3339Nano, msg); pingerErr == nil {
+				rtt := time.Since(sentAt)
+				log.Printf("%d bytes from from %s time=%d ms\n", n, from.String(), int(rtt.Seconds()*1000))
+			}
+		}
+	}()
+
+	// Start read-loop on relayConn
+	go func() {
+		buf := make([]byte, 1600)
+		for {
+			n, from, readerErr := relayConn.ReadFrom(buf)
+			if readerErr != nil {
+				break
+			}
+
+			// Echo back
+			if _, readerErr = relayConn.WriteTo(buf[:n], from); readerErr != nil {
+				break
+			}
+		}
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Send 10 packets from relayConn to the echo server
+	for i := 0; i < 10; i++ {
+		msg := time.Now().Format(time.RFC3339Nano)
+		_, err = pingerConn.WriteTo([]byte(msg), relayConn.LocalAddr())
+		if err != nil {
+			return err
+		}
+
+		// For simplicity, this example does not wait for the pong (reply).
+		// Instead, sleep 1 second.
+		time.Sleep(time.Second)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## TURN Client TLS Example

Adds an example of a turn-client talking to turn-server over tls. Example has flags for bypassing server cert verification or providing a specific CA cert for verification.

Closes https://github.com/pion/turn/issues/434

### Testing

Running existing server example, with cert signed by private CA:

```
✔ ~/go/src/github.com/adrianosela/turn/examples/turn-server/tls [tls-client-example|…3]
19:38 $ go run main.go -public-ip 127.0.0.1 -users username=password -cert server.crt -key server.key
```

Running new client example, with CA cert passed for server cert verification:

```
✔ ~/go/src/github.com/adrianosela/turn/examples/turn-client/tls [tls-client-example|…3]
19:38 $ go run main.go -host localhost -user username=password -ca ca.crt -ping
2026/01/12 19:38:11 relayed-address=127.0.0.1:58498
2026/01/12 19:38:12 32 bytes from from 127.0.0.1:58498 time=2 ms
2026/01/12 19:38:13 31 bytes from from 127.0.0.1:58498 time=0 ms
2026/01/12 19:38:14 32 bytes from from 127.0.0.1:58498 time=7 ms
2026/01/12 19:38:15 32 bytes from from 127.0.0.1:58498 time=1 ms
2026/01/12 19:38:16 31 bytes from from 127.0.0.1:58498 time=1 ms
2026/01/12 19:38:17 32 bytes from from 127.0.0.1:58498 time=0 ms
```

Running new client example, with -insecure flag to skip server cert verification:

```
✔ ~/go/src/github.com/adrianosela/turn/examples/turn-client/tls [tls-client-example|…3]
19:39 $ go run main.go -host localhost -user username=password -insecure -ping
2026/01/12 19:39:48 Warning: Server certificate verification is disabled
2026/01/12 19:39:48 relayed-address=127.0.0.1:60877
2026/01/12 19:39:48 31 bytes from from 127.0.0.1:60877 time=0 ms
2026/01/12 19:39:49 32 bytes from from 127.0.0.1:60877 time=1 ms
2026/01/12 19:39:50 31 bytes from from 127.0.0.1:60877 time=0 ms
2026/01/12 19:39:51 31 bytes from from 127.0.0.1:60877 time=0 ms
```

Running new client example, with neither -ca nor -insecure flags (therefore using the system's trusted certs - which should result in failed verification):

```
✔ ~/go/src/github.com/adrianosela/turn/examples/turn-client/tls [tls-client-example|…3]
19:40 $ go run main.go -host localhost -user username=password
2026/01/12 19:40:12 Failed to connect to TURN server: tls: failed to verify certificate: x509: “turn-server” certificate is not trusted
panic: Failed to connect to TURN server: tls: failed to verify certificate: x509: “turn-server” certificate is not trusted

goroutine 1 [running]:
log.Panicf({0x1027e872b?, 0x1028bacb0?}, {0x14000149dd0?, 0x1027de776?, 0x1?})
	/opt/homebrew/Cellar/go@1.23/1.23.12/libexec/src/log/log.go:439 +0x64
main.main()
	/Users/adriano/go/src/github.com/adrianosela/turn/examples/turn-client/tls/main.go:70 +0x528
exit status 2
```