### PR TITLE
fix(server): accept v6 peers on default-IPv4 allocations for dual-stack relays

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -744,9 +744,22 @@ func handleConnectionBindRequest(req Request, stunMsg *stun.Message) error {
 }
 
 // ipMatchesFamily checks if an IP address matches the given address family.
+//
+// Relaxed for dual-stack/IPv6-only hosts: when the allocation declared the
+// RFC 6156 default IPv4 family but the relay socket was bound dual-stack
+// ("udp" wildcard) the v6 peer is reachable through the same allocation,
+// so we accept it. Strict RFC 6156 behavior is preserved for IPv6
+// allocations (a v4 peer is still rejected).
+//
+// Background: browsers' WebRTC TURN clients never set
+// REQUESTED-ADDRESS-FAMILY, so every Allocate is implicitly IPv4 family.
+// On IPv6-only Kubernetes clusters (where backend pod addresses are
+// pure IPv6, e.g. EKS Auto with IPv6 STACK_TYPE) that makes every
+// CreatePermission to a v6 peer fail with errPeerAddressFamilyMismatch
+// even though the relay socket itself is reachable from v6.
 func ipMatchesFamily(ip net.IP, family proto.RequestedAddressFamily) bool {
 	if family == proto.RequestedFamilyIPv4 {
-		return ip.To4() != nil
+		return ip.To4() != nil || (ip.To4() == nil && ip.To16() != nil)
 	}
 	if family == proto.RequestedFamilyIPv6 {
 		return ip.To4() == nil && ip.To16() != nil

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -583,13 +583,15 @@ func TestIPMatchesFamily(t *testing.T) {
 
 	t.Run("IPv6", func(t *testing.T) {
 		ipv6 := net.ParseIP("2001:db8::1")
-		assert.False(t, ipMatchesFamily(ipv6, proto.RequestedFamilyIPv4))
+		// Relaxed: v6 peers are accepted on v4-default allocations because
+		// dual-stack relay sockets reach both families. See ipMatchesFamily.
+		assert.True(t, ipMatchesFamily(ipv6, proto.RequestedFamilyIPv4))
 		assert.True(t, ipMatchesFamily(ipv6, proto.RequestedFamilyIPv6))
 	})
 
 	t.Run("IPv6Loopback", func(t *testing.T) {
 		ipv6Loopback := net.ParseIP("::1")
-		assert.False(t, ipMatchesFamily(ipv6Loopback, proto.RequestedFamilyIPv4))
+		assert.True(t, ipMatchesFamily(ipv6Loopback, proto.RequestedFamilyIPv4))
 		assert.True(t, ipMatchesFamily(ipv6Loopback, proto.RequestedFamilyIPv6))
 	})
 
@@ -948,8 +950,10 @@ func TestHandleChannelBindRequest(t *testing.T) { // nolint:maintidx
 		assert.Error(t, err)
 	})
 
-	// Peer address family mismatch (IPv6 peer with IPv4 allocation)
-	t.Run("PeerAddressFamilyMismatch", func(t *testing.T) {
+	// Cross-family bind: v6 peer on v4-default allocation now SUCCEEDS thanks
+	// to the relaxed ipMatchesFamily (relay socket binds dual-stack on Linux,
+	// so the v6 peer is reachable through the same allocation).
+	t.Run("CrossFamilyV6PeerOnV4Alloc", func(t *testing.T) {
 		conn.Reset()
 		m := &stun.Message{}
 		m.TransactionID = stun.NewTransactionID()
@@ -958,14 +962,12 @@ func TestHandleChannelBindRequest(t *testing.T) { // nolint:maintidx
 		assert.NoError(t, (stun.Nonce(staticKey)).AddTo(m))
 		assert.NoError(t, (stun.Realm(staticKey)).AddTo(m))
 		assert.NoError(t, (stun.Username(testUser)).AddTo(m))
-		assert.NoError(t, (proto.ChannelNumber(0x4000)).AddTo(m))
-		// Try to bind IPv6 peer to IPv4 allocation
+		assert.NoError(t, (proto.ChannelNumber(0x4001)).AddTo(m))
 		assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("2001:db8::1"), Port: 8080}).AddTo(m))
 
 		err = handleChannelBindRequest(req, m)
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, errPeerAddressFamilyMismatch)
-		assertLastResponse(t, stun.ClassErrorResponse, stun.CodePeerAddrFamilyMismatch)
+		assert.NoError(t, err)
+		assertLastResponse(t, stun.ClassSuccessResponse, 0)
 	})
 
 	t.Run("PermissionDenied", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`internal/server/turn.go ipMatchesFamily` strictly rejects pure-IPv6
peer addresses against an IPv4 allocation, including the **default**
IPv4 allocation that pion/turn applies when an `Allocate` request
omits `REQUESTED-ADDRESS-FAMILY` (RFC 6156 §4.1.1).

Browser WebRTC TURN clients (Chrome, Firefox, Safari) **never** set
`REQUESTED-ADDRESS-FAMILY` in their `Allocate` requests, so on a
dual-stack or IPv6-only Linux host every browser-driven allocation
ends up IPv4-family even when the listener and relay sockets are
bound `[::]`. Subsequent `CreatePermission`/`ChannelBind` requests
with v6 peer addresses are then rejected with
`errPeerAddressFamilyMismatch` (logged at `Info` level, easy to
miss), and the very first `Send-indication` fails with
`errNoPermission`.

This is the canonical failure mode for pion/turn-based TURN servers
deployed in front of IPv6-only Kubernetes pod networks. With the
relay socket actually bound dual-stack on Linux (`net.ipv6.bindv6only=0`,
which is the default), v6 peer reachability is fine; only the
protocol-level family check blocks the permission.

## Repro & root-cause

Detailed write-up + minimal repro in **#566**.

Short version: with a Linux dual-stack relay socket and a v4-default
allocation, peer reachability works in both directions but
`ipMatchesFamily(v6-peer, IPv4-family)` returns false ⇒ no
permission ⇒ no Send-indication forwarded ⇒ WebRTC PC times out.

## Fix (this PR)

Relax the v4-default branch of `ipMatchesFamily` to also accept v6
peers, matching what a dual-stack relay socket can actually deliver.

```go
 if family == proto.RequestedFamilyIPv4 {
-    return ip.To4() != nil
+    return ip.To4() != nil || (ip.To4() == nil && ip.To16() != nil)
 }
```

The symmetric IPv6-allocation case is **unchanged**: a v4 peer on a
v6-explicit allocation is still rejected, preserving RFC 6156
strict-mode for the case where the client opted into v6 by sending
`REQUESTED-ADDRESS-FAMILY=IPv6`.

`Refresh` request family handling is untouched.

## Tests

`internal/server` had two assertion sites baked to the strict cross-
family rejection. They are updated to match the new permissive
behavior:

- `TestIPMatchesFamily/IPv6` and `/IPv6Loopback`: `ipMatchesFamily(v6,
  RequestedFamilyIPv4)` now returns `true`.
- `TestHandleChannelBindRequest/PeerAddressFamilyMismatch` is renamed
  to `CrossFamilyV6PeerOnV4Alloc` and asserts the success response
  (the previous request flow now produces `ClassSuccessResponse`
  instead of 443 `PeerAddrFamilyMismatch`).

All other tests in `./...` pass unchanged.

## Caveats / alternatives discussed in #566

This is the simplest of the three options I sketched in #566. The
other two would be more conservative:

1. **Default the allocation family to the listener's family** when
   `REQUESTED-ADDRESS-FAMILY` is absent — backwards-compatible for
   IPv4-only deployments, correct for IPv6-only listeners.
2. **A `Server` config knob** (`PermissiveAddressFamily bool` or
   similar) that opts in to relaxed cross-family. RFC 6156 strict
   stays the default.

I went with the simplest patch first because it fixes the canonical
deployment case with the smallest diff. Happy to refactor to either
option (1) or (2) if maintainers prefer — let me know.

## Compatibility note

This subtly changes behavior for clients that explicitly relied on
the v4-default + v6-peer = 443 response to detect IPv6 capability.
In practice no real-world TURN client does this (they all either
omit the attribute or explicitly request a family); but worth
flagging for review.

Refs: #566