### PR TITLE
Fixed channel number reuse, added server logs

### DIFF
--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -151,9 +151,16 @@ func (a *Allocation) AddChannelBind(chanBind *ChannelBind, channelLifetime, perm
 	// Check that this channel id isn't bound to another transport address, and
 	// that this transport address isn't bound to another channel number.
 	channelByNumber := a.GetChannelByNumber(chanBind.Number)
+	channelByAddr := a.GetChannelByAddr(chanBind.Peer)
 
-	if channelByNumber != a.GetChannelByAddr(chanBind.Peer) {
-		return errSameChannelDifferentPeer
+	// Peer already bound to a different channel number.
+	if channelByAddr != nil && channelByAddr.Number != chanBind.Number {
+		return ErrSamePeerDifferentChannel
+	}
+
+	// Channel number already bound to a different peer.
+	if channelByNumber != nil && !ipnet.AddrEqual(channelByNumber.Peer, chanBind.Peer) {
+		return ErrSameChannelDifferentPeer
 	}
 
 	// Add or refresh this channel.

--- a/internal/allocation/errors.go
+++ b/internal/allocation/errors.go
@@ -9,11 +9,18 @@ var (
 	ErrTCPConnectionTimeoutOrFailure = errors.New("failed to create tcp connection")
 	ErrDupeTCPConnection             = errors.New("tcp connection already exists for peer address")
 
+	// ErrSameChannelDifferentPeer is returned when a client attempts to bind a
+	// channel number that is already bound to a different peer address.
+	ErrSameChannelDifferentPeer = errors.New("you cannot use the same channel number with different peer")
+
+	// ErrSamePeerDifferentChannel is returned when a client attempts to bind a
+	// peer address that is already bound to a different channel number.
+	ErrSamePeerDifferentChannel = errors.New("you cannot use the same peer with different channel number")
+
 	errAllocatePacketConnMustBeSet  = errors.New("AllocatePacketConn must be set")
 	errAllocateListenerMustBeSet    = errors.New("AllocateListener must be set")
 	errAllocateConnMustBeSet        = errors.New("AllocateConn must be set")
 	errLeveledLoggerMustBeSet       = errors.New("LeveledLogger must be set")
-	errSameChannelDifferentPeer     = errors.New("you cannot use the same channel number with different peer")
 	errNilFiveTuple                 = errors.New("allocations must not be created with nil FivTuple")
 	errNilFiveTupleSrcAddr          = errors.New("allocations must not be created with nil FiveTuple.SrcAddr")
 	errNilFiveTupleDstAddr          = errors.New("allocations must not be created with nil FiveTuple.DstAddr")

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -472,8 +472,6 @@ func (c *UDPConn) bind(bound *binding) error {
 
 	trRes, err := c.client.PerformTransaction(msg, c.serverAddr, false)
 	if err != nil {
-		c.bindingMgr.deleteByAddr(bound.addr)
-
 		return err
 	}
 

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUDPConn(t *testing.T) {
+func TestUDPConn(t *testing.T) { // nolint:maintidx
 	makeConn := func(client *mockClient, bm *bindingManager) UDPConn {
 		return UDPConn{
 			allocation: allocation{
@@ -104,7 +104,7 @@ func TestUDPConn(t *testing.T) {
 					return TransactionResult{}, errFake
 				},
 				expectErr:            errFake,
-				expectBindingDeleted: true,
+				expectBindingDeleted: false,
 			},
 			{
 				name: "ErrorResponse with CodeStaleNonce triggers nonce update",
@@ -134,6 +134,14 @@ func TestUDPConn(t *testing.T) {
 				if tt.expectBindingDeleted {
 					assert.Empty(t, bm.chanMap)
 					assert.Empty(t, bm.addrMap)
+				} else {
+					// Binding should remain so we don't re-bind the same peer with a different channel number
+					// after a lost/failed ChannelBind transaction.
+					assert.NotEmpty(t, bm.chanMap)
+					assert.NotEmpty(t, bm.addrMap)
+					b2, ok := bm.findByAddr(bound.addr)
+					assert.True(t, ok)
+					assert.Equal(t, bound.number, b2.number)
 				}
 
 				nonceT1 := conn.nonce()
@@ -233,6 +241,52 @@ func TestUDPConn(t *testing.T) {
 		assert.Equal(t, len(payload), n,
 			"WriteTo should return payload length (%d), not STUN message length (%d)",
 			len(payload), len(writtenData))
+	})
+
+	t.Run("ChannelBind transaction failure retains channel number", func(t *testing.T) {
+		addr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9999}
+		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
+
+		pm := newPermissionMap()
+		assert.True(t, pm.insert(addr, &permission{st: permStatePermitted}))
+
+		bm := newBindingManager()
+		bound := bm.create(addr)
+		originalCh := bound.number
+
+		client := &mockClient{
+			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				return TransactionResult{}, errFake
+			},
+			writeTo: func(data []byte, _ net.Addr) (int, error) {
+				return len(data), nil
+			},
+		}
+
+		conn := UDPConn{
+			allocation: allocation{
+				client:     client,
+				serverAddr: serverAddr,
+				permMap:    pm,
+				username:   stun.NewUsername("user"),
+				realm:      stun.NewRealm("realm"),
+				integrity:  stun.NewShortTermIntegrity("pass"),
+				_nonce:     stun.NewNonce("nonce"),
+				log:        logging.NewDefaultLoggerFactory().NewLogger("test"),
+			},
+			bindingMgr: bm,
+		}
+
+		// A failed bind attempt should not remove the binding, so a subsequent WriteTo
+		// should not allocate a different channel number for the same peer.
+		err := conn.bind(bound)
+		assert.ErrorIs(t, err, errFake)
+
+		_, _ = conn.WriteTo([]byte("hi"), addr)
+
+		b2, ok := bm.findByAddr(addr)
+		assert.True(t, ok)
+		assert.Equal(t, originalCh, b2.number)
 	})
 }
 

--- a/internal/ipnet/util.go
+++ b/internal/ipnet/util.go
@@ -26,15 +26,26 @@ func AddrIPPort(a net.Addr) (net.IP, int, error) {
 	return nil, 0, errFailedToCastAddr
 }
 
-// AddrEqual asserts that two net.Addrs are equal
-// Currently only supports UDP but will be extended in the future to support others.
-func AddrEqual(a, b net.Addr) bool {
-	aUDP, ok := a.(*net.UDPAddr)
+// AddrEqual asserts that two net.Addrs are equal.
+// Compares IP and Port and intentionally ignores IPv6 Zone.
+func AddrEqual(addrA, addrB net.Addr) bool {
+	aUDP, ok := addrA.(*net.UDPAddr)
 	if !ok {
-		return false
+		var aTCP, bTCP *net.TCPAddr
+		aTCP, ok = addrA.(*net.TCPAddr)
+		if !ok {
+			return false
+		}
+
+		bTCP, ok = addrB.(*net.TCPAddr)
+		if !ok {
+			return false
+		}
+
+		return aTCP.IP.Equal(bTCP.IP) && aTCP.Port == bTCP.Port
 	}
 
-	bUDP, ok := b.(*net.UDPAddr)
+	bUDP, ok := addrB.(*net.UDPAddr)
 	if !ok {
 		return false
 	}

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -8,7 +8,10 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -816,12 +819,10 @@ func TestHandleSendIndication(t *testing.T) {
 	})
 }
 
-func TestHandleChannelBindRequest(t *testing.T) {
-	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
-	assert.NoError(t, err)
+func TestHandleChannelBindRequest(t *testing.T) { // nolint:maintidx
+	logger := &captureLogger{}
+	conn := newCapturePacketConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3478})
 	defer conn.Close() //nolint:errcheck
-
-	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
 
 	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
 		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
@@ -861,7 +862,41 @@ func TestHandleChannelBindRequest(t *testing.T) {
 		},
 	}
 
+	buildAuthMsg := func(ch uint16, peerIP string, peerPort int) *stun.Message {
+		m := &stun.Message{}
+		m.TransactionID = stun.NewTransactionID()
+		assert.NoError(t, m.Build(stun.NewType(stun.MethodChannelBind, stun.ClassRequest)))
+		assert.NoError(t, (stun.MessageIntegrity(staticKey)).AddTo(m))
+		assert.NoError(t, (stun.Nonce(staticKey)).AddTo(m))
+		assert.NoError(t, (stun.Realm(staticKey)).AddTo(m))
+		assert.NoError(t, (stun.Username(testUser)).AddTo(m))
+		assert.NoError(t, (proto.ChannelNumber(ch)).AddTo(m))
+		assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP(peerIP), Port: peerPort}).AddTo(m))
+
+		return m
+	}
+
+	assertLastResponse := func(t *testing.T, expectedClass stun.MessageClass, expectedCode stun.ErrorCode) {
+		t.Helper()
+		raw := conn.LastWrite()
+		if !assert.NotEmpty(t, raw, "server should write a response") {
+			return
+		}
+
+		res := &stun.Message{Raw: append([]byte(nil), raw...)}
+		assert.NoError(t, res.Decode())
+		assert.Equal(t, stun.MethodChannelBind, res.Type.Method)
+		assert.Equal(t, expectedClass, res.Type.Class)
+
+		if expectedClass == stun.ClassErrorResponse {
+			var code stun.ErrorCodeAttribute
+			assert.NoError(t, code.GetFrom(res))
+			assert.Equal(t, expectedCode, code.Code)
+		}
+	}
+
 	t.Run("NoAllocationFound", func(t *testing.T) {
+		conn.Reset()
 		m := &stun.Message{}
 		m.TransactionID = stun.NewTransactionID()
 		assert.NoError(t, m.Build(stun.NewType(stun.MethodChannelBind, stun.ClassRequest)))
@@ -886,6 +921,7 @@ func TestHandleChannelBindRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("MissingChannelNumber", func(t *testing.T) {
+		conn.Reset()
 		m := &stun.Message{}
 		m.TransactionID = stun.NewTransactionID()
 		assert.NoError(t, m.Build(stun.NewType(stun.MethodChannelBind, stun.ClassRequest)))
@@ -899,6 +935,7 @@ func TestHandleChannelBindRequest(t *testing.T) {
 	})
 
 	t.Run("MissingPeerAddress", func(t *testing.T) {
+		conn.Reset()
 		m := &stun.Message{}
 		m.TransactionID = stun.NewTransactionID()
 		assert.NoError(t, m.Build(stun.NewType(stun.MethodChannelBind, stun.ClassRequest)))
@@ -914,6 +951,7 @@ func TestHandleChannelBindRequest(t *testing.T) {
 
 	// Peer address family mismatch (IPv6 peer with IPv4 allocation)
 	t.Run("PeerAddressFamilyMismatch", func(t *testing.T) {
+		conn.Reset()
 		m := &stun.Message{}
 		m.TransactionID = stun.NewTransactionID()
 		assert.NoError(t, m.Build(stun.NewType(stun.MethodChannelBind, stun.ClassRequest)))
@@ -928,9 +966,87 @@ func TestHandleChannelBindRequest(t *testing.T) {
 		err = handleChannelBindRequest(req, m)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, errPeerAddressFamilyMismatch)
+		assertLastResponse(t, stun.ClassErrorResponse, stun.CodePeerAddrFamilyMismatch)
+	})
+
+	t.Run("PermissionDenied", func(t *testing.T) {
+		conn.Reset()
+
+		var denyAM *allocation.Manager
+		denyAM, err = allocation.NewManager(allocation.ManagerConfig{
+			AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+				con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
+				if listenErr != nil {
+					return nil, nil, listenErr
+				}
+
+				return con, con.LocalAddr(), nil
+			},
+			AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
+				return nil, nil, nil
+			},
+			AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
+				return nil, nil //nolint:nilnil
+			},
+			PermissionHandler: func(net.Addr, net.IP) bool { return false },
+			LeveledLogger:     logger,
+		})
+		assert.NoError(t, err)
+		defer denyAM.Close() //nolint:errcheck
+
+		denyReq := req
+		denyReq.AllocationManager = denyAM
+		fiveTuple := &allocation.FiveTuple{
+			SrcAddr:  denyReq.SrcAddr,
+			DstAddr:  denyReq.Conn.LocalAddr(),
+			Protocol: allocation.UDP,
+		}
+		_, err = denyReq.AllocationManager.CreateAllocation(fiveTuple, denyReq.Conn, proto.ProtoUDP,
+			0, time.Hour, testUser, "", proto.RequestedFamilyIPv4)
+		assert.NoError(t, err)
+
+		m := buildAuthMsg(0x4000, "192.168.1.1", 8080)
+		err = handleChannelBindRequest(denyReq, m)
+		assert.Error(t, err)
+		assertLastResponse(t, stun.ClassErrorResponse, stun.CodeUnauthorized)
+	})
+
+	t.Run("RejectSamePeerDifferentChannel", func(t *testing.T) {
+		conn.Reset()
+		logger.Reset()
+
+		m1 := buildAuthMsg(0x4010, "192.168.1.1", 8080)
+		err = handleChannelBindRequest(req, m1)
+		assert.NoError(t, err)
+
+		conn.Reset()
+		m2 := buildAuthMsg(0x4011, "192.168.1.1", 8080)
+		err = handleChannelBindRequest(req, m2)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, allocation.ErrSamePeerDifferentChannel)
+		assertLastResponse(t, stun.ClassErrorResponse, stun.CodeBadRequest)
+		assert.True(t, logger.ContainsWarn("peer 192.168.1.1:8080 already bound"), fmt.Sprintf("warn logs: %v", logger.warns))
+	})
+
+	t.Run("RejectSameChannelDifferentPeer", func(t *testing.T) {
+		conn.Reset()
+		logger.Reset()
+
+		m1 := buildAuthMsg(0x4020, "192.168.2.1", 8080)
+		err = handleChannelBindRequest(req, m1)
+		assert.NoError(t, err)
+
+		conn.Reset()
+		m2 := buildAuthMsg(0x4020, "192.168.2.2", 8080)
+		err = handleChannelBindRequest(req, m2)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, allocation.ErrSameChannelDifferentPeer)
+		assertLastResponse(t, stun.ClassErrorResponse, stun.CodeBadRequest)
+		assert.True(t, logger.ContainsWarn("channel 16416 already bound"), fmt.Sprintf("warn logs: %v", logger.warns))
 	})
 
 	t.Run("Success", func(t *testing.T) {
+		conn.Reset()
 		m := &stun.Message{}
 		m.TransactionID = stun.NewTransactionID()
 		assert.NoError(t, m.Build(stun.NewType(stun.MethodChannelBind, stun.ClassRequest)))
@@ -938,12 +1054,114 @@ func TestHandleChannelBindRequest(t *testing.T) {
 		assert.NoError(t, (stun.Nonce(staticKey)).AddTo(m))
 		assert.NoError(t, (stun.Realm(staticKey)).AddTo(m))
 		assert.NoError(t, (stun.Username(testUser)).AddTo(m))
-		assert.NoError(t, (proto.ChannelNumber(0x4000)).AddTo(m))
-		assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("192.168.1.1"), Port: 8080}).AddTo(m))
+		assert.NoError(t, (proto.ChannelNumber(0x4030)).AddTo(m))
+		assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("192.168.3.1"), Port: 8080}).AddTo(m))
 
 		err = handleChannelBindRequest(req, m)
 		assert.NoError(t, err)
 	})
