### PR TITLE
Add Method field to RequestAttributes

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -8,6 +8,8 @@ package auth
 import (
 	"crypto/tls"
 	"net"
+
+	"github.com/pion/stun/v3"
 )
 
 // RequestAttributes represents attributes of a TURN request which
@@ -17,6 +19,7 @@ type RequestAttributes struct {
 	Realm    string
 	SrcAddr  net.Addr
 	TLS      *tls.ConnectionState
+	Method   stun.Method
 
 	// extend as needed
 }

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -110,6 +110,7 @@ func authenticateRequest(req Request, stunMsg *stun.Message, callingMethod stun.
 		Realm:    realmAttr.String(),
 		SrcAddr:  req.SrcAddr,
 		TLS:      req.TLS,
+		Method:   callingMethod,
 	})
 	if !ok {
 		return nil, false, "", buildAndSendErr(


### PR DESCRIPTION
Allows AuthHandler implementations to differentiate between Allocate, Refresh, CreatePermission, and ChannelBind requests for custom auth policies (e.g. applying TTL checks only on initial allocation creation).
