### PR TITLE
Recover binding if state is lost

### DIFF
--- a/e2e/e2e_coturn_channelbind_test.go
+++ b/e2e/e2e_coturn_channelbind_test.go
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build coturn && !js
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/stun/v3"
+	"github.com/pion/turn/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+const channelBindDropDuration = 1500 * time.Millisecond
+
+type channelBindDropConn struct {
+	net.PacketConn
+
+	dropUntil           atomic.Int64
+	droppedChannelBinds atomic.Uint32
+	sentChannelData     atomic.Uint32
+}
+
+func (c *channelBindDropConn) dropChannelBindResponsesFor(d time.Duration) {
+	c.dropUntil.Store(time.Now().Add(d).UnixNano())
+}
+
+func (c *channelBindDropConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	for {
+		n, addr, err := c.PacketConn.ReadFrom(p)
+		if err != nil {
+			return n, addr, err
+		}
+		if time.Now().UnixNano() < c.dropUntil.Load() && isChannelBindSTUNMessage(p[:n]) {
+			c.droppedChannelBinds.Add(1)
+
+			continue
+		}
+
+		return n, addr, nil
+	}
+}
+
+func (c *channelBindDropConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	if isTURNChannelData(p) {
+		c.sentChannelData.Add(1)
+	}
+
+	return c.PacketConn.WriteTo(p, addr)
+}
+
+func isChannelBindSTUNMessage(data []byte) bool {
+	msg := &stun.Message{Raw: data}
+	if err := msg.Decode(); err != nil {
+		return false
+	}
+
+	return msg.Type.Method == stun.MethodChannelBind
+}
+
+func isTURNChannelData(data []byte) bool {
+	return len(data) >= 4 && data[0]&0xc0 == 0x40
+}
+
+func clientPionChannelBindAmbiguous400(manager *testmgr) {
+	if err := waitForCoturnReady(manager); err != nil {
+		manager.errChan <- err
+
+		return
+	}
+	manager.clientMutex.Lock()
+	defer manager.clientMutex.Unlock()
+
+	recoveryClient, err := newChannelBindRecoveryClient(manager)
+	if err != nil {
+		manager.errChan <- err
+
+		return
+	}
+	defer recoveryClient.close()
+
+	if err = exerciseChannelBindAmbiguous400(recoveryClient); err != nil {
+		manager.errChan <- err
+
+		return
+	}
+
+	manager.messageReceived <- testMessage
+
+	manager.clientDone <- nil
+	close(manager.clientDone)
+}
+
+func waitForCoturnReady(manager *testmgr) error {
+	select {
+	case <-manager.serverReady:
+		return nil
+	case <-time.After(5 * time.Second):
+		return errServerTimeout
+	}
+}
+
+type channelBindRecoveryClient struct {
+	client       *turn.Client
+	filteredConn *channelBindDropConn
+	peerConn     net.PacketConn
+	relayConn    net.PacketConn
+}
+
+func newChannelBindRecoveryClient(manager *testmgr) (*channelBindRecoveryClient, error) {
+	var err error
+	manager.clientConn, err = net.ListenPacket("udp4", "127.0.0.1:0") //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("listen client: %w", err)
+	}
+	filteredConn := &channelBindDropConn{PacketConn: manager.clientConn}
+	client, err := turn.NewClient(&turn.ClientConfig{
+		TURNServerAddr: manager.serverAddr,
+		Username:       manager.username,
+		Password:       manager.password,
+		Realm:          manager.realm,
+		Conn:           filteredConn,
+		RTO:            10 * time.Millisecond,
+		LoggerFactory:  logging.NewDefaultLoggerFactory(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new client: %w", err)
+	}
+
+	if err = client.Listen(); err != nil {
+		client.Close()
+
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+
+	relayConn, err := client.Allocate()
+	if err != nil {
+		client.Close()
+
+		return nil, fmt.Errorf("allocate: %w", err)
+	}
+
+	peerConn, err := net.ListenPacket("udp4", "127.0.0.1:0") //nolint:noctx
+	if err != nil {
+		_ = relayConn.Close()
+		client.Close()
+
+		return nil, fmt.Errorf("listen peer: %w", err)
+	}
+
+	return &channelBindRecoveryClient{
+		client:       client,
+		filteredConn: filteredConn,
+		peerConn:     peerConn,
+		relayConn:    relayConn,
+	}, nil
+}
+
+func (c *channelBindRecoveryClient) close() {
+	_ = c.peerConn.Close()
+	_ = c.relayConn.Close()
+	c.client.Close()
+}
+
+func exerciseChannelBindAmbiguous400(recovery *channelBindRecoveryClient) error {
+	peerAddr := recovery.peerConn.LocalAddr()
+	payload := []byte(testMessage)
+	retryPayload := []byte(testMessage + " retry")
+
+	recovery.filteredConn.dropChannelBindResponsesFor(channelBindDropDuration)
+	if _, err := recovery.relayConn.WriteTo(payload, peerAddr); err != nil {
+		return fmt.Errorf("first WriteTo: %w", err)
+	}
+
+	time.Sleep(channelBindDropDuration + 500*time.Millisecond)
+	if recovery.filteredConn.droppedChannelBinds.Load() == 0 {
+		return errors.New("did not drop any coturn ChannelBind responses") //nolint:err113
+	}
+
+	drainPackets(recovery.peerConn)
+	sentChannelDataStart := recovery.filteredConn.sentChannelData.Load()
+	if err := writeUntilClosedWithoutChannelData(
+		recovery.relayConn,
+		peerAddr,
+		retryPayload,
+		recovery.filteredConn,
+		sentChannelDataStart,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeUntilClosedWithoutChannelData(
+	relayConn net.PacketConn,
+	peerAddr net.Addr,
+	payload []byte,
+	filteredConn *channelBindDropConn,
+	sentChannelDataStart uint32,
+) error {
+	deadline := time.Now().Add(testTimeLimit)
+	attempt := 0
+	for time.Now().Before(deadline) {
+		attempt++
+		attemptPayload := []byte(fmt.Sprintf("%s %d", payload, attempt))
+		if _, err := relayConn.WriteTo(attemptPayload, peerAddr); err != nil {
+			if isAllocationClosedWriteError(relayConn, err) {
+				return nil
+			}
+
+			return fmt.Errorf("WriteTo failed before expected allocation close: %w", err)
+		}
+		if filteredConn.sentChannelData.Load() > sentChannelDataStart {
+			return errors.New("sent ChannelData after ambiguous ChannelBind 400") //nolint:err113
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return errors.New("timed out waiting for allocation close after ambiguous ChannelBind 400") //nolint:err113
+}
+
+func isAllocationClosedWriteError(relayConn net.PacketConn, err error) bool {
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) || opErr.Op != "write" || opErr.Err == nil {
+		return false
+	}
+
+	localAddr := relayConn.LocalAddr()
+	if localAddr == nil || opErr.Addr == nil ||
+		opErr.Net != localAddr.Network() ||
+		opErr.Addr.String() != localAddr.String() {
+		return false
+	}
+
+	return errors.Is(err, net.ErrClosed) ||
+		strings.Contains(opErr.Err.Error(), "use of closed network connection")
+}
+
+func drainPackets(conn net.PacketConn) {
+	buf := make([]byte, 1500)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(25 * time.Millisecond))
+		if _, _, err := conn.ReadFrom(buf); err != nil {
+			return
+		}
+	}
+}
+
+func TestPionCoturnChannelBindAmbiguous400Closes(t *testing.T) {
+	t.Parallel()
+	testPionE2ESimple(t, serverCoturn, clientPionChannelBindAmbiguous400)
+}
+
+func TestTURNChannelDataDetection(t *testing.T) {
+	assert.True(t, isTURNChannelData([]byte{0x40, 0x00, 0x00, 0x00}))
+	assert.False(t, isTURNChannelData([]byte{0x00, 0x01, 0x00, 0x00}))
+	assert.False(t, isTURNChannelData([]byte{0x80, 0x00, 0x00, 0x00}))
+	assert.False(t, isTURNChannelData([]byte{0x40, 0x00, 0x00}))
+}

--- a/e2e/e2e_coturn_test.go
+++ b/e2e/e2e_coturn_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 //go:build coturn && !js
-// +build coturn,!js
 
 package e2e
 
@@ -26,7 +25,7 @@ const (
 
 // serverCoturn starts a coturn TURN server.
 //
-//nolint:varnamelen
+//nolint:dupl,varnamelen
 func serverCoturn(m *testmgr) {
 	go func() {
 		m.serverMutex.Lock()
@@ -48,6 +47,8 @@ user=%s:%s
 realm=%s
 lt-cred-mech
 fingerprint
+allow-loopback-peers
+no-cli
 no-tls
 no-dtls
 log-file=stdout
@@ -173,7 +174,7 @@ func clientCoturn(m *testmgr) {
 	close(m.clientDone)
 }
 
-//nolint:varnamelen
+//nolint:dupl,varnamelen
 func serverCoturnIPv6(m *testmgr) {
 	go func() {
 		m.serverMutex.Lock()

--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -24,6 +24,8 @@ type bindingState int32
 const (
 	bindingStateIdle bindingState = iota
 	bindingStateRequest
+	bindingStateUnknown
+	bindingStateReadyUnknown
 	bindingStateReady
 	bindingStateRefresh
 	bindingStateFailed
@@ -64,7 +66,7 @@ func (b *binding) refreshedAt() time.Time {
 func (b *binding) ok() bool {
 	state := b.state()
 
-	return state == bindingStateReady || state == bindingStateRefresh
+	return state == bindingStateReady || state == bindingStateRefresh || state == bindingStateReadyUnknown
 }
 
 // Thread-safe binding map.

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -22,6 +22,7 @@ var (
 	errUnexpectedSTUNRequestMessage        = errors.New("unexpected STUN request message")
 	errCannotBindChannel                   = errors.New("cannot bind channel")
 	errChannelBindBadRequest               = errors.New("channel bind bad request")
+	errChannelBindTransactionFailed        = errors.New("channel bind transaction failed")
 )
 
 type timeoutError struct {

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -437,44 +437,101 @@ func (c *UDPConn) FindAddrByChannelNumber(chNum uint16) (net.Addr, bool) {
 }
 
 func (c *UDPConn) maybeBind(bound *binding) {
-	bind := func() {
-		var err error
-		for range maxRetryAttempts {
-			if err = c.bind(bound); !errors.Is(err, errTryAgain) {
-				break
-			}
-		}
-		if err != nil {
-			c.log.Warnf("Failed to bind channel %d: %s", bound.number, err)
-			bound.setState(bindingStateFailed)
-			if errors.Is(err, errChannelBindBadRequest) {
-				c.closeAfterChannelBindBadRequest(bound)
-			}
-
-			return
-		}
-		bound.setRefreshedAt(time.Now())
-		bound.setState(bindingStateReady)
-	}
-
 	// Block only callers with the same binding until
 	// the binding transaction has been complete
 	bound.muBind.Lock()
 	defer bound.muBind.Unlock()
 
-	state := bound.state()
-	switch {
-	case state == bindingStateIdle:
-		bound.setState(bindingStateRequest)
-	case state == bindingStateReady && time.Since(bound.refreshedAt()) > c.bindingRefreshInterval:
-		bound.setState(bindingStateRefresh)
-	default:
+	startState, ok := c.startBinding(bound)
+	if !ok {
 		return
 	}
 
 	// Establish binding with the server if eligible
 	// with regard to cases right above.
-	go bind()
+	go c.bindChannel(bound, startState)
+}
+
+func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
+	startState := bound.state()
+	switch {
+	case startState == bindingStateIdle || startState == bindingStateUnknown:
+		bound.setState(bindingStateRequest)
+	case startState == bindingStateReadyUnknown:
+		bound.setState(bindingStateRefresh)
+	case startState == bindingStateReady && time.Since(bound.refreshedAt()) > c.bindingRefreshInterval:
+		bound.setState(bindingStateRefresh)
+	default:
+		return startState, false
+	}
+
+	return startState, true
+}
+
+func (c *UDPConn) bindChannel(bound *binding, startState bindingState) {
+	var err error
+	for range maxRetryAttempts {
+		if err = c.bind(bound); !errors.Is(err, errTryAgain) {
+			break
+		}
+	}
+	if err != nil {
+		c.handleBindChannelError(bound, startState, err)
+
+		return
+	}
+
+	bound.setRefreshedAt(time.Now())
+	bound.setState(bindingStateReady)
+}
+
+func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState, err error) {
+	if c.recoverChannelBindBadRequest(bound, startState, err) {
+		return
+	}
+
+	c.log.Warnf("Failed to bind channel %d: %s", bound.number, err)
+	if errors.Is(err, errChannelBindTransactionFailed) {
+		if bindingStateWasReady(startState) {
+			bound.setState(bindingStateReadyUnknown)
+		} else {
+			bound.setState(bindingStateUnknown)
+		}
+
+		return
+	}
+
+	bound.setState(bindingStateFailed)
+	if errors.Is(err, errChannelBindBadRequest) {
+		c.closeAfterChannelBindBadRequest(bound)
+	}
+}
+
+func (c *UDPConn) recoverChannelBindBadRequest(bound *binding, startState bindingState, err error) bool {
+	if !errors.Is(err, errChannelBindBadRequest) {
+		return false
+	}
+	if !bindingStateWasReady(startState) {
+		return false
+	}
+
+	// If this binding was previously confirmed, a refresh transaction failure or
+	// unexpected 400 does not prove that the saved channel mapping is wrong. The
+	// server may still have the old binding, and switching channels would be
+	// worse because it can trigger "same peer with different channel number" (like what we get from Coturn).
+	// This Keep the saved mapping usable and retry refresh later.
+	c.log.Warnf(
+		"ChannelBind returned 400 for saved binding %s on channel %d; keeping binding ready",
+		bound.addr,
+		bound.number,
+	)
+	bound.setState(bindingStateReady)
+
+	return true
+}
+
+func bindingStateWasReady(state bindingState) bool {
+	return state == bindingStateReady || state == bindingStateReadyUnknown
 }
 
 func (c *UDPConn) closeAfterChannelBindBadRequest(bound *binding) {
@@ -509,7 +566,7 @@ func (c *UDPConn) bind(bound *binding) error {
 
 	trRes, err := c.client.PerformTransaction(msg, c.serverAddr, false)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", errChannelBindTransactionFailed, err)
 	}
 
 	res := trRes.Msg

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -6,6 +6,7 @@ package client
 import (
 	"errors"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop
+func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	makeConn := func(client *mockClient, bm *bindingManager) UDPConn {
 		return UDPConn{
 			allocation: allocation{
@@ -35,6 +36,13 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop
 		)
 	}
 
+	badRequestMsg := func() *stun.Message {
+		return stun.MustBuild(
+			stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
+			stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
+		)
+	}
+
 	t.Run("maybeBind()", func(t *testing.T) {
 		tests := []struct {
 			name          string
@@ -46,6 +54,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop
 		}{
 			{"idle -> request -> ready", bindingStateIdle, bindingStateRequest, bindingStateReady, false, true},
 			{"idle -> request -> failed", bindingStateIdle, bindingStateRequest, bindingStateFailed, false, false},
+			{"unknown -> request -> ready", bindingStateUnknown, bindingStateRequest, bindingStateReady, false, true},
+			{"ready unknown -> refresh -> ready", bindingStateReadyUnknown, bindingStateRefresh, bindingStateReady, false, true},
 			{"ready (stale) -> refresh -> ready", bindingStateReady, bindingStateRefresh, bindingStateReady, true, true},
 			{"ready (stale) -> refresh -> failed", bindingStateReady, bindingStateRefresh, bindingStateFailed, true, false},
 
@@ -201,6 +211,37 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop
 		}
 	})
 
+	t.Run("maybeBind() retries unknown binding after transaction failure", func(t *testing.T) {
+		var failed atomic.Bool
+
+		bm := newBindingManager()
+		bound := bm.create(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234})
+		originalCh := bound.number
+		conn := makeConn(&mockClient{
+			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+				if failed.CompareAndSwap(false, true) {
+					return TransactionResult{}, errFake
+				}
+
+				return TransactionResult{Msg: new(stun.Message)}, nil
+			},
+		}, bm)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return bound.state() == bindingStateUnknown
+		}, 5*time.Second, 10*time.Millisecond)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return bound.state() == bindingStateReady
+		}, 5*time.Second, 10*time.Millisecond)
+
+		b2, ok := bm.findByAddr(bound.addr)
+		assert.True(t, ok)
+		assert.Equal(t, originalCh, b2.number)
+	})
+
 	t.Run("ChannelBind 400 closes allocation", func(t *testing.T) {
 		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
 		peerAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50000}
@@ -288,6 +329,146 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop
 
 		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
 		assert.ErrorIs(t, err, errClosed)
+	})
+
+	t.Run("ChannelBind 400 after unknown binding closes allocation", func(t *testing.T) {
+		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
+		peerAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
+
+		var channelBindAttempts atomic.Int32
+		deallocatedCh := make(chan net.Addr, 1)
+
+		conn := NewUDPConn(&AllocationConfig{
+			Client: &mockClient{
+				performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+					switch msg.Type.Method {
+					case stun.MethodChannelBind:
+						if channelBindAttempts.Add(1) == 1 {
+							return TransactionResult{}, errFake
+						}
+
+						return TransactionResult{Msg: badRequestMsg()}, nil
+					case stun.MethodRefresh:
+						return TransactionResult{}, nil
+					default:
+						return TransactionResult{}, errFake
+					}
+				},
+				onDeallocated: func(addr net.Addr) {
+					deallocatedCh <- addr
+				},
+			},
+			RelayedAddr: relayedAddr,
+			ServerAddr:  serverAddr,
+			Username:    stun.NewUsername("user"),
+			Realm:       stun.NewRealm("realm"),
+			Integrity:   stun.NewShortTermIntegrity("pass"),
+			Nonce:       stun.NewNonce("nonce"),
+			Lifetime:    time.Hour,
+			Log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
+		})
+		defer func() { _ = conn.Close() }()
+
+		bound := conn.bindingMgr.create(peerAddr)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return bound.state() == bindingStateUnknown
+		}, 5*time.Second, 10*time.Millisecond)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return bound.state() == bindingStateFailed && conn.isClosed()
+		}, 5*time.Second, 10*time.Millisecond)
+		assert.Equal(t, int32(2), channelBindAttempts.Load())
+
+		select {
+		case deallocatedAddr := <-deallocatedCh:
+			assert.Equal(t, relayedAddr, deallocatedAddr)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for deallocation callback")
+		}
+	})
+
+	t.Run("ChannelBind 400 after lost ready refresh keeps saved binding", func(t *testing.T) {
+		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
+		peerAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
+
+		var channelBindAttempts atomic.Int32
+
+		conn := NewUDPConn(&AllocationConfig{
+			Client: &mockClient{
+				performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+					switch msg.Type.Method {
+					case stun.MethodChannelBind:
+						if channelBindAttempts.Add(1) == 1 {
+							return TransactionResult{}, newTimeoutError("channel bind timeout")
+						}
+
+						return TransactionResult{Msg: badRequestMsg()}, nil
+					case stun.MethodRefresh:
+						return TransactionResult{}, nil
+					default:
+						return TransactionResult{}, errFake
+					}
+				},
+			},
+			RelayedAddr: relayedAddr,
+			ServerAddr:  serverAddr,
+			Username:    stun.NewUsername("user"),
+			Realm:       stun.NewRealm("realm"),
+			Integrity:   stun.NewShortTermIntegrity("pass"),
+			Nonce:       stun.NewNonce("nonce"),
+			Lifetime:    time.Hour,
+			Log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
+		})
+		defer func() { _ = conn.Close() }()
+
+		bound := conn.bindingMgr.create(peerAddr)
+		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
+		bound.setState(bindingStateReady)
+		bound.setRefreshedAt(staleRefreshedAt)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return bound.state() == bindingStateReadyUnknown
+		}, 5*time.Second, 10*time.Millisecond)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return channelBindAttempts.Load() == 2 && bound.state() == bindingStateReady
+		}, 5*time.Second, 10*time.Millisecond)
+		assert.True(t, bound.refreshedAt().Equal(staleRefreshedAt))
+		assert.False(t, conn.isClosed())
+	})
+
+	t.Run("ChannelBind 400 refresh keeps saved binding", func(t *testing.T) {
+		bm := newBindingManager()
+		bound := bm.create(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234})
+		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
+		var channelBindAttempts atomic.Int32
+		bound.setState(bindingStateReady)
+		bound.setRefreshedAt(staleRefreshedAt)
+		conn := makeConn(&mockClient{
+			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+				channelBindAttempts.Add(1)
+
+				return TransactionResult{Msg: badRequestMsg()}, nil
+			},
+		}, bm)
+
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return channelBindAttempts.Load() == 1 && bound.state() == bindingStateReady
+		}, 5*time.Second, 10*time.Millisecond)
+		assert.True(t, bound.refreshedAt().Equal(staleRefreshedAt))
+		startState, ok := conn.startBinding(bound)
+		assert.True(t, ok, "recovered binding should remain eligible for refresh")
+		assert.Equal(t, bindingStateReady, startState)
+		assert.Equal(t, bindingStateRefresh, bound.state())
+		assert.False(t, conn.isClosed())
 	})
 
 	t.Run("WriteTo()", func(t *testing.T) {


### PR DESCRIPTION
#### Description
This is more of a hack. This changes UDP ChannelBind handling so we we retry transaction failures binding states instead of immediately failing and reallocating a new channel. It also handles ambiguous 400 Bad Request responses differently depending on whether the binding was already known-ready.

Added a e2e test to prove that this fixes the issue when we lose the binding state in the wire, and instead of close the allocation we just re-use the allocation
#### Reference issue
Fixes #540 based on #578 