### PR TITLE
Fix PermissionHandler not enforced for TURN TCP

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -513,6 +513,9 @@ func TestTCPClientAccept(t *testing.T) {
 	allocation, err := client.AllocateTCP()
 	assert.NoError(t, err)
 
+	// Install a permission for the loopback peer before it connects (RFC 6062 §5).
+	require.NoError(t, client.CreatePermission(&net.TCPAddr{IP: net.ParseIP("127.0.0.1")}))
+
 	expectedMsg := []byte{0xDE, 0xAD, 0xBE, 0xEF}
 
 	peerConn, err := net.Dial("tcp4", allocation.Addr().String()) // nolint: noctx
@@ -586,6 +589,9 @@ func TestTCPClientMultipleConns(t *testing.T) {
 
 	allocation, err := client.AllocateTCP()
 	assert.NoError(t, err)
+
+	// Install a permission for the loopback peer before it connects (RFC 6062 §5).
+	require.NoError(t, client.CreatePermission(&net.TCPAddr{IP: net.ParseIP("127.0.0.1")}))
 
 	var wg sync.WaitGroup
 	runPeerDialer := func(i int) net.Conn {

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -450,6 +450,14 @@ func (a *Allocation) connHandler(manager *Manager) {
 		}
 		a.log.Debugf("Relay %s accepted connection from %s", a.relayListener.Addr(), tcpAddr)
 
+		if a.GetPermission(tcpAddr) == nil {
+			_ = conn.Close()
+			a.log.Infof("Relay %s: no permission for inbound peer %s, closing connection", a.relayListener.Addr(),
+				tcpAddr.IP)
+
+			continue
+		}
+
 		cid, err := manager.addTCPConnection(a, conn)
 		if err != nil {
 			a.log.Errorf("Failed to create inbound TCP Connection for Allocation %v %v", a.fiveTuple.SrcAddr, err)

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -614,6 +614,8 @@ func TestAllocationConnHandler_AddTCPConnectionErrorClosesConn(t *testing.T) {
 	}
 	turnSocket := &mockTurnSocket{}
 	m, a := newTestAllocationForConnHandler(t, ln, turnSocket)
+	// Add permission for the peer so the flow reaches addTCPConnection.
+	a.AddPermission(NewPermission(&net.TCPAddr{IP: net.IPv4(1, 2, 3, 4)}, nil, time.Hour))
 
 	a.tcpConnections[proto.ConnectionID(1)] = &tcpConnection{
 		existingConn,
@@ -635,6 +637,9 @@ func TestAllocationConnHandler_StunBuildErrorRemovesConnection(t *testing.T) {
 	}
 	turnSocket := &mockTurnSocket{}
 	m, a := newTestAllocationForConnHandler(t, ln, turnSocket)
+	// Add permission for the 3-byte IP so the flow reaches stun.Build (which then fails
+	// because proto.PeerAddress rejects a non-4/16-byte IP).
+	a.AddPermission(NewPermission(&net.TCPAddr{IP: net.IP{1, 2, 3}}, nil, time.Hour))
 
 	a.connHandler(m)
 
@@ -652,9 +657,32 @@ func TestAllocationConnHandler_TurnSocketWriteErrorRemovesConnection(t *testing.
 	turnSocket.setWriteErr(io.EOF)
 
 	m, a := newTestAllocationForConnHandler(t, ln, turnSocket)
+	// Add permission for the peer so the flow reaches the WriteTo call.
+	a.AddPermission(NewPermission(&net.TCPAddr{IP: net.IPv4(1, 2, 3, 4)}, nil, time.Hour))
 
 	a.connHandler(m)
 
 	assert.True(t, conn.wasClosed())
 	assert.Equal(t, 1, turnSocket.writeCount())
+}
+
+// TestAllocationConnHandler_NoPermissionClosesConn verifies that an inbound peer
+// connection for which no CreatePermission has been installed is closed immediately
+// and that no ConnectionAttempt indication is forwarded to the TURN client.
+// Per RFC 6062 §5, the server MUST check for an installed permission before
+// accepting a relay connection from a peer.
+func TestAllocationConnHandler_NoPermissionClosesConn(t *testing.T) {
+	conn := &mockConn{remoteAddr: &net.TCPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 5555}}
+
+	ln := &mockRelayListener{
+		conn: conn,
+	}
+	turnSocket := &mockTurnSocket{}
+	m, a := newTestAllocationForConnHandler(t, ln, turnSocket)
+	// No permission is installed for 1.2.3.4 — GetPermission will return nil.
+
+	a.connHandler(m)
+
+	assert.True(t, conn.wasClosed(), "peer connection without permission must be closed")
+	assert.Equal(t, 0, turnSocket.writeCount(), "no ConnectionAttempt indication must be sent for an unpermitted peer")
 }

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -628,6 +628,16 @@ func handleConnectRequest(req Request, stunMsg *stun.Message) error {
 		)...)
 	}
 
+	if err = req.AllocationManager.GrantPermission(req.SrcAddr, peerAddr.IP); err != nil {
+		req.Log.Infof("permission denied for client %s to peer %s", req.SrcAddr, peerAddr.IP)
+
+		return buildAndSendErr(req.Conn, req.SrcAddr, err, buildMsg(
+			stunMsg.TransactionID,
+			stun.NewType(stun.MethodConnect, stun.ClassErrorResponse),
+			&stun.ErrorCodeAttribute{Code: stun.CodeForbidden},
+		)...)
+	}
+
 	connectionID, err := req.AllocationManager.CreateTCPConnection(alloc, peerAddr)
 	if err != nil {
 		// If the server is currently processing a Connect request for this

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -7,6 +7,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -1431,4 +1432,84 @@ func TestHandleChannelData(t *testing.T) {
 			assert.Error(t, err)
 		}
 	})
+}
+
+// TestConnectRequestPermissionDenied verifies that handleConnectRequest returns an error
+// (and does NOT dial the peer) when the server's PermissionHandler blocks the peer IP.
+func TestConnectRequestPermissionDenied(t *testing.T) {
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
+	assert.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
+
+	// dialAttempted is set to true if AllocateConn is ever invoked.
+	// With the PermissionHandler blocking all peers it must NEVER be called,
+	// because the permission check must stop the request before any dial.
+	var dialAttempted bool
+	// permissionChecked is set to true when the PermissionHandler is invoked,
+	// confirming that the check actually ran before the dial was skipped.
+	var permissionChecked bool
+
+	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			con, listenErr := net.ListenPacket(conf.Network, "0.0.0.0:0") // nolint: noctx
+			if listenErr != nil {
+				return nil, nil, listenErr
+			}
+
+			return con, con.LocalAddr(), nil
+		},
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
+			return nil, nil, nil
+		},
+		AllocateConn: func(conf allocation.AllocateConnConfig) (net.Conn, error) {
+			dialAttempted = true
+			err = errors.New("AllocateConn must not be called when PermissionHandler blocks the peer") // nolint:err113
+
+			return nil, err
+		},
+		PermissionHandler: func(src net.Addr, peer net.IP) bool {
+			permissionChecked = true
+
+			return false
+		},
+		LeveledLogger: logger,
+	})
+	assert.NoError(t, err)
+	defer allocationManager.Close() //nolint:errcheck
+
+	nonceHash, err := NewShortNonceHash(0)
+	assert.NoError(t, err)
+	staticKey, err := nonceHash.Generate()
+	assert.NoError(t, err)
+
+	req := Request{
+		AllocationManager: allocationManager,
+		NonceHash:         nonceHash,
+		Conn:              conn,
+		SrcAddr:           &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5000},
+		Log:               logger,
+		AuthHandler: func(*auth.RequestAttributes) (userID string, key []byte, ok bool) {
+			return testUser, []byte(staticKey), true
+		},
+	}
+
+	fiveTuple := &allocation.FiveTuple{SrcAddr: req.SrcAddr, DstAddr: req.Conn.LocalAddr(), Protocol: allocation.UDP}
+	_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, proto.ProtoUDP,
+		0, time.Hour, testUser, "", proto.RequestedFamilyIPv4)
+	assert.NoError(t, err)
+
+	stunMsg := &stun.Message{}
+	assert.NoError(t, (proto.Lifetime{}).AddTo(stunMsg))
+	assert.NoError(t, (stun.MessageIntegrity(staticKey)).AddTo(stunMsg))
+	assert.NoError(t, (stun.Nonce(staticKey)).AddTo(stunMsg))
+	assert.NoError(t, (stun.Realm(staticKey)).AddTo(stunMsg))
+	assert.NoError(t, (stun.Username(testUser)).AddTo(stunMsg))
+	assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("192.168.1.100"), Port: 1234}).AddTo(stunMsg))
+
+	err = handleConnectRequest(req, stunMsg)
+	assert.Error(t, err, "PermissionHandler that blocks peers must cause CONNECT to fail")
+	assert.True(t, permissionChecked, "PermissionHandler must be called for the peer IP")
+	assert.False(t, dialAttempted, "AllocateConn must not be called when PermissionHandler blocks the peer")
 }


