### PR TITLE
Make RelayGen allocator API extensible

### DIFF
--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -333,23 +333,23 @@ func TestTCPRelay_E2E(t *testing.T) {
 
 	manager, err := NewManager(ManagerConfig{
 		LeveledLogger: logging.NewDefaultLoggerFactory().NewLogger("test"),
-		AllocatePacketConn: func(string, int) (net.PacketConn, net.Addr, error) {
+		AllocatePacketConn: func(AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			ln, listenerErr := (&net.ListenConfig{Control: reuseport.Control}).
 				Listen(context.TODO(), "tcp4", "127.0.0.1:0")
 			assert.NoError(t, listenerErr)
 
 			return ln, ln.Addr(), nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(info AllocateConnConfig) (net.Conn, error) {
 			dialer := net.Dialer{
-				LocalAddr: laddr,
+				LocalAddr: info.LocalAddr,
 				Control:   reuseport.Control,
 			}
 
-			return dialer.Dial(network, raddr.String())
+			return dialer.Dial(info.Network, info.RemoteAddr.String())
 		},
 	})
 	assert.NoError(t, err)

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -63,18 +63,18 @@ func TestAllocationLifeTime(t *testing.T) {
 		logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 		allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-			AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-				con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+			AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+				con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 				if err != nil {
 					return nil, nil, listenErr
 				}
 
 				return con, con.LocalAddr(), nil
 			},
-			AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+			AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 				return nil, nil, nil
 			},
-			AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+			AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 				return nil, nil //nolint:nilnil
 			},
 			LeveledLogger: logger,
@@ -126,18 +126,18 @@ func TestRequestedTransport(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if err != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -181,19 +181,19 @@ func TestConnectRequest(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if err != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, _, raddr net.Addr) (net.Conn, error) {
-			return net.Dial("tcp4", raddr.String()) // nolint: noctx
+		AllocateConn: func(conf allocation.AllocateConnConfig) (net.Conn, error) {
+			return net.Dial("tcp4", conf.RemoteAddr.String()) // nolint: noctx
 		},
 		LeveledLogger: logger,
 	})
@@ -268,19 +268,19 @@ func TestConnectionBindRequest(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if err != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, _, raddr net.Addr) (net.Conn, error) {
-			return net.Dial("tcp4", raddr.String()) // nolint: noctx
+		AllocateConn: func(conf allocation.AllocateConnConfig) (net.Conn, error) {
+			return net.Dial("tcp4", conf.RemoteAddr.String()) // nolint: noctx
 		},
 		LeveledLogger: logger,
 	})
