### PR TITLE
Default omitted address family to listener family

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,9 +38,10 @@ type Request struct {
 	Log   logging.LeveledLogger
 	Realm string
 
-	ChannelBindTimeout time.Duration
-	PermissionTimeout  time.Duration
-	AllocationLifetime time.Duration
+	ChannelBindTimeout  time.Duration
+	PermissionTimeout   time.Duration
+	AllocationLifetime  time.Duration
+	StrictAddressFamily bool
 }
 
 // HandleRequest processes the give Request.

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -160,9 +160,8 @@ func handleAllocateRequest(req Request, stunMsg *stun.Message) error { //nolint:
 	_ = realmAttr.GetFrom(stunMsg)
 
 	// RFC 6156: Parse REQUESTED-ADDRESS-FAMILY attribute if present.
-	// If absent, default to IPv4 per RFC 6156 Section 4.1.1.
-	// "If the REQUESTED-ADDRESS-FAMILY attribute is absent, the server MUST
-	// allocate an IPv4-relayed transport address for the TURN client."
+	// If absent, default to the listener family unless strict RFC 6156
+	// behavior is requested.
 	// "Length:  this 16-bit field contains the length of the attribute in
 	// bytes.  The length of this attribute is 4 bytes."
 	// "If the server does not support the address family requested by the
@@ -173,7 +172,7 @@ func handleAllocateRequest(req Request, stunMsg *stun.Message) error { //nolint:
 	if err = requestedFamily.GetFrom(stunMsg); err != nil {
 		switch {
 		case errors.Is(err, stun.ErrAttributeNotFound):
-			requestedFamily = proto.RequestedFamilyIPv4
+			requestedFamily = defaultAllocationAddressFamily(req)
 		case stun.IsAttrSizeInvalid(err) || stun.IsAttrSizeOverflow(err):
 			return buildAndSendErr(req.Conn, req.SrcAddr, err, badRequestMsg...)
 		default:
@@ -763,4 +762,49 @@ func ipMatchesFamily(ip net.IP, family proto.RequestedAddressFamily) bool {
 	}
 
 	return false
+}
+
+func defaultAllocationAddressFamily(req Request) proto.RequestedAddressFamily {
+	if req.StrictAddressFamily {
+		return proto.RequestedFamilyIPv4
+	}
+
+	ip, _, err := ipnet.AddrIPPort(req.Conn.LocalAddr())
+	if err != nil {
+		return proto.RequestedFamilyIPv4
+	}
+
+	// some dual-stack wildcard sockets can report [::] as LocalAddr even for IPv4 or
+	// ipv6-mapped IPv4 addresses.
+	if ip.IsUnspecified() {
+		if family, ok := addressFamilyFromAddr(req.SrcAddr); ok {
+			return family
+		}
+	}
+
+	if family, ok := addressFamilyFromIP(ip); ok {
+		return family
+	}
+
+	return proto.RequestedFamilyIPv4
+}
+
+func addressFamilyFromAddr(addr net.Addr) (proto.RequestedAddressFamily, bool) {
+	ip, _, err := ipnet.AddrIPPort(addr)
+	if err != nil {
+		return 0, false
+	}
+
+	return addressFamilyFromIP(ip)
+}
+
+func addressFamilyFromIP(ip net.IP) (proto.RequestedAddressFamily, bool) {
+	if ip.To4() != nil {
+		return proto.RequestedFamilyIPv4, true
+	}
+	if ip.To16() != nil {
+		return proto.RequestedFamilyIPv6, true
+	}
+
+	return 0, false
 }

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -395,6 +395,101 @@ func TestRequestedAddressFamilyIPv6(t *testing.T) {
 	assert.Equal(t, proto.RequestedFamilyIPv6, foundAlloc.AddressFamily())
 }
 
+func TestAllocateDefaultAddressFamilyFromListener(t *testing.T) {
+	t.Run("IPv6 listener", func(t *testing.T) {
+		family, network := allocateWithoutRequestedAddressFamily(t, false)
+
+		assert.Equal(t, proto.RequestedFamilyIPv6, family)
+		assert.Equal(t, "udp6", network)
+	})
+
+	t.Run("strict mode", func(t *testing.T) {
+		family, network := allocateWithoutRequestedAddressFamily(t, true)
+
+		assert.Equal(t, proto.RequestedFamilyIPv4, family)
+		assert.Equal(t, "udp4", network)
+	})
+}
+
+func allocateWithoutRequestedAddressFamily(
+	t *testing.T,
+	strictAddressFamily bool,
+) (proto.RequestedAddressFamily, string) {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp6", "[::]:0") // nolint: noctx
+	assert.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	logger := logging.NewDefaultLoggerFactory().NewLogger("turn")
+	relayNetwork := ""
+
+	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
+		AllocatePacketConn: func(conf allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			relayNetwork = conf.Network
+			addr := "0.0.0.0:0"
+			if conf.Network == "udp6" {
+				addr = "[::]:0"
+			}
+
+			con, listenErr := net.ListenPacket(conf.Network, addr) // nolint: noctx
+			if listenErr != nil {
+				return nil, nil, listenErr
+			}
+
+			return con, con.LocalAddr(), nil
+		},
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
+			return nil, nil, nil
+		},
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
+			return nil, nil //nolint:nilnil
+		},
+		LeveledLogger: logger,
+	})
+	assert.NoError(t, err)
+	defer allocationManager.Close() //nolint:errcheck
+
+	nonceHash, err := NewShortNonceHash(0)
+	assert.NoError(t, err)
+	staticKey, err := nonceHash.Generate()
+	assert.NoError(t, err)
+
+	req := Request{
+		AllocationManager:   allocationManager,
+		NonceHash:           nonceHash,
+		Conn:                conn,
+		SrcAddr:             &net.UDPAddr{IP: net.ParseIP("::1"), Port: 5000},
+		Log:                 logger,
+		AllocationLifetime:  proto.DefaultLifetime,
+		StrictAddressFamily: strictAddressFamily,
+		Realm:               "pion.ly",
+		AuthHandler: func(*auth.RequestAttributes) (userID string, key []byte, ok bool) {
+			return testUser, []byte(staticKey), true
+		},
+	}
+
+	msg := &stun.Message{}
+	msg.TransactionID = stun.NewTransactionID()
+	assert.NoError(t, msg.Build(stun.NewType(stun.MethodAllocate, stun.ClassRequest)))
+	assert.NoError(t, (proto.RequestedTransport{Protocol: proto.ProtoUDP}).AddTo(msg))
+	assert.NoError(t, (stun.Nonce(staticKey)).AddTo(msg))
+	assert.NoError(t, (stun.Realm("pion.ly")).AddTo(msg))
+	assert.NoError(t, (stun.Username(testUser)).AddTo(msg))
+	assert.NoError(t, (stun.MessageIntegrity(staticKey)).AddTo(msg))
+
+	assert.NoError(t, handleAllocateRequest(req, msg))
+
+	alloc := allocationManager.GetAllocation(&allocation.FiveTuple{
+		SrcAddr:  req.SrcAddr,
+		DstAddr:  req.Conn.LocalAddr(),
+		Protocol: allocation.UDP,
+	})
+	assert.NotNil(t, alloc)
+
+	return alloc.AddressFamily(), relayNetwork
+}
+
 func TestRequestedAddressFamilyUnsupported(t *testing.T) {
 	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
 	assert.NoError(t, err)

--- a/server.go
+++ b/server.go
@@ -24,15 +24,16 @@ const (
 
 // Server is an instance of the Pion TURN Server.
 type Server struct {
-	log                logging.LeveledLogger
-	authHandler        AuthHandler
-	quotaHandler       QuotaHandler
-	realm              string
-	channelBindTimeout time.Duration
-	permissionTimeout  time.Duration
-	allocationLifetime time.Duration
-	nonceHash          server.NonceManager
-	eventHandler       EventHandler
+	log                 logging.LeveledLogger
+	authHandler         AuthHandler
+	quotaHandler        QuotaHandler
+	realm               string
+	channelBindTimeout  time.Duration
+	permissionTimeout   time.Duration
+	allocationLifetime  time.Duration
+	strictAddressFamily bool
+	nonceHash           server.NonceManager
+	eventHandler        EventHandler
 
 	packetConnConfigs  []PacketConnConfig
 	listenerConfigs    []ListenerConfig
@@ -62,18 +63,19 @@ func NewServer(config ServerConfig) (*Server, error) { //nolint:gocognit,cyclop
 	}
 
 	server := &Server{
-		log:                loggerFactory.NewLogger("turn"),
-		authHandler:        config.AuthHandler,
-		quotaHandler:       config.QuotaHandler,
-		realm:              config.Realm,
-		channelBindTimeout: config.ChannelBindTimeout,
-		permissionTimeout:  config.PermissionTimeout,
-		allocationLifetime: config.AllocationLifetime,
-		packetConnConfigs:  config.PacketConnConfigs,
-		listenerConfigs:    config.ListenerConfigs,
-		nonceHash:          nonceHash,
-		inboundMTU:         mtu,
-		eventHandler:       config.EventHandler,
+		log:                 loggerFactory.NewLogger("turn"),
+		authHandler:         config.AuthHandler,
+		quotaHandler:        config.QuotaHandler,
+		realm:               config.Realm,
+		channelBindTimeout:  config.ChannelBindTimeout,
+		permissionTimeout:   config.PermissionTimeout,
+		allocationLifetime:  config.AllocationLifetime,
+		strictAddressFamily: config.StrictAddressFamily,
+		packetConnConfigs:   config.PacketConnConfigs,
+		listenerConfigs:     config.ListenerConfigs,
+		nonceHash:           nonceHash,
+		inboundMTU:          mtu,
+		eventHandler:        config.EventHandler,
 	}
 
 	if server.channelBindTimeout == 0 {
@@ -264,19 +266,20 @@ func (s *Server) readLoop(conn net.PacketConn, allocationManager *allocation.Man
 		}
 
 		if err := server.HandleRequest(server.Request{
-			Conn:               conn,
-			SrcAddr:            addr,
-			Buff:               buf[:n],
-			TLS:                tlsState,
-			Log:                s.log,
-			AuthHandler:        s.authHandler,
-			QuotaHandler:       s.quotaHandler,
-			Realm:              s.realm,
-			AllocationManager:  allocationManager,
-			ChannelBindTimeout: s.channelBindTimeout,
-			PermissionTimeout:  s.permissionTimeout,
-			AllocationLifetime: s.allocationLifetime,
-			NonceHash:          s.nonceHash,
+			Conn:                conn,
+			SrcAddr:             addr,
+			Buff:                buf[:n],
+			TLS:                 tlsState,
+			Log:                 s.log,
+			AuthHandler:         s.authHandler,
+			QuotaHandler:        s.quotaHandler,
+			Realm:               s.realm,
+			AllocationManager:   allocationManager,
+			ChannelBindTimeout:  s.channelBindTimeout,
+			PermissionTimeout:   s.permissionTimeout,
+			AllocationLifetime:  s.allocationLifetime,
+			StrictAddressFamily: s.strictAddressFamily,
+			NonceHash:           s.nonceHash,
 		}); err != nil {
 			if s.eventHandler.OnAllocationError != nil {
 				s.eventHandler.OnAllocationError(addr, conn.LocalAddr(), allocation.UDP.String(), err.Error())

--- a/server_config.go
+++ b/server_config.go
@@ -165,6 +165,11 @@ type ServerConfig struct {
 	// AllocationLife sets the lifetime of allocation. Defaults to 10 minutes.
 	AllocationLifetime time.Duration
 
+	// StrictAddressFamily keeps the RFC 6156 default of IPv4 when
+	// REQUESTED-ADDRESS-FAMILY is omitted. By default, omitted address family
+	// follows the listener address family for browser compatibility.
+	StrictAddressFamily bool
+
 	// Sets the server inbound MTU(Maximum transmition unit). Defaults to 1600 bytes.
 	InboundMTU int
 }


### PR DESCRIPTION
#### Description

Browsers and some clients don't send THE RFC-6156 REQUESTED-ADDRESS-FAMILY attribute on allocate request when connecting to TURN servers over IPv6. Instead they just send RFC-5766-like allocate requests (even tho this spec doesn't support IPv6) and pion/turn ends up default to IPv4 which breaks IPV6-only listeners.

This changes the default behavior to derive the allocation family from the listener address when requested address family is omitted. Also adds a new optin config  StrictAddressFamily for users who want a strict RFC-6156 behavior for whatever reason.

I tested with chrome in a docker setup and it seems to be working.

#### Reference issue
Fixes #566