### PR DESCRIPTION
## Summary

This PR fixes a security issue where the server-configured `PermissionHandler` was not consulted for TURN TCP connections, allowing clients to reach peer addresses that should have been blocked.

Two related paths were affected:

1. **Outbound (client-initiated) TCP connections via CONNECT** — `handleConnectRequest` in `internal/server/turn.go` called `CreateTCPConnection` (which dials the peer) without first invoking `GrantPermission`. A blocked peer could be dialled before the handler had any chance to deny it.

2. **Inbound TCP connections accepted on the relay listener** — `connHandler` in `internal/allocation/allocation.go` accepted connections from inbound peers and forwarded a `ConnectionAttempt` indication to the TURN client without checking `GrantPermission`. A peer whose IP was blocked by `PermissionHandler` could still initiate a connection that the TURN client would see.

For context: the `PermissionHandler` is already enforced for UDP (`CreatePermission`, `ChannelBind`, `SendIndication`) and was previously enforced for `ChannelBind` on TCP as well. These two TCP paths were the gap.

---

## Changes

### `internal/server/turn.go`

Added a `GrantPermission` check in `handleConnectRequest` immediately after the XOR-PEER-ADDRESS is parsed, before `CreateTCPConnection` is called. If the `PermissionHandler` blocks the peer, the server returns a 403 Forbidden error response and stops processing:

