### PR TITLE
Tighten IPv6 address-family handling

### DIFF
--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -331,7 +331,16 @@ func (m *Manager) CreateTCPConnection( // nolint: cyclop
 	}
 	m.lock.Unlock()
 
-	conn, err := m.allocateConn("tcp4", relayAddr, remoteAddr) // nolint: noctx
+	// RFC 6156:
+	// "After the request has been successfully authenticated, the TURN
+	// server allocates a transport address of the type indicated in the
+	// REQUESTED-ADDRESS-FAMILY attribute."
+	network := "tcp4"
+	if allocation.AddressFamily() == proto.RequestedFamilyIPv6 {
+		network = "tcp6"
+	}
+
+	conn, err := m.allocateConn(network, relayAddr, remoteAddr) // nolint: noctx
 	if err != nil {
 		m.log.Warnf("Failed to create TCP Connection: %v", err)
 

--- a/internal/client/tcp_conn_test.go
+++ b/internal/client/tcp_conn_test.go
@@ -197,3 +197,26 @@ func TestTCPConn(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestTCPAllocationServerTCPAddrPreservesZone(t *testing.T) {
+	zone := "eth0"
+	ip := net.ParseIP("fe80::1")
+
+	alloc := TCPAllocation{allocation: allocation{
+		serverAddr: &net.TCPAddr{IP: ip, Port: 3478, Zone: zone},
+	}}
+	addr, err := alloc.serverTCPAddr()
+	assert.NoError(t, err)
+	assert.Equal(t, zone, addr.Zone)
+	assert.Equal(t, ip, addr.IP)
+	assert.Equal(t, 3478, addr.Port)
+
+	alloc = TCPAllocation{allocation: allocation{
+		serverAddr: &net.UDPAddr{IP: ip, Port: 3478, Zone: zone},
+	}}
+	addr, err = alloc.serverTCPAddr()
+	assert.NoError(t, err)
+	assert.Equal(t, zone, addr.Zone)
+	assert.Equal(t, ip, addr.IP)
+	assert.Equal(t, 3478, addr.Port)
+}


### PR DESCRIPTION
#### Description

I had nothing on my todo list today so i thought with helping testing the new turn stuff \:)
Found few nits with IPV6 handling while testing on an IPv6 network.

this does:
- honor requested address family for TCP connections
- return 443 on invalid/mismatched requested-family in refresh
- preserve IPv6 zone when deriving TCP server addr.
