### PR TITLE
Close allocation on ChannelBind 400

### DIFF
--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -3,9 +3,7 @@
 
 package client
 
-import (
-	"errors"
-)
+import "errors"
 
 var (
 	errFake                                = errors.New("fake error")
@@ -23,6 +21,7 @@ var (
 	errInvalidTURNAddress                  = errors.New("invalid TURN server address")
 	errUnexpectedSTUNRequestMessage        = errors.New("unexpected STUN request message")
 	errCannotBindChannel                   = errors.New("cannot bind channel")
+	errChannelBindBadRequest               = errors.New("channel bind bad request")
 )
 
 type timeoutError struct {

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/pion/stun/v3"
@@ -42,6 +43,7 @@ type UDPConn struct {
 	checkBindingsTimer     *PeriodicTimer    // Thread-safe
 	readCh                 chan *inboundData // Thread-safe
 	closeCh                chan struct{}     // Thread-safe
+	closeMutex             sync.Mutex        // Thread-safe
 	bindingRefreshInterval time.Duration     // Read-only
 	allocation
 }
@@ -188,6 +190,14 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 	if !ok {
 		return 0, errUDPAddrCast
 	}
+	if c.isClosed() {
+		return 0, &net.OpError{
+			Op:   "write",
+			Net:  c.LocalAddr().Network(),
+			Addr: c.LocalAddr(),
+			Err:  errClosed,
+		}
+	}
 
 	// Check if we have a permission for the destination IP addr
 	perm, ok := c.permMap.find(addr)
@@ -276,6 +286,15 @@ func (c *UDPConn) Close() error {
 // LocalAddr returns the local network address.
 func (c *UDPConn) LocalAddr() net.Addr {
 	return c.relayedAddr
+}
+
+func (c *UDPConn) isClosed() bool {
+	select {
+	case <-c.closeCh:
+		return true
+	default:
+		return false
+	}
 }
 
 // SetDeadline sets the read and write deadlines associated
@@ -425,6 +444,9 @@ func (c *UDPConn) maybeBind(bound *binding) {
 		if err != nil {
 			c.log.Warnf("Failed to bind channel %d: %s", bound.number, err)
 			bound.setState(bindingStateFailed)
+			if errors.Is(err, errChannelBindBadRequest) {
+				c.closeAfterChannelBindBadRequest(bound)
+			}
 
 			return
 		}
@@ -452,6 +474,18 @@ func (c *UDPConn) maybeBind(bound *binding) {
 	go bind()
 }
 
+func (c *UDPConn) closeAfterChannelBindBadRequest(bound *binding) {
+	c.log.Warnf(
+		"ChannelBind rejected with 400 for %s on channel %d; closing TURN allocation",
+		bound.addr,
+		bound.number,
+	)
+
+	if err := c.Close(); err != nil && !errors.Is(err, errAlreadyClosed) {
+		c.log.Warnf("Failed to close TURN allocation after ChannelBind 400: %s", err)
+	}
+}
+
 func (c *UDPConn) bind(bound *binding) error {
 	setters := []stun.Setter{
 		stun.TransactionID,
@@ -477,24 +511,31 @@ func (c *UDPConn) bind(bound *binding) error {
 
 	res := trRes.Msg
 	if res.Type.Class == stun.ClassErrorResponse {
-		var code stun.ErrorCodeAttribute
-		if err = code.GetFrom(res); err == nil {
-			if code.Code == stun.CodeStaleNonce {
-				c.setNonceFromMsg(res)
-
-				return errTryAgain
-			}
-
-			return fmt.Errorf("%w: received error %d", errCannotBindChannel, code.Code) // nolint:err113
-		}
-
-		return fmt.Errorf("%w: unexpected response type %s", errCannotBindChannel, res.Type) // nolint:err113
+		return c.handleChannelBindErrorResponse(res)
 	}
 
 	c.log.Debugf("Channel binding successful: %s %d", bound.addr, bound.number)
 
 	// Success.
 	return nil
+}
+
+func (c *UDPConn) handleChannelBindErrorResponse(res *stun.Message) error {
+	var code stun.ErrorCodeAttribute
+	if err := code.GetFrom(res); err != nil {
+		return fmt.Errorf("%w: unexpected response type %s", errCannotBindChannel, res.Type) // nolint:err113
+	}
+
+	switch code.Code {
+	case stun.CodeStaleNonce:
+		c.setNonceFromMsg(res)
+
+		return errTryAgain
+	case stun.CodeBadRequest:
+		return fmt.Errorf("%w: %w: received error %d", errCannotBindChannel, errChannelBindBadRequest, code.Code)
+	default:
+		return fmt.Errorf("%w: received error %d", errCannotBindChannel, code.Code) // nolint:err113
+	}
 }
 
 func (c *UDPConn) sendChannelData(data []byte, chNum uint16) (int, error) {

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -267,6 +267,9 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 // Close closes the connection.
 // Any blocked ReadFrom or WriteTo operations will be unblocked and return errors.
 func (c *UDPConn) Close() error {
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
+
 	c.refreshAllocTimer.Stop()
 	c.refreshPermsTimer.Stop()
 	c.checkBindingsTimer.Stop()

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
+	"github.com/pion/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUDPConn(t *testing.T) { // nolint:maintidx
+func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop
 	makeConn := func(client *mockClient, bm *bindingManager) UDPConn {
 		return UDPConn{
 			allocation: allocation{
@@ -96,6 +97,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx
 			transactionFn        func(*stun.Message, net.Addr, bool) (TransactionResult, error)
 			expectErr            error
 			expectErrContains    string
+			expectBadRequest     bool
 			expectBindingDeleted bool
 			expectNonceChanged   bool
 		}{
@@ -129,6 +131,20 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx
 				expectErrContains: "received error",
 			},
 			{
+				name: "ErrorResponse with CodeBadRequest is detectable",
+				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+					res := stun.MustBuild(
+						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
+						stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
+					)
+
+					return TransactionResult{Msg: res}, nil
+				},
+				expectErr:         errCannotBindChannel,
+				expectErrContains: "received error",
+				expectBadRequest:  true,
+			},
+			{
 				name: "ErrorResponse without error code returns unexpected response type error",
 				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
 					res := stun.MustBuild(
@@ -159,6 +175,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx
 				if tt.expectErrContains != "" {
 					assert.ErrorContains(t, err, tt.expectErrContains)
 				}
+				assert.Equal(t, tt.expectBadRequest, errors.Is(err, errChannelBindBadRequest))
 
 				if tt.expectBindingDeleted {
 					assert.Empty(t, bm.chanMap)
@@ -182,6 +199,95 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx
 				}
 			})
 		}
+	})
+
+	t.Run("ChannelBind 400 closes allocation", func(t *testing.T) {
+		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
+		peerAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50000}
+		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
+
+		deallocatedCh := make(chan net.Addr, 1)
+		refreshLifetimeCh := make(chan time.Duration, 1)
+		refreshDontWaitCh := make(chan bool, 1)
+		refreshErrCh := make(chan error, 1)
+
+		client := &mockClient{
+			performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+				switch msg.Type.Method {
+				case stun.MethodChannelBind:
+					return TransactionResult{
+						Msg: stun.MustBuild(
+							stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
+							stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
+						),
+					}, nil
+				case stun.MethodRefresh:
+					var lifetime proto.Lifetime
+					if err := lifetime.GetFrom(msg); err != nil {
+						refreshErrCh <- err
+					} else {
+						refreshLifetimeCh <- lifetime.Duration
+						refreshDontWaitCh <- dontWait
+					}
+
+					return TransactionResult{}, nil
+				default:
+					return TransactionResult{}, errFake
+				}
+			},
+			onDeallocated: func(addr net.Addr) {
+				deallocatedCh <- addr
+			},
+		}
+
+		conn := NewUDPConn(&AllocationConfig{
+			Client:      client,
+			RelayedAddr: relayedAddr,
+			ServerAddr:  serverAddr,
+			Username:    stun.NewUsername("user"),
+			Realm:       stun.NewRealm("realm"),
+			Integrity:   stun.NewShortTermIntegrity("pass"),
+			Nonce:       stun.NewNonce("nonce"),
+			Lifetime:    time.Hour,
+			Log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
+		})
+		defer func() { _ = conn.Close() }()
+
+		bound := conn.bindingMgr.create(peerAddr)
+		conn.maybeBind(bound)
+
+		assert.Eventually(t, func() bool {
+			return bound.state() == bindingStateFailed && conn.isClosed()
+		}, 5*time.Second, 10*time.Millisecond)
+
+		select {
+		case err := <-refreshErrCh:
+			assert.NoError(t, err)
+		default:
+		}
+		select {
+		case deallocatedAddr := <-deallocatedCh:
+			assert.Equal(t, relayedAddr, deallocatedAddr)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for deallocation callback")
+		}
+
+		select {
+		case lifetime := <-refreshLifetimeCh:
+			assert.Equal(t, time.Duration(0), lifetime)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for refresh deallocation")
+		}
+
+		select {
+		case dontWait := <-refreshDontWaitCh:
+			assert.True(t, dontWait)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for refresh dontWait flag")
+		}
+
+		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
+		assert.ErrorIs(t, err, errClosed)
 	})
 
 	t.Run("WriteTo()", func(t *testing.T) {


### PR DESCRIPTION
#### Description
This tears down the allocation when  we receive a 400 Bad Request during channelbind, that makes it possible for the caller/ICE layer to recover by creating a fresh allocation after coturn or others rejects the bind with "You cannot use the same peer with different channel number"
#### Reference issue
should help resolve #540

> If the client receives a ChannelBind failure response that indicates that the channel information is out of sync between the client and the server (e.g., an unexpected 400 "Bad Request" response), then it is RECOMMENDED that the client immediately delete the allocation and start afresh with a new allocation.
> https://datatracker.ietf.org/doc/html/rfc8656