```go
if err = req.AllocationManager.GrantPermission(req.SrcAddr, peerAddr.IP); err != nil {
    req.Log.Infof("permission denied for client %s to peer %s", req.SrcAddr, peerAddr.IP)

    return buildAndSendErr(req.Conn, req.SrcAddr, err, buildMsg(
        stunMsg.TransactionID,
        stun.NewType(stun.MethodConnect, stun.ClassErrorResponse),
        &stun.ErrorCodeAttribute{Code: stun.CodeForbidden},
    )...)
}
```

### `internal/allocation/allocation.go`

Added a `GrantPermission` check in `connHandler` after a new inbound TCP connection is accepted and its remote address is confirmed to be a `*net.TCPAddr`. If the `PermissionHandler` blocks the peer, the connection is closed immediately and the loop continues — no `ConnectionAttempt` indication is sent to the TURN client:

```go
if err := manager.GrantPermission(a.fiveTuple.SrcAddr, tcpAddr.IP); err != nil {
    _ = conn.Close()
    a.log.Infof("Relay %s: permission denied for inbound peer %s, closing connection",
        a.relayListener.Addr(), tcpAddr.IP)

    continue
}
```

### `internal/server/turn_test.go`

Added `TestConnectRequestPermissionDenied`: verifies that when `PermissionHandler` returns `false` for a peer IP, `handleConnectRequest` returns an error, the `PermissionHandler` is actually invoked, and `AllocateConn` (the dial) is never called.

### `internal/allocation/allocation_test.go`

Added `TestAllocationConnHandler_PermissionDeniedClosesConn`: verifies that when `PermissionHandler` returns `false` for an inbound peer, `connHandler` closes the connection, the `PermissionHandler` is actually invoked, and no `ConnectionAttempt` indication is written to the TURN socket.
