### PR TITLE
Fix UDPConn.WriteTo to return the payload length

### DIFF
--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -238,7 +238,11 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 			return 0, err
 		}
 
-		return c.client.WriteTo(msg.Raw, c.serverAddr)
+		if _, err = c.client.WriteTo(msg.Raw, c.serverAddr); err != nil {
+			return 0, err
+		}
+
+		return len(payload), nil
 	}
 
 	// Binding is ready beyond this point, so send over it.


### PR DESCRIPTION
`UDPConn.WriteTo` has two paths: write via ChannelData (after binding channel) or write via SendIndication (before binding). The SendIndication path was returning the STUN message size instead of the actual payload size (the ChanelData write-path is already returning the correct payload length). This breaks `io.Copy` which expects Write to return exactly the number of bytes from the source buffer. When this invariant does not hold, io.Copy fails with "invalid write result". 

This fix ensures both paths return len(payload) per the net.PacketConn contract.