@@ -339,18 +339,18 @@ func TestRequestedAddressFamilyIPv6(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "[::]:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "[::]:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -400,18 +400,18 @@ func TestRequestedAddressFamilyUnsupported(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -459,18 +459,18 @@ func TestRequestedAddressFamilyMutualExclusivity(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -519,18 +519,18 @@ func TestHandleRefreshRequestRequestedAddressFamilyMismatch(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -606,18 +606,18 @@ func TestHandleCreatePermissionRequest(t *testing.T) { //nolint:dupl
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -720,18 +720,18 @@ func TestHandleSendIndication(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -824,18 +824,18 @@ func TestHandleChannelBindRequest(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -954,18 +954,18 @@ func TestHandleAllocationRequest(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -1035,18 +1035,18 @@ func TestHandleDuplicateAllocationRequest(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,
@@ -1134,18 +1134,18 @@ func TestHandleChannelData(t *testing.T) {
 	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
-		AllocatePacketConn: func(network string, _ int) (net.PacketConn, net.Addr, error) {
-			con, listenErr := net.ListenPacket(network, "0.0.0.0:0") // nolint: noctx
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
 			if listenErr != nil {
 				return nil, nil, listenErr
 			}
 
 			return con, con.LocalAddr(), nil
 		},
-		AllocateListener: func(string, int) (net.Listener, net.Addr, error) {
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
 			return nil, nil, nil
 		},
-		AllocateConn: func(network string, laddr, raddr net.Addr) (net.Conn, error) {
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
 			return nil, nil //nolint:nilnil
 		},
 		LeveledLogger: logger,

--- a/relay_address_generator_static.go
+++ b/relay_address_generator_static.go
@@ -49,10 +49,10 @@ func (r *RelayAddressGeneratorStatic) Validate() error {
 // AllocatePacketConn generates a new PacketConn to receive traffic on and the IP/Port
 // to populate the allocation response with.
 func (r *RelayAddressGeneratorStatic) AllocatePacketConn(
-	network string,
-	requestedPort int,
+	conf AllocateListenerConfig,
 ) (net.PacketConn, net.Addr, error) {
-	conn, err := r.Net.ListenPacket(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort))) // nolint: noctx
+	conn, err := r.Net.ListenPacket(conf.Network,
+		net.JoinHostPort(r.Address, strconv.Itoa(conf.RequestedPort))) // nolint: noctx
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,7 +70,7 @@ func (r *RelayAddressGeneratorStatic) AllocatePacketConn(
 
 // AllocateListener generates a new Listener to receive traffic on and the IP/Port
 // to populate the allocation response with.
-func (r *RelayAddressGeneratorStatic) AllocateListener(network string, requestedPort int) (net.Listener, net.Addr, error) { // nolint: lll
+func (r *RelayAddressGeneratorStatic) AllocateListener(conf AllocateListenerConfig) (net.Listener, net.Addr, error) {
 	// AllocateListener can be called independently of Validate (e.g. in tests),
 	// so ensure we're initialized to avoid nil dereferences.
 	if r.Net == nil || r.Address == "" || r.RelayAddress == nil {
@@ -79,7 +79,7 @@ func (r *RelayAddressGeneratorStatic) AllocateListener(network string, requested
 		}
 	}
 
-	tcpAddr, err := r.Net.ResolveTCPAddr(network, net.JoinHostPort(r.Address, strconv.Itoa(requestedPort)))
+	tcpAddr, err := r.Net.ResolveTCPAddr(conf.Network, net.JoinHostPort(r.Address, strconv.Itoa(conf.RequestedPort)))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,7 +89,7 @@ func (r *RelayAddressGeneratorStatic) AllocateListener(network string, requested
 		// bind to the same relay address.
 		Control: reuseport.Control,
 	})
-	ln, err := listenConfig.Listen(context.TODO(), network, tcpAddr.String())
+	ln, err := listenConfig.Listen(context.TODO(), conf.Network, tcpAddr.String())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,13 +108,13 @@ func (r *RelayAddressGeneratorStatic) AllocateListener(network string, requested
 }
 
 // AllocateConn creates a new outgoing TCP connection bound to the relay address to send traffic to a peer.
-func (r *RelayAddressGeneratorStatic) AllocateConn(network string, laddr, raddr net.Addr) (net.Conn, error) {
+func (r *RelayAddressGeneratorStatic) AllocateConn(conf AllocateConnConfig) (net.Conn, error) {
 	dialer := r.Net.CreateDialer(&net.Dialer{
-		LocalAddr: laddr,
+		LocalAddr: conf.LocalAddr,
 		// Enable SO_REUSEADDR and SO_REUSEPORT where needed to let multiple connnections
 		// bind to the same relay address.
 		Control: reuseport.Control,
 	})
 
-	return dialer.Dial(network, raddr.String())
+	return dialer.Dial(conf.Network, conf.RemoteAddr.String())
 }

--- a/server.go
+++ b/server.go
@@ -208,15 +208,15 @@ type nilAddressGenerator struct{}
 
 func (n *nilAddressGenerator) Validate() error { return errRelayAddressGeneratorNil }
 
-func (n *nilAddressGenerator) AllocatePacketConn(string, int) (net.PacketConn, net.Addr, error) {
+func (n *nilAddressGenerator) AllocatePacketConn(AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
 	return nil, nil, errRelayAddressGeneratorNil
 }
 
-func (n *nilAddressGenerator) AllocateListener(string, int) (net.Listener, net.Addr, error) {
+func (n *nilAddressGenerator) AllocateListener(AllocateListenerConfig) (net.Listener, net.Addr, error) {
 	return nil, nil, errRelayAddressGeneratorNil
 }
 
-func (n *nilAddressGenerator) AllocateConn(network string, laddr, raddr net.Addr) (net.Conn, error) {
+func (n *nilAddressGenerator) AllocateConn(AllocateConnConfig) (net.Conn, error) {
 	return nil, errRelayAddressGeneratorNil
 }
 

--- a/server_config.go
+++ b/server_config.go
@@ -15,6 +15,12 @@ import (
 	"github.com/pion/turn/v4/internal/auth"
 )
 
+// AllocateListenerConfig defines the parameters passed to the relay address allocator.
+type AllocateListenerConfig = allocation.AllocateListenerConfig
+
+// AllocateConnConfig defines the parameters passed to the TCP connection generator.
+type AllocateConnConfig = allocation.AllocateConnConfig
+
 // RelayAddressGenerator is used to generate a RelayAddress when creating an allocation.
 // You can use one of the provided ones or provide your own.
 type RelayAddressGenerator interface {
@@ -22,13 +28,13 @@ type RelayAddressGenerator interface {
 	Validate() error
 
 	// Allocate a PacketConn (UDP) RelayAddress
-	AllocatePacketConn(network string, requestedPort int) (net.PacketConn, net.Addr, error)
+	AllocatePacketConn(AllocateListenerConfig) (net.PacketConn, net.Addr, error)
 
 	// Allocate a Listener (TCP) RelayAddress
-	AllocateListener(network string, requestedPort int) (net.Listener, net.Addr, error)
+	AllocateListener(AllocateListenerConfig) (net.Listener, net.Addr, error)
 
-	// Allocate a Conn (TCP) RelayAddress
-	AllocateConn(network string, laddr, raddr net.Addr) (net.Conn, error)
+	// Allocate a Conn (TCP) relay connection
+	AllocateConn(AllocateConnConfig) (net.Conn, error)
 }
 
 // PermissionHandler is a callback to filter incoming CreatePermission and ChannelBindRequest


### PR DESCRIPTION
See #150 and [this comment](https://github.com/pion/turn/issues/150#issuecomment-3743797983)

There has been a couple of requests to extend the RelayGenerator listener/connection allocation API with new parameters. Especially adding the username/realm to the allocators' parameter list is compelling, in order to "personalize" relay address/connection allocations and implement per-user bandwidth quotas. This PR aims to make the API extensible by packing all parameters into a struct.
