### PR TITLE
Support alternate for UDP allocation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,4 +28,6 @@ var (
 	errFailedToDecodeSTUN            = errors.New("failed to decode STUN message")
 	errUnexpectedSTUNRequestMessage  = errors.New("unexpected STUN request message")
 	errRelayAddressGeneratorNil      = errors.New("RelayAddressGenerator is nil")
+	errAlternateServerRedirects      = errors.New("turn: too many ALTERNATE-SERVER redirects")
+	errAlternateServerLoop           = errors.New("turn: ALTERNATE-SERVER redirect loop detected")
 )


### PR DESCRIPTION
#### Description

This is a draft for supporting alternate addresses, this works for UDP.

two things:
1. to support alternate for TCP allocation we'll have to add a connection-factory helper or something so users can provide connections for alternate addresses or create the connections our-self, i feel like v5 was a missed opportunity to fix this. 
2. I reviewed the libwebrtc code and a few other libraries and couldn't find any explicit limit on the number of alternatives they follow. idk that felt risky to me, so I hard-coded a limit of 64, which I think is very generous.

#### Reference issue

Fixes #544
