### PR TITLE
Update Module Path to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
   <a href="https://github.com/pion/awesome-pion" alt="Awesome Pion"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg"></a>
   <br>
   <img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/pion/turn/test.yaml">
-  <a href="https://pkg.go.dev/github.com/pion/turn/v4"><img src="https://pkg.go.dev/badge/github.com/pion/turn/v4.svg" alt="Go Reference"></a>
+  <a href="https://pkg.go.dev/github.com/pion/turn/v5"><img src="https://pkg.go.dev/badge/github.com/pion/turn/v5.svg" alt="Go Reference"></a>
   <a href="https://codecov.io/gh/pion/turn"><img src="https://codecov.io/gh/pion/turn/branch/master/graph/badge.svg" alt="Coverage Status"></a>
-  <a href="https://goreportcard.com/report/github.com/pion/turn/v4"><img src="https://goreportcard.com/badge/github.com/pion/turn/v4" alt="Go Report Card"></a>
+  <a href="https://goreportcard.com/report/github.com/pion/turn/v5"><img src="https://goreportcard.com/badge/github.com/pion/turn/v5" alt="Go Report Card"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 <br>

--- a/addr_family.go
+++ b/addr_family.go
@@ -3,7 +3,7 @@
 
 package turn
 
-import "github.com/pion/turn/v4/internal/proto"
+import "github.com/pion/turn/v5/internal/proto"
 
 // RequestedAddressFamily represents the REQUESTED-ADDRESS-FAMILY Attribute as
 // defined in RFC 6156 Section 4.1.1.

--- a/client.go
+++ b/client.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
 	"github.com/pion/transport/v4/stdnet"
-	"github.com/pion/turn/v4/internal/client"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/client"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 const (

--- a/client_test.go
+++ b/client_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/examples/lt-cred-generator/main.go
+++ b/examples/lt-cred-generator/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 // Outputs username & password according to the

--- a/examples/mutual-tls-auth/turn-client/main.go
+++ b/examples/mutual-tls-auth/turn-client/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/mutual-tls-auth/turn-server/main.go
+++ b/examples/mutual-tls-auth/turn-server/main.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 // getClientTLSAuthHandler returns an AuthHandler that validates client TLS certificates

--- a/examples/stun-only-server/main.go
+++ b/examples/stun-only-server/main.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-client/ipv6/main.go
+++ b/examples/turn-client/ipv6/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-client/tcp-alloc/main.go
+++ b/examples/turn-client/tcp-alloc/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func setupSignalingChannel(addrCh chan string, signaling bool, relayAddr string) {

--- a/examples/turn-client/tcp/main.go
+++ b/examples/turn-client/tcp/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-client/tls/main.go
+++ b/examples/turn-client/tls/main.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-client/udp/main.go
+++ b/examples/turn-client/udp/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-server/add-software-attribute/main.go
+++ b/examples/turn-server/add-software-attribute/main.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 // attributeAdder wraps a PacketConn and appends the SOFTWARE attribute to STUN packets.

--- a/examples/turn-server/bw-quota/main.go
+++ b/examples/turn-server/bw-quota/main.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 	"golang.org/x/time/rate"
 )
 

--- a/examples/turn-server/ipv6/main.go
+++ b/examples/turn-server/ipv6/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() { //nolint:gocyclo,cyclop

--- a/examples/turn-server/log/main.go
+++ b/examples/turn-server/log/main.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 // stunLogger wraps a PacketConn and prints incoming/outgoing STUN packets

--- a/examples/turn-server/lt-cred-turn-rest/main.go
+++ b/examples/turn-server/lt-cred-turn-rest/main.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/lt-cred/main.go
+++ b/examples/turn-server/lt-cred/main.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/perm-filter/main.go
+++ b/examples/turn-server/perm-filter/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/port-range/main.go
+++ b/examples/turn-server/port-range/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/simple-multithreaded/main.go
+++ b/examples/turn-server/simple-multithreaded/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 	"golang.org/x/sys/unix"
 )
 