+}
+
+type capturePacketConn struct {
+	mu        sync.Mutex
+	localAddr net.Addr
+	lastWrite []byte
+	closed    bool
+}
+
+func newCapturePacketConn(localAddr net.Addr) *capturePacketConn {
+	return &capturePacketConn{localAddr: localAddr}
+}
+
+func (c *capturePacketConn) ReadFrom([]byte) (int, net.Addr, error) {
+	return 0, nil, net.ErrClosed
+}
+
+func (c *capturePacketConn) WriteTo(p []byte, _ net.Addr) (n int, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return 0, net.ErrClosed
+	}
+	c.lastWrite = append([]byte(nil), p...)
+
+	return len(p), nil
+}
+
+func (c *capturePacketConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+
+	return nil
+}
+
+func (c *capturePacketConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c *capturePacketConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *capturePacketConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *capturePacketConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (c *capturePacketConn) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastWrite = nil
+}
+
+func (c *capturePacketConn) LastWrite() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([]byte(nil), c.lastWrite...)
+}
+
+type captureLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *captureLogger) Reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = nil
+}
+
+func (l *captureLogger) ContainsWarn(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, w := range l.warns {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *captureLogger) Trace(string)          {}
+func (l *captureLogger) Tracef(string, ...any) {}
+func (l *captureLogger) Debug(string)          {}
+func (l *captureLogger) Debugf(string, ...any) {}
+func (l *captureLogger) Info(string)           {}
+func (l *captureLogger) Infof(string, ...any)  {}
+func (l *captureLogger) Error(string)          {}
+func (l *captureLogger) Errorf(string, ...any) {}
+func (l *captureLogger) Warn(msg string)       { l.Warnf("%s", msg) }
+
+func (l *captureLogger) Warnf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, fmt.Sprintf(format, args...))
 }
 
 func TestHandleAllocationRequest(t *testing.T) {


### PR DESCRIPTION
This PR addresses intermittent Coturn errors like:

```error 400: You cannot use the same peer with different channel number```

and improves observability on the pion/turn server side when the same conflict happens.

**Problem**
Under packet loss / transient failures, a TURN client may send a `ChannelBind` request, the server may apply it, but the client might not receive the success response. In `pion/turn`’s UDP client, a failed `ChannelBind` transaction used to delete the local peer→channel binding state. A subsequent send to the same peer then created a new binding with a new channel number, producing a second `ChannelBind` for the same peer but a different channel number.

Coturn correctly rejects that with 400 and logs “same peer with different channel number”.

Separately, pion/turn’s server already rejects conflicting binds, but it did so without a clear, targeted log message indicating which conflict occurred.

**Fix 1: Client-side stability**

- Do not delete the client-side binding when a ChannelBind transaction fails. This keeps the channel number stable for a peer even if a response is lost, preventing “same peer, different channel” rebind attempts.

**Fix 2: Server-side conflict logging + clearer errors**

- Split channel-bind conflict detection into two explicit error conditions:
  - same peer bound to a different channel number (`allocation.ErrSamePeerDifferentChannel`)
  - same channel number bound to a different peer (`allocation.ErrSameChannelDifferentPeer`)
- Add targeted server warning logs in `ChannelBind` handling to surface these conflicts with peer/channel context (and the existing binding when available).

Fixes #540
