### PR TITLE
Return the parsed user-id from the AuthHandler

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -153,8 +153,8 @@ func TestClientNonceExpiration(t *testing.T) {
 	assert.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		PacketConnConfigs: []PacketConnConfig{
 			{
@@ -201,8 +201,8 @@ func TestTCPClient(t *testing.T) {
 	require.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		ListenerConfigs: []ListenerConfig{
 			{
@@ -268,7 +268,7 @@ func TestTCPClientWithoutAddress(t *testing.T) {
 	assert.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
 			// Sleep needed for sending retransmission.
 			if runtime.GOOS == "windows" {
 				time.Sleep(20 * time.Millisecond)
@@ -276,7 +276,7 @@ func TestTCPClientWithoutAddress(t *testing.T) {
 				time.Sleep(time.Millisecond)
 			}
 
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		ListenerConfigs: []ListenerConfig{
 			{
@@ -337,8 +337,8 @@ func TestClientReadTimout(t *testing.T) {
 	assert.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		PacketConnConfigs: []PacketConnConfig{
 			{
@@ -387,8 +387,8 @@ func TestTCPClientDial(t *testing.T) {
 	require.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		ListenerConfigs: []ListenerConfig{
 			{
@@ -481,8 +481,8 @@ func TestTCPClientAccept(t *testing.T) {
 	require.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		ListenerConfigs: []ListenerConfig{
 			{
@@ -555,8 +555,8 @@ func TestTCPClientMultipleConns(t *testing.T) {
 	require.NoError(t, err)
 
 	server, err := NewServer(ServerConfig{
-		AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-			return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 		},
 		ListenerConfigs: []ListenerConfig{
 			{
@@ -811,8 +811,8 @@ func TestClientE2E(t *testing.T) {
 		assert.NoError(t, err)
 
 		server, err := NewServer(ServerConfig{
-			AuthHandler: func(ra *RequestAttributes) (key []byte, ok bool) {
-				return GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+			AuthHandler: func(ra *RequestAttributes) (userID string, key []byte, ok bool) {
+				return ra.Username, GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
 			},
 			PacketConnConfigs: []PacketConnConfig{
 				{

--- a/examples/mutual-tls-auth/turn-server/main.go
+++ b/examples/mutual-tls-auth/turn-server/main.go
@@ -29,11 +29,11 @@ import (
 // In your own code, you may choose to use some other uniquely-identifying property
 // in the certificate e.g. serial number or combination of SANs.
 func getClientTLSAuthHandler(verifyOpts x509.VerifyOptions) turn.AuthHandler {
-	return func(ra *turn.RequestAttributes) ([]byte, bool) {
+	return func(ra *turn.RequestAttributes) (string, []byte, bool) {
 		if ra.TLS == nil || len(ra.TLS.PeerCertificates) == 0 {
 			log.Printf("Request not allowed: no TLS state metadata")
 
-			return nil, false
+			return "", nil, false
 		}
 
 		for _, cert := range ra.TLS.PeerCertificates {
@@ -52,12 +52,12 @@ func getClientTLSAuthHandler(verifyOpts x509.VerifyOptions) turn.AuthHandler {
 			log.Printf("Certificate validated for username %q", ra.Username)
 
 			// Note the empty password for certificate-based auth
-			return turn.GenerateAuthKey(ra.Username, ra.Realm, ""), true
+			return ra.Username, turn.GenerateAuthKey(ra.Username, ra.Realm, ""), true
 		}
 
 		log.Printf("Request not allowed: no valid certificates found")
 
-		return nil, false
+		return "", nil, false
 	}
 }
 

--- a/examples/turn-server/add-software-attribute/main.go
+++ b/examples/turn-server/add-software-attribute/main.go
@@ -80,12 +80,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: []turn.PacketConnConfig{

--- a/examples/turn-server/ipv6/main.go
+++ b/examples/turn-server/ipv6/main.go
@@ -58,12 +58,12 @@ func main() { //nolint:gocyclo,cyclop
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: []turn.PacketConnConfig{

--- a/examples/turn-server/log/main.go
+++ b/examples/turn-server/log/main.go
@@ -88,12 +88,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: []turn.PacketConnConfig{

--- a/examples/turn-server/perm-filter/main.go
+++ b/examples/turn-server/perm-filter/main.go
@@ -57,12 +57,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: []turn.PacketConnConfig{

--- a/examples/turn-server/port-range/main.go
+++ b/examples/turn-server/port-range/main.go
@@ -55,12 +55,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: []turn.PacketConnConfig{

--- a/examples/turn-server/simple-multithreaded/main.go
+++ b/examples/turn-server/simple-multithreaded/main.go
@@ -94,12 +94,12 @@ func main() { //nolint:cyclop
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: packetConnConfigs,

--- a/examples/turn-server/simple/main.go
+++ b/examples/turn-server/simple/main.go
@@ -54,12 +54,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// PacketConnConfigs is a list of UDP Listeners and the configuration around them
 		PacketConnConfigs: []turn.PacketConnConfig{

--- a/examples/turn-server/tcp/main.go
+++ b/examples/turn-server/tcp/main.go
@@ -54,12 +54,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// ListenerConfig is a list of Listeners and the configuration around them
 		ListenerConfigs: []turn.ListenerConfig{

--- a/examples/turn-server/tls/main.go
+++ b/examples/turn-server/tls/main.go
@@ -69,12 +69,12 @@ func main() {
 		// Set AuthHandler callback
 		// This is called every time a user tries to authenticate with the TURN server
 		// Return the key for that user, or false when no user is found
-		AuthHandler: func(ra *turn.RequestAttributes) ([]byte, bool) {
+		AuthHandler: func(ra *turn.RequestAttributes) (string, []byte, bool) {
 			if key, ok := usersMap[ra.Username]; ok {
-				return key, true
+				return ra.Username, key, true
 			}
 
-			return nil, false
+			return "", nil, false
 		},
 		// ListenerConfig is a list of Listeners and the configuration around them
 		ListenerConfigs: []turn.ListenerConfig{

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -42,7 +42,7 @@ type Allocation struct {
 	channelBindings     []*ChannelBind
 	lifetimeTimer       *time.Timer
 	closed              chan any
-	username, realm     string
+	userID, realm       string
 	eventHandler        EventHandler
 	log                 logging.LeveledLogger
 	addressFamily       proto.RequestedAddressFamily // RFC 6156
@@ -110,7 +110,7 @@ func (a *Allocation) AddPermission(perms *Permission) {
 	if a.eventHandler.OnPermissionCreated != nil {
 		if u, ok := perms.Addr.(*net.UDPAddr); ok {
 			a.eventHandler.OnPermissionCreated(a.fiveTuple.SrcAddr, a.fiveTuple.DstAddr,
-				a.fiveTuple.Protocol.String(), a.username, a.realm,
+				a.fiveTuple.Protocol.String(), a.userID, a.realm,
 				a.RelayAddr, u.IP)
 		}
 	}
@@ -127,7 +127,7 @@ func (a *Allocation) RemovePermission(addr net.Addr) {
 	if a.eventHandler.OnPermissionDeleted != nil {
 		if u, ok := addr.(*net.UDPAddr); ok {
 			a.eventHandler.OnPermissionDeleted(a.fiveTuple.SrcAddr, a.fiveTuple.DstAddr,
-				a.fiveTuple.Protocol.String(), a.username, a.realm,
+				a.fiveTuple.Protocol.String(), a.userID, a.realm,
 				a.RelayAddr, u.IP)
 		}
 	}
@@ -170,7 +170,7 @@ func (a *Allocation) AddChannelBind(chanBind *ChannelBind, channelLifetime, perm
 
 		if a.eventHandler.OnChannelCreated != nil {
 			a.eventHandler.OnChannelCreated(a.fiveTuple.SrcAddr, a.fiveTuple.DstAddr,
-				a.fiveTuple.Protocol.String(), a.username, a.realm,
+				a.fiveTuple.Protocol.String(), a.userID, a.realm,
 				a.RelayAddr, chanBind.Peer, uint16(chanBind.Number))
 		}
 	} else {
@@ -192,7 +192,7 @@ func (a *Allocation) RemoveChannelBind(number proto.ChannelNumber) bool {
 		if a.channelBindings[i].Number == number {
 			if a.eventHandler.OnChannelDeleted != nil {
 				a.eventHandler.OnChannelDeleted(a.fiveTuple.SrcAddr, a.fiveTuple.DstAddr,
-					a.fiveTuple.Protocol.String(), a.username, a.realm,
+					a.fiveTuple.Protocol.String(), a.userID, a.realm,
 					a.RelayAddr, a.channelBindings[i].Peer, uint16(a.channelBindings[i].Number))
 			}
 

--- a/internal/allocation/event_handler.go
+++ b/internal/allocation/event_handler.go
@@ -9,9 +9,10 @@ import (
 
 // EventHandler is a set of callbacks that the server will call at certain hook points during an
 // allocation's lifecycle. All events are reported with the context that identifies the allocation
-// triggering the event (source and destination address, protocol, username and realm used for
-// authenticating the allocation), plus additional callback specific parameters. It is OK to handle
-// only a subset of the callbacks.
+// triggering the event (source and destination address, protocol, user-id (as parsed and returned
+// by the authentication handler from the TURN username) and realm used for authenticating the
+// allocation), plus additional callback specific parameters. It is OK to handle only a subset of
+// the callbacks.
 type EventHandler struct {
 	// OnAuth is called after an authentication request has been processed with the TURN method
 	// triggering the authentication request (either "Allocate", "Refresh" "CreatePermission",
@@ -20,28 +21,28 @@ type EventHandler struct {
 	// OnAllocationCreated is called after a new allocation has been made. The relayAddr
 	// argument specifies the relay address and requestedPort is the port requested by the
 	// client (if any).
-	OnAllocationCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+	OnAllocationCreated func(srcAddr, dstAddr net.Addr, protocol, userID, realm string,
 		relayAddr net.Addr, requestedPort int)
 	// OnAllocationDeleted is called after an allocation has been removed.
-	OnAllocationDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string)
+	OnAllocationDeleted func(srcAddr, dstAddr net.Addr, protocol, userID, realm string)
 	// OnAllocationError is called when the readloop hdndling an allocation exits with an
 	// error with an error message.
 	OnAllocationError func(srcAddr, dstAddr net.Addr, protocol, message string)
 	// OnPermissionCreated is called after a new permission has been made to an IP address.
-	OnPermissionCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+	OnPermissionCreated func(srcAddr, dstAddr net.Addr, protocol, userID, realm string,
 		relayAddr net.Addr, peer net.IP)
 	// OnPermissionDeleted is called after a permission for a given IP address has been
 	// removed.
-	OnPermissionDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+	OnPermissionDeleted func(srcAddr, dstAddr net.Addr, protocol, userID, realm string,
 		relayAddr net.Addr, peer net.IP)
 	// OnChannelCreated is called after a new channel has been made. The relay address, the
 	// peer address and the channel number can be used to uniquely identify the channel
 	// created.
-	OnChannelCreated func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+	OnChannelCreated func(srcAddr, dstAddr net.Addr, protocol, userID, realm string,
 		relayAddr, peer net.Addr, channelNumber uint16)
 	// OnChannelDeleted is called after a channel has been removed from the server. The relay
 	// address, the peer address and the channel number can be used to uniquely identify the
 	// channel deleted.
-	OnChannelDeleted func(srcAddr, dstAddr net.Addr, protocol, username, realm string,
+	OnChannelDeleted func(srcAddr, dstAddr net.Addr, protocol, userID, realm string,
 		relayAddr, peer net.Addr, channelNumber uint16)
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -23,4 +23,4 @@ type RequestAttributes struct {
 
 // AuthHandler is a callback used to handle incoming auth requests,
 // allowing users to customize Pion TURN with custom behavior.
-type AuthHandler func(ra *RequestAttributes) (key []byte, ok bool)
+type AuthHandler func(ra *RequestAttributes) (userID string, key []byte, ok bool)

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -105,7 +105,7 @@ func authenticateRequest(req Request, stunMsg *stun.Message, callingMethod stun.
 		return nil, false, "", buildAndSendErr(req.Conn, req.SrcAddr, err, badRequestMsg...)
 	}
 
-	ourKey, ok := req.AuthHandler(&auth.RequestAttributes{
+	userID, ourKey, ok := req.AuthHandler(&auth.RequestAttributes{
 		Username: usernameAttr.String(),
 		Realm:    realmAttr.String(),
 		SrcAddr:  req.SrcAddr,
@@ -128,7 +128,7 @@ func authenticateRequest(req Request, stunMsg *stun.Message, callingMethod stun.
 
 	genAuthEvent(req, stunMsg, callingMethod, true)
 
-	return stun.MessageIntegrity(ourKey), true, usernameAttr.String(), nil
+	return stun.MessageIntegrity(ourKey), true, userID, nil
 }
 
 func genAuthEvent(req Request, stunMsg *stun.Message, callingMethod stun.Method, verdict bool) {
@@ -141,6 +141,7 @@ func genAuthEvent(req Request, stunMsg *stun.Message, callingMethod stun.Method,
 		return
 	}
 
+	// Auth event is generated per the username, not the user-id.
 	usernameAttr := &stun.Username{}
 	if err := usernameAttr.GetFrom(stunMsg); err != nil {
 		return


### PR DESCRIPTION
This PR changes the `AuthHandler` to return the user-id from the auth layer. The user-id is typically the same as the TURN username, except for authentication schemes that overload the username with additional info (like [time-windowed TURN credentials](https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00)). The rest of the server stack then uses the user-id instead of the username to identify users in the various handlers, which makes sure that, e.g., the `EventHandler` API will identify allocations per user-id and the same user-id is then passed to the `QuotaHanlder` and the `RelayAddressGenerator` socket allocators. This prevents errors when, e.g., we account two allocations created with the same user-id but with different timestamps as two different users in the quota handler.

Merging strategy: if this is merged, then rebase and merge #531, and then rebase and merge #532.