--- a/examples/turn-server/simple-quota/main.go
+++ b/examples/turn-server/simple-quota/main.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 const maxAllocationsPerUser = 1

--- a/examples/turn-server/simple/main.go
+++ b/examples/turn-server/simple/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/tcp/main.go
+++ b/examples/turn-server/tcp/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/tls/main.go
+++ b/examples/turn-server/tls/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v4"
+	"github.com/pion/turn/v5"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pion/turn/v4
+module github.com/pion/turn/v5
 
 go 1.21
 

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/ipnet"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/ipnet"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 type allocationResponse struct {

--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/randutil"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 // If no ConnectionBind request associated with this peer data

--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/reuseport"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4/reuseport"
-	"github.com/pion/turn/v4/internal/ipnet"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/ipnet"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/allocation/channel_bind.go
+++ b/internal/allocation/channel_bind.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 // ChannelBind represents a TURN Channel

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 // AllocationConfig is a set of configuration params use by NewUDPConn and NewTCPAllocation.

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/pion/turn/v4/internal/ipnet"
+	"github.com/pion/turn/v5/internal/ipnet"
 )
 
 type permState int32

--- a/internal/client/tcp_alloc.go
+++ b/internal/client/tcp_alloc.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 var (

--- a/internal/client/tcp_conn.go
+++ b/internal/client/tcp_conn.go
@@ -8,7 +8,7 @@ import (
 	"net"
 
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 var (

--- a/internal/client/tcp_conn_test.go
+++ b/internal/client/tcp_conn_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 const (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/allocation"
-	"github.com/pion/turn/v4/internal/auth"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/auth"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 // Request contains all the state needed to process a single incoming datagram.

--- a/internal/server/stun.go
+++ b/internal/server/stun.go
@@ -5,7 +5,7 @@ package server
 
 import (
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/ipnet"
+	"github.com/pion/turn/v5/internal/ipnet"
 )
 
 func handleBindingRequest(req Request, stunMsg *stun.Message) error {

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/pion/randutil"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/allocation"
-	"github.com/pion/turn/v4/internal/ipnet"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/ipnet"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 const runesAlpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4/test"
-	"github.com/pion/turn/v4/internal/allocation"
-	"github.com/pion/turn/v4/internal/auth"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/auth"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v4/internal/auth"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/auth"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 const (

--- a/lt_cred.go
+++ b/lt_cred.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4/internal/auth"
+	"github.com/pion/turn/v5/internal/auth"
 )
 
 // GenerateLongTermCredentials can be used to create credentials valid for [duration] time.

--- a/server.go
+++ b/server.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4/internal/allocation"
-	"github.com/pion/turn/v4/internal/proto"
-	"github.com/pion/turn/v4/internal/server"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/proto"
+	"github.com/pion/turn/v5/internal/server"
 )
 
 const (

--- a/server_config.go
+++ b/server_config.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v4/internal/allocation"
-	"github.com/pion/turn/v4/internal/auth"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/auth"
 )
 
 // AllocateListenerConfig defines the parameters passed to the relay address allocator.

--- a/server_test.go
+++ b/server_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/pion/transport/v4/reuseport"
 	"github.com/pion/transport/v4/test"
 	"github.com/pion/transport/v4/vnet"
-	"github.com/pion/turn/v4/internal/allocation"
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/stunn_conn.go
+++ b/stunn_conn.go
@@ -6,7 +6,7 @@ package turn
 import (
 	"net"
 
-	"github.com/pion/turn/v4/internal/proto"
+	"github.com/pion/turn/v5/internal/proto"
 )
 
 type STUNConn = proto.STUNConn


### PR DESCRIPTION
## Update Module Path to v5

Part of https://github.com/pion/turn/issues/537

Done with:

```
rg -l "github.com/pion/turn/v4" | xargs sed -i '' 's|github.com/pion/turn/v4|github.com/pion/turn/v5|g'
```

then

```
go mod tidy
```