### PR TITLE
Add deterministic UDP peer preparation

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@
 package turn
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"fmt"
 	"math"
@@ -569,6 +570,21 @@ func (c *Client) CreatePermission(addrs ...net.Addr) error {
 	}
 
 	return nil
+}
+
+// PrepareUDPPeer creates a permission for peer on the client's UDP allocation
+// and waits until the TURN server confirms a channel binding for it. After it
+// returns nil, writes to peer use ChannelData (or fail) for the lifetime of
+// the allocation; they never fall back to Send indications. Concurrent calls
+// for the same peer share one permission and one bind; canceling ctx wakes
+// only that caller and leaves the shared work running.
+func (c *Client) PrepareUDPPeer(ctx context.Context, peer net.Addr) error {
+	conn := c.relayedUDPConn()
+	if conn == nil {
+		return errUDPAllocationNotFound
+	}
+
+	return conn.PreparePeer(ctx, peer)
 }
 
 // PerformTransaction performs STUN transaction.

--- a/errors.go
+++ b/errors.go
@@ -24,6 +24,7 @@ var (
 	errSTUNServerAddressNotSet       = errors.New("STUN server address is not set for the client")
 	errOneAllocateOnly               = errors.New("only one Allocate() caller is allowed")
 	errAlreadyAllocated              = errors.New("already allocated")
+	errUDPAllocationNotFound         = errors.New("UDP allocation not found")
 	errNonSTUNMessage                = errors.New("non-STUN message from STUN server")
 	errFailedToDecodeSTUN            = errors.New("failed to decode STUN message")
 	errUnexpectedSTUNRequestMessage  = errors.New("unexpected STUN request message")

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -49,6 +49,10 @@ type allocation struct {
 	readTimer         *time.Timer           // Thread-safe
 	mutex             sync.RWMutex          // Thread-safe
 	log               logging.LeveledLogger // Read-only
+
+	// onPermRefreshFailure, when set, observes a permission refresh that kept
+	// failing after retries. Read-only after construction.
+	onPermRefreshFailure func(error)
 }
 
 func (a *allocation) setNonceFromMsg(msg *stun.Message) {
@@ -166,6 +170,9 @@ func (a *allocation) onRefreshTimers(id int) {
 		}
 		if err != nil {
 			a.log.Warnf("Failed to refresh permissions: %s", err)
+			if a.onPermRefreshFailure != nil {
+				a.onPermRefreshFailure(err)
+			}
 		}
 	}
 }

--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -37,12 +37,52 @@ type binding struct {
 	addr         net.Addr        // Read-only
 	mgr          *bindingManager // Read-only
 	muBind       sync.Mutex      // Thread-safe, for ChannelBind ops
+	attemptDone  chan struct{}   // Protected by muBind; non-nil while a bind attempt is in flight
+	prepared     atomic.Bool     // Thread-safe; peer promised ChannelData-only writes
 	_refreshedAt time.Time       // Protected by mutex
+	_bindErr     error           // Protected by mutex; last failed bind attempt or terminal cause
+	_terminal    bool            // Protected by mutex; binding failed permanently
 	mutex        sync.RWMutex    // Thread-safe
 }
 
 func (b *binding) setState(state bindingState) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if b._terminal {
+		state = bindingStateFailed
+	}
 	atomic.StoreInt32((*int32)(&b.st), int32(state))
+}
+
+// terminalize permanently fails the binding: every later setState collapses to
+// bindingStateFailed so an in-flight bind attempt cannot resurrect it.
+func (b *binding) terminalize(err error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if b._terminal {
+		return
+	}
+	b._terminal = true
+	b._bindErr = err
+	atomic.StoreInt32((*int32)(&b.st), int32(bindingStateFailed))
+}
+
+func (b *binding) setBindErr(err error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if !b._terminal {
+		b._bindErr = err
+	}
+}
+
+func (b *binding) bindErr() error {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	return b._bindErr
 }
 
 func (b *binding) state() bindingState {
@@ -97,8 +137,18 @@ func (mgr *bindingManager) assignChannelNumber() uint16 {
 }
 
 func (mgr *bindingManager) create(addr net.Addr) *binding {
+	return mgr.getOrCreate(addr)
+}
+
+// getOrCreate returns the existing binding for addr, or creates one, so that
+// concurrent callers for the same peer share a single channel number.
+func (mgr *bindingManager) getOrCreate(addr net.Addr) *binding {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
+
+	if b, ok := mgr.addrMap[addr.String()]; ok {
+		return b
+	}
 
 	b := &binding{
 		number:       mgr.assignChannelNumber(),

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -23,6 +23,11 @@ var (
 	errCannotBindChannel                   = errors.New("cannot bind channel")
 	errChannelBindBadRequest               = errors.New("channel bind bad request")
 	errChannelBindTransactionFailed        = errors.New("channel bind transaction failed")
+	errChannelBindFailed                   = errors.New("channel bind failed")
+	errChannelBindingExpired               = errors.New("confirmed channel binding expired")
+	errPermissionRefreshFailed             = errors.New("permission refresh failed")
+	errInvalidUDPAddr                      = errors.New("invalid UDP address")
+	errNilContext                          = errors.New("context must not be nil")
 )
 
 type timeoutError struct {

--- a/internal/client/periodic_timer.go
+++ b/internal/client/periodic_timer.go
@@ -17,6 +17,7 @@ type PeriodicTimer struct {
 	interval       time.Duration
 	timeoutHandler PeriodicTimerTimeoutHandler
 	stopFunc       func()
+	doneCh         chan struct{}
 	mutex          sync.RWMutex
 }
 
@@ -40,8 +41,10 @@ func (t *PeriodicTimer) Start() bool {
 	}
 
 	cancelCh := make(chan struct{})
+	doneCh := make(chan struct{})
 
 	go func() {
+		defer close(doneCh)
 		canceling := false
 
 		for !canceling {
@@ -60,6 +63,7 @@ func (t *PeriodicTimer) Start() bool {
 	t.stopFunc = func() {
 		close(cancelCh)
 	}
+	t.doneCh = doneCh
 
 	return true
 }
@@ -72,6 +76,22 @@ func (t *PeriodicTimer) Stop() {
 	if t.stopFunc != nil {
 		t.stopFunc()
 		t.stopFunc = nil
+	}
+}
+
+// StopAndWait stops the timer and waits for its handler goroutine to return.
+// It must not be called from the timer's own timeout handler.
+func (t *PeriodicTimer) StopAndWait() {
+	t.mutex.Lock()
+	if t.stopFunc != nil {
+		t.stopFunc()
+		t.stopFunc = nil
+	}
+	doneCh := t.doneCh
+	t.mutex.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
 	}
 }
 

--- a/internal/client/periodic_timer_test.go
+++ b/internal/client/periodic_timer_test.go
@@ -45,10 +45,12 @@ func TestPeriodicTimer(t *testing.T) {
 
 	t.Run("stop inside handler", func(t *testing.T) {
 		timerID := 4
+		stopped := make(chan struct{})
 		var rt *PeriodicTimer
 		rt = NewPeriodicTimer(timerID, func(id int) {
 			assert.Equal(t, timerID, id)
 			rt.Stop()
+			close(stopped)
 		}, 20*time.Millisecond)
 
 		assert.False(t, rt.IsRunning(), "should not be running yet")
@@ -56,7 +58,14 @@ func TestPeriodicTimer(t *testing.T) {
 		ok := rt.Start()
 		assert.True(t, ok, "should be true")
 		assert.True(t, rt.IsRunning(), "should be running")
-		time.Sleep(30 * time.Millisecond)
+
+		// Wait for the handler's Stop instead of calibrating a sleep against
+		// the timer interval, which is racy on slow runners.
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for handler to stop the timer")
+		}
 		assert.False(t, rt.IsRunning(), "should not be running")
 	})
 }

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -19,9 +19,11 @@ const (
 )
 
 type permission struct {
-	addr  net.Addr
-	st    permState    // Thread-safe (atomic op)
-	mutex sync.RWMutex // Thread-safe
+	addr        net.Addr
+	st          permState     // Thread-safe (atomic op)
+	attemptDone chan struct{} // Protected by mutex; non-nil while a create attempt is in flight
+	attemptErr  error         // Protected by mutex; result of the last create attempt
+	mutex       sync.RWMutex  // Thread-safe
 }
 
 func (p *permission) setState(state permState) {
@@ -45,6 +47,23 @@ func (m *permissionMap) insert(addr net.Addr, p *permission) bool {
 	m.permMap[ipnet.FingerprintAddr(addr)] = p
 
 	return true
+}
+
+// getOrCreate returns the existing permission for addr, or creates one, so
+// that concurrent callers for the same peer share a single permission.
+func (m *permissionMap) getOrCreate(addr net.Addr) *permission {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	key := ipnet.FingerprintAddr(addr)
+	if p, ok := m.permMap[key]; ok {
+		return p
+	}
+
+	p := &permission{addr: addr}
+	m.permMap[key] = p
+
+	return p
 }
 
 func (m *permissionMap) find(addr net.Addr) (*permission, bool) {

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -21,9 +21,15 @@ const (
 type permission struct {
 	addr        net.Addr
 	st          permState     // Thread-safe (atomic op)
-	attemptDone chan struct{} // Protected by mutex; non-nil while a create attempt is in flight
-	attemptErr  error         // Protected by mutex; result of the last create attempt
-	mutex       sync.RWMutex  // Thread-safe
+	attemptDone chan struct{} // Protected by attemptMutex; non-nil while a create attempt is in flight
+	attemptErr  error         // Protected by attemptMutex; result of the last create attempt
+
+	// attemptMutex guards the attempt bookkeeping only. It is never held
+	// across a transaction, unlike mutex, which createPermission holds for
+	// the duration of the CreatePermission transaction; waiters joining an
+	// attempt must not block behind that transaction.
+	attemptMutex sync.Mutex   // Thread-safe
+	mutex        sync.RWMutex // Thread-safe
 }
 
 func (p *permission) setState(state permState) {

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -25,6 +25,7 @@ type prepareHarness struct {
 	permCount atomic.Int32
 	bindCount atomic.Int32
 	bindGate  chan struct{} // If non-nil, ChannelBind transactions block on it
+	permGate  chan struct{} // If non-nil, CreatePermission transactions block on it
 	failPerms atomic.Bool   // If set, CreatePermission transactions return 403
 	writes    struct {
 		sync.Mutex
@@ -47,6 +48,9 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
 				harness.permCount.Add(1)
+				if harness.permGate != nil {
+					<-harness.permGate
+				}
 				if harness.failPerms.Load() {
 					return TransactionResult{Msg: stun.MustBuild(
 						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
@@ -259,6 +263,46 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			assert.Fail(t, "timed out waiting for surviving waiter")
 		}
 		assert.Equal(t, int32(1), harness.bindCount.Load(), "cancellation must not restart or cancel the shared bind")
+	})
+
+	t.Run("cancellation wakes waiter during in-flight permission transaction", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		harness.permGate = make(chan struct{})
+
+		// First caller's CreatePermission transaction is in flight (and holds
+		// the permission mutex for its duration, as createPermission does).
+		resultA := make(chan error, 1)
+		go func() { resultA <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+		assert.Eventually(t, func() bool {
+			return harness.permCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// A second caller for the same peer must wait on the attempt channel,
+		// where its cancellation can wake it — not on the permission mutex.
+		ctxB, cancelB := context.WithCancelCause(context.Background())
+		defer cancelB(nil)
+		resultB := make(chan error, 1)
+		go func() { resultB <- harness.conn.PreparePeer(ctxB, harness.peer) }()
+		time.Sleep(100 * time.Millisecond)
+
+		cause := errors.New("waiter B gave up") //nolint:err113 // test-local cause
+		cancelB(cause)
+		select {
+		case err := <-resultB:
+			assert.ErrorIs(t, err, cause,
+				"waiter must be cancelable while the permission transaction is in flight")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "canceled waiter did not wake during in-flight permission transaction")
+		}
+
+		close(harness.permGate)
+		select {
+		case err := <-resultA:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for first caller")
+		}
+		assert.Equal(t, int32(1), harness.permCount.Load(), "permission transactions should coalesce")
 	})
 
 	t.Run("permission refresh failure fails writes, never Send indication", func(t *testing.T) {

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/stun/v3"
+	"github.com/pion/turn/v5/internal/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+// prepareHarness drives a NewUDPConn against a scripted mock TURN server.
+type prepareHarness struct {
+	conn      *UDPConn
+	peer      *net.UDPAddr
+	permCount atomic.Int32
+	bindCount atomic.Int32
+	bindGate  chan struct{} // If non-nil, ChannelBind transactions block on it
+	failPerms atomic.Bool   // If set, CreatePermission transactions return 403
+	writes    struct {
+		sync.Mutex
+		data [][]byte
+	}
+}
+
+func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
+	t.Helper()
+
+	harness := &prepareHarness{
+		peer: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+	}
+	if gateBinds {
+		harness.bindGate = make(chan struct{})
+	}
+
+	mock := &mockClient{
+		performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
+			switch msg.Type.Method {
+			case stun.MethodCreatePermission:
+				harness.permCount.Add(1)
+				if harness.failPerms.Load() {
+					return TransactionResult{Msg: stun.MustBuild(
+						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
+						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
+					)}, nil
+				}
+
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
+				)}, nil
+			case stun.MethodChannelBind:
+				harness.bindCount.Add(1)
+				if harness.bindGate != nil {
+					<-harness.bindGate
+				}
+
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
+				)}, nil
+			case stun.MethodRefresh:
+				return TransactionResult{}, nil
+			default:
+				return TransactionResult{}, errFake
+			}
+		},
+		writeTo: func(data []byte, _ net.Addr) (int, error) {
+			harness.writes.Lock()
+			harness.writes.data = append(harness.writes.data, append([]byte(nil), data...))
+			harness.writes.Unlock()
+
+			return len(data), nil
+		},
+	}
+
+	harness.conn = NewUDPConn(&AllocationConfig{
+		Client:      mock,
+		RelayedAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
+		ServerAddr:  &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
+		Username:    stun.NewUsername("user"),
+		Realm:       stun.NewRealm("realm"),
+		Integrity:   stun.NewShortTermIntegrity("pass"),
+		Nonce:       stun.NewNonce("nonce"),
+		Lifetime:    time.Hour,
+		Log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
+	})
+	t.Cleanup(func() { _ = harness.conn.Close() })
+
+	return harness
+}
+
+func (harness *prepareHarness) writeCount() int {
+	harness.writes.Lock()
+	defer harness.writes.Unlock()
+
+	return len(harness.writes.data)
+}
+
+func (harness *prepareHarness) lastWrite() []byte {
+	harness.writes.Lock()
+	defer harness.writes.Unlock()
+
+	if len(harness.writes.data) == 0 {
+		return nil
+	}
+
+	return harness.writes.data[len(harness.writes.data)-1]
+}
+
+func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
+	t.Run("readiness success then ChannelData writes", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Equal(t, int32(1), harness.permCount.Load())
+		assert.Equal(t, int32(1), harness.bindCount.Load())
+
+		n, err := harness.conn.WriteTo([]byte("hello"), harness.peer)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.True(t, proto.IsChannelData(harness.lastWrite()),
+			"write after successful PreparePeer must be ChannelData, not Send indication")
+	})
+
+	t.Run("invalid peers rejected", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}), errUDPAddrCast)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 1234}), errInvalidUDPAddr)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}), errInvalidUDPAddr)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("224.0.0.1"), Port: 1234}), errInvalidUDPAddr)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 1234, Zone: "en0"}), errInvalidUDPAddr)
+	})
+
+	t.Run("peer aliases share the prepared binding", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		peer := &net.UDPAddr{IP: net.ParseIP("::1"), Port: 5678}
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), peer))
+		assert.Equal(t, int32(1), harness.bindCount.Load())
+
+		// A zoned alias of the prepared peer must map onto its channel binding
+		// instead of bypassing it via Send indication.
+		alias := &net.UDPAddr{IP: net.ParseIP("::1"), Port: 5678, Zone: "en0"}
+		_, err := harness.conn.WriteTo([]byte("via alias"), alias)
+		assert.NoError(t, err)
+		assert.True(t, proto.IsChannelData(harness.lastWrite()),
+			"write to an alias of a prepared peer must be ChannelData")
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "alias must not create a second binding")
+	})
+
+	t.Run("terminal failure survives an in-flight bind success", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		harness.conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// Terminalize while the bind transaction is still in flight, then let
+		// it succeed: the binding must stay failed.
+		bound.prepared.Store(true)
+		bound.terminalize(errFake)
+		close(harness.bindGate)
+
+		assert.Eventually(t, func() bool {
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return bound.attemptDone == nil
+		}, 5*time.Second, 10*time.Millisecond)
+		assert.Equal(t, bindingStateFailed, bound.state(),
+			"completed bind attempt must not resurrect a terminalized binding")
+
+		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
+		assert.ErrorIs(t, err, errFake)
+	})
+
+	t.Run("same-peer callers coalesce onto one bind", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		const waiters = 4
+		results := make(chan error, waiters)
+		for range waiters {
+			go func() {
+				results <- harness.conn.PreparePeer(context.Background(), harness.peer)
+			}()
+		}
+
+		// Let the first attempt start and the rest pile onto it.
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
+		close(harness.bindGate)
+
+		for range waiters {
+			select {
+			case err := <-results:
+				assert.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				assert.Fail(t, "timed out waiting for PreparePeer")
+			}
+		}
+		assert.Equal(t, int32(1), harness.permCount.Load(), "permission transactions should coalesce")
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "ChannelBind transactions should coalesce")
+	})
+
+	t.Run("cancellation wakes only that waiter", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		ctxA, cancelA := context.WithCancelCause(context.Background())
+		defer cancelA(nil)
+		causeA := errors.New("waiter A gave up") //nolint:err113 // test-local cause
+
+		resultA := make(chan error, 1)
+		resultB := make(chan error, 1)
+		go func() { resultA <- harness.conn.PreparePeer(ctxA, harness.peer) }()
+		go func() { resultB <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		cancelA(causeA)
+		select {
+		case err := <-resultA:
+			assert.ErrorIs(t, err, causeA, "canceled waiter must observe its cause")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "canceled waiter did not wake promptly")
+		}
+
+		// The shared bind attempt must survive waiter A's cancellation.
+		select {
+		case err := <-resultB:
+			assert.Failf(t, "waiter B finished early", "err: %v", err)
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		close(harness.bindGate)
+		select {
+		case err := <-resultB:
+			assert.NoError(t, err, "surviving waiter should complete via the shared bind")
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for surviving waiter")
+		}
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "cancellation must not restart or cancel the shared bind")
+	})
+
+	t.Run("permission refresh failure fails writes, never Send indication", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+
+		// Simulate the permission-refresh timer firing against a server that
+		// now rejects the refresh.
+		harness.failPerms.Store(true)
+		harness.conn.onRefreshTimers(timerIDRefreshPerms)
+
+		writesBefore := harness.writeCount()
+		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
+		assert.ErrorIs(t, err, errPermissionRefreshFailed)
+		assert.Equal(t, writesBefore, harness.writeCount(),
+			"failed write for a prepared peer must not emit anything (no Send indication fallback)")
+
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), errPermissionRefreshFailed,
+			"readiness must be terminal after permission refresh failure")
+	})
+
+	t.Run("bind failure surfaces to preparing caller", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		// First permission succeeds, but every ChannelBind transaction fails.
+		mock, ok := harness.conn.client.(*mockClient)
+		assert.True(t, ok)
+		inner := mock.performTransaction
+		mock.performTransaction = func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+			if msg.Type.Method == stun.MethodChannelBind {
+				harness.bindCount.Add(1)
+
+				return TransactionResult{}, errFake
+			}
+
+			return inner(msg, to, dontWait)
+		}
+
+		err := harness.conn.PreparePeer(context.Background(), harness.peer)
+		assert.ErrorIs(t, err, errChannelBindTransactionFailed)
+		assert.False(t, harness.conn.isClosed())
+	})
+
+	t.Run("close joins in-flight bind workers", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		prepareResult := make(chan error, 1)
+		go func() { prepareResult <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		closeResult := make(chan error, 1)
+		go func() { closeResult <- harness.conn.Close() }()
+
+		// The waiter unblocks promptly; Close must keep waiting for the worker.
+		select {
+		case err := <-prepareResult:
+			assert.ErrorIs(t, err, errClosed)
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "PreparePeer waiter did not unblock on close")
+		}
+		select {
+		case <-closeResult:
+			assert.Fail(t, "Close returned while a bind worker was still in flight")
+		case <-time.After(300 * time.Millisecond):
+		}
+
+		close(harness.bindGate)
+		select {
+		case err := <-closeResult:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "Close did not return after the bind worker finished")
+		}
+	})
+}

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -261,9 +261,9 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer net.Addr) error {
 		if perm.state() == permStatePermitted {
 			return nil
 		}
-		perm.mutex.RLock()
+		perm.attemptMutex.Lock()
 		err := perm.attemptErr
-		perm.mutex.RUnlock()
+		perm.attemptMutex.Unlock()
 		if err != nil {
 			return err
 		}
@@ -275,8 +275,8 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer net.Addr) error {
 // CreatePermission attempt (existing or newly started) completes. It returns
 // nil once the allocation is closing.
 func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan struct{} {
-	perm.mutex.Lock()
-	defer perm.mutex.Unlock()
+	perm.attemptMutex.Lock()
+	defer perm.attemptMutex.Unlock()
 
 	if perm.attemptDone != nil {
 		return perm.attemptDone
@@ -295,10 +295,10 @@ func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan 
 				break
 			}
 		}
-		perm.mutex.Lock()
+		perm.attemptMutex.Lock()
 		perm.attemptDone = nil
 		perm.attemptErr = err
-		perm.mutex.Unlock()
+		perm.attemptMutex.Unlock()
 		close(done)
 	}()
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -5,11 +5,13 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -22,6 +24,7 @@ const (
 	defaultPermRefreshInterval    = 120 * time.Second
 	defaultBindingRefreshInterval = 5 * time.Minute
 	defaultBindingCheckInterval   = 30 * time.Second
+	channelBindingLifetime        = 10 * time.Minute
 	maxRetryAttempts              = 3
 )
 
@@ -43,7 +46,8 @@ type UDPConn struct {
 	checkBindingsTimer     *PeriodicTimer    // Thread-safe
 	readCh                 chan *inboundData // Thread-safe
 	closeCh                chan struct{}     // Thread-safe
-	closeMutex             sync.Mutex        // Thread-safe
+	closeMutex             sync.Mutex        // Thread-safe; also gates workerWG.Add vs close
+	workerWG               sync.WaitGroup    // Joins bind/permission workers on Close
 	bindingRefreshInterval time.Duration     // Read-only
 	allocation
 }
@@ -74,6 +78,7 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 	if config.BindingRefreshInterval != 0 {
 		conn.bindingRefreshInterval = config.BindingRefreshInterval
 	}
+	conn.onPermRefreshFailure = conn.failPreparedBindings
 
 	conn.log.Debugf("Initial lifetime: %d seconds", int(conn.lifetime().Seconds()))
 
@@ -179,6 +184,252 @@ func (a *allocation) createPermission(perm *permission, addr net.Addr) error {
 	return nil
 }
 
+// PreparePeer creates a permission for peer and waits until the TURN server
+// confirms a channel binding for it. After it returns nil, writes to peer use
+// ChannelData (or fail) for the lifetime of the allocation; they never fall
+// back to Send indications. Concurrent callers for the same peer share one
+// permission and one bind attempt; canceling ctx wakes only that caller (with
+// its cause) and leaves the shared work running.
+func (c *UDPConn) PreparePeer(ctx context.Context, peer net.Addr) error {
+	if ctx == nil {
+		return errNilContext
+	}
+	udpPeer, err := canonicalUDPPeer(peer)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return context.Cause(ctx)
+	}
+	if c.isClosed() {
+		return errClosed
+	}
+
+	if err := c.awaitPermission(ctx, udpPeer); err != nil {
+		return err
+	}
+
+	return c.awaitBinding(ctx, c.bindingMgr.getOrCreate(udpPeer))
+}
+
+// canonicalUDPPeer validates peer and reduces it to a canonical form so that
+// aliases of the same peer (IPv4-mapped IPv6, zoned addresses) share one
+// permission and one channel binding.
+func canonicalUDPPeer(peer net.Addr) (*net.UDPAddr, error) {
+	udpPeer, ok := peer.(*net.UDPAddr)
+	if !ok || udpPeer == nil {
+		return nil, errUDPAddrCast
+	}
+	if udpPeer.Port <= 0 || udpPeer.Port > math.MaxUint16 || udpPeer.Zone != "" {
+		return nil, errInvalidUDPAddr
+	}
+
+	addr, ok := netip.AddrFromSlice(udpPeer.IP)
+	if !ok {
+		return nil, errInvalidUDPAddr
+	}
+	addr = addr.Unmap()
+	if addr.IsUnspecified() || addr.IsMulticast() {
+		return nil, errInvalidUDPAddr
+	}
+
+	return &net.UDPAddr{IP: net.IP(addr.AsSlice()), Port: udpPeer.Port}, nil
+}
+
+// awaitPermission blocks until a permission for peer is installed, the shared
+// create attempt fails, or ctx is canceled.
+func (c *UDPConn) awaitPermission(ctx context.Context, peer net.Addr) error {
+	for {
+		perm := c.permMap.getOrCreate(peer)
+		if perm.state() == permStatePermitted {
+			return nil
+		}
+
+		done := c.ensurePermissionAttempt(perm, peer)
+		if done == nil {
+			return errClosed
+		}
+
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-c.closeCh:
+			return errClosed
+		}
+
+		if perm.state() == permStatePermitted {
+			return nil
+		}
+		perm.mutex.RLock()
+		err := perm.attemptErr
+		perm.mutex.RUnlock()
+		if err != nil {
+			return err
+		}
+		// The attempt we joined predates our loop iteration; re-evaluate.
+	}
+}
+
+// ensurePermissionAttempt returns a channel that closes when the in-flight
+// CreatePermission attempt (existing or newly started) completes. It returns
+// nil once the allocation is closing.
+func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan struct{} {
+	perm.mutex.Lock()
+	defer perm.mutex.Unlock()
+
+	if perm.attemptDone != nil {
+		return perm.attemptDone
+	}
+	if !c.addWorker() {
+		return nil
+	}
+
+	done := make(chan struct{})
+	perm.attemptDone = done
+	go func() {
+		defer c.workerWG.Done()
+		var err error
+		for range maxRetryAttempts {
+			if err = c.createPermission(perm, peer); !errors.Is(err, errTryAgain) {
+				break
+			}
+		}
+		perm.mutex.Lock()
+		perm.attemptDone = nil
+		perm.attemptErr = err
+		perm.mutex.Unlock()
+		close(done)
+	}()
+
+	return done
+}
+
+// awaitBinding blocks until the server confirms the channel binding, the
+// binding fails, or ctx is canceled.
+func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //nolint:cyclop
+	for {
+		if final, err := bindingResult(bound); final {
+			return err
+		}
+
+		bound.muBind.Lock()
+		done := bound.attemptDone
+		if done == nil {
+			done = c.startBindAttemptLocked(bound)
+		}
+		bound.muBind.Unlock()
+
+		if done == nil {
+			// No attempt is needed (state already decisive) or none can start (closing).
+			if final, err := bindingResult(bound); final {
+				return err
+			}
+			if c.isClosed() {
+				return errClosed
+			}
+
+			return errChannelBindFailed
+		}
+
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-c.closeCh:
+			return errClosed
+		}
+
+		if final, err := bindingResult(bound); final {
+			return err
+		}
+		// The joined attempt ended without confirming; surface its error rather
+		// than retrying forever on the caller's behalf.
+		if err := bound.bindErr(); err != nil {
+			return err
+		}
+	}
+}
+
+// bindingResult reports whether the binding reached a decisive state for a
+// preparing caller: (true, nil) once the server has confirmed the channel
+// mapping, (true, err) once the binding failed or its confirmation expired.
+func bindingResult(bound *binding) (bool, error) {
+	if bound.ok() {
+		if time.Since(bound.refreshedAt()) >= channelBindingLifetime {
+			bound.terminalize(errChannelBindingExpired)
+
+			return true, errChannelBindingExpired
+		}
+		bound.prepared.Store(true)
+
+		return true, nil
+	}
+	if bound.state() == bindingStateFailed {
+		if err := bound.bindErr(); err != nil {
+			return true, err
+		}
+
+		return true, errChannelBindFailed
+	}
+
+	return false, nil
+}
+
+// startBindAttemptLocked starts a tracked bind attempt if the binding state
+// calls for one. It requires bound.muBind to be held and returns the channel
+// that closes when the attempt completes, or nil if no attempt was started.
+func (c *UDPConn) startBindAttemptLocked(bound *binding) chan struct{} {
+	if !c.addWorker() {
+		return nil
+	}
+	startState, ok := c.startBinding(bound)
+	if !ok {
+		c.workerWG.Done()
+
+		return nil
+	}
+
+	done := make(chan struct{})
+	bound.attemptDone = done
+	go func() {
+		defer c.workerWG.Done()
+		err := c.bindChannel(bound, startState)
+		bound.setBindErr(err)
+		bound.muBind.Lock()
+		bound.attemptDone = nil
+		bound.muBind.Unlock()
+		close(done)
+	}()
+
+	return done
+}
+
+// addWorker registers an allocation-owned goroutine with the close join.
+// It returns false once the allocation has begun closing.
+func (c *UDPConn) addWorker() bool {
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
+
+	if c.isClosed() {
+		return false
+	}
+	c.workerWG.Add(1)
+
+	return true
+}
+
+// failPreparedBindings terminalizes every prepared binding: once a peer is
+// prepared, losing its permission must fail writes rather than fall back to
+// Send indications.
+func (c *UDPConn) failPreparedBindings(err error) {
+	for _, bound := range c.bindingMgr.all() {
+		if bound.prepared.Load() {
+			bound.terminalize(fmt.Errorf("%w: %w", errPermissionRefreshFailed, err))
+		}
+	}
+}
+
 // WriteTo writes a packet with payload to addr.
 // WriteTo can be made to time out and return
 // an Error with Timeout() == true after a fixed time limit;
@@ -186,9 +437,21 @@ func (a *allocation) createPermission(perm *permission, addr net.Addr) error {
 // On packet-oriented connections, write timeouts are rare.
 func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint:gocognit,cyclop
 	var err error
-	_, ok := addr.(*net.UDPAddr)
-	if !ok {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if !ok || udpAddr == nil {
 		return 0, errUDPAddrCast
+	}
+	// Reduce aliases (IPv4-mapped IPv6, zoned addresses) to the canonical peer
+	// so they share its permission and channel binding. Peers that cannot be
+	// canonicalized are left as-is.
+	if canonical, cerr := canonicalUDPPeer(udpAddr); cerr == nil {
+		addr = canonical
+	} else if udpAddr.Zone != "" {
+		unzoned := *udpAddr
+		unzoned.Zone = ""
+		if canonical, cerr = canonicalUDPPeer(&unzoned); cerr == nil {
+			addr = canonical
+		}
 	}
 	if c.isClosed() {
 		return 0, &net.OpError{
@@ -226,6 +489,21 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 	bound, ok := c.bindingMgr.findByAddr(addr)
 	if !ok {
 		bound = c.bindingMgr.create(addr)
+	}
+
+	// A prepared peer promised ChannelData-only writes: fail instead of ever
+	// falling back to Send indications.
+	if bound.prepared.Load() {
+		if bound.ok() && time.Since(bound.refreshedAt()) >= channelBindingLifetime {
+			bound.terminalize(errChannelBindingExpired)
+		}
+		if !bound.ok() {
+			if bindErr := bound.bindErr(); bindErr != nil {
+				return 0, bindErr
+			}
+
+			return 0, errChannelBindFailed
+		}
 	}
 
 	//nolint:nestif
@@ -266,7 +544,28 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 
 // Close closes the connection.
 // Any blocked ReadFrom or WriteTo operations will be unblocked and return errors.
+// Close returns only after allocation-owned goroutines (refresh timers and
+// bind/permission workers) have finished. It never closes or sets deadlines on
+// the caller-owned base socket, so a worker blocked on that socket is joined
+// only once the caller unblocks its I/O.
 func (c *UDPConn) Close() error {
+	first, err := c.startClose()
+
+	c.refreshAllocTimer.StopAndWait()
+	c.refreshPermsTimer.StopAndWait()
+	c.checkBindingsTimer.StopAndWait()
+	c.workerWG.Wait()
+
+	if !first {
+		return errAlreadyClosed
+	}
+
+	return err
+}
+
+// startClose makes the allocation refuse new work and emits the deallocate
+// refresh. It performs no joins, so allocation-owned workers may call it safely.
+func (c *UDPConn) startClose() (bool, error) {
 	c.closeMutex.Lock()
 	defer c.closeMutex.Unlock()
 
@@ -276,14 +575,14 @@ func (c *UDPConn) Close() error {
 
 	select {
 	case <-c.closeCh:
-		return errAlreadyClosed
+		return false, nil
 	default:
 		close(c.closeCh)
 	}
 
 	c.client.OnDeallocated(c.relayedAddr)
 
-	return c.refreshAllocation(0, true /* dontWait=true */)
+	return true, c.refreshAllocation(0, true /* dontWait=true */)
 }
 
 // LocalAddr returns the local network address.
@@ -438,18 +737,14 @@ func (c *UDPConn) FindAddrByChannelNumber(chNum uint16) (net.Addr, bool) {
 
 func (c *UDPConn) maybeBind(bound *binding) {
 	// Block only callers with the same binding until
-	// the binding transaction has been complete
+	// the binding transaction has been started
 	bound.muBind.Lock()
 	defer bound.muBind.Unlock()
 
-	startState, ok := c.startBinding(bound)
-	if !ok {
-		return
+	if bound.attemptDone == nil {
+		// Establish binding with the server if the state machine allows it.
+		c.startBindAttemptLocked(bound)
 	}
-
-	// Establish binding with the server if eligible
-	// with regard to cases right above.
-	go c.bindChannel(bound, startState)
 }
 
 func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
@@ -468,7 +763,9 @@ func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
 	return startState, true
 }
 
-func (c *UDPConn) bindChannel(bound *binding, startState bindingState) {
+// bindChannel performs one ChannelBind attempt. It returns nil when the
+// binding was confirmed or recovered, and the attempt's error otherwise.
+func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
 	var err error
 	for range maxRetryAttempts {
 		if err = c.bind(bound); !errors.Is(err, errTryAgain) {
@@ -476,18 +773,23 @@ func (c *UDPConn) bindChannel(bound *binding, startState bindingState) {
 		}
 	}
 	if err != nil {
-		c.handleBindChannelError(bound, startState, err)
+		if c.handleBindChannelError(bound, startState, err) {
+			return nil
+		}
 
-		return
+		return err
 	}
 
 	bound.setRefreshedAt(time.Now())
 	bound.setState(bindingStateReady)
+
+	return nil
 }
 
-func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState, err error) {
+// handleBindChannelError reports whether the binding recovered (kept usable).
+func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState, err error) bool {
 	if c.recoverChannelBindBadRequest(bound, startState, err) {
-		return
+		return true
 	}
 
 	c.log.Warnf("Failed to bind channel %d: %s", bound.number, err)
@@ -498,13 +800,15 @@ func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState
 			bound.setState(bindingStateUnknown)
 		}
 
-		return
+		return false
 	}
 
 	bound.setState(bindingStateFailed)
 	if errors.Is(err, errChannelBindBadRequest) {
 		c.closeAfterChannelBindBadRequest(bound)
 	}
+
+	return false
 }
 
 func (c *UDPConn) recoverChannelBindBadRequest(bound *binding, startState bindingState, err error) bool {
@@ -541,7 +845,9 @@ func (c *UDPConn) closeAfterChannelBindBadRequest(bound *binding) {
 		bound.number,
 	)
 
-	if err := c.Close(); err != nil && !errors.Is(err, errAlreadyClosed) {
+	// startClose, not Close: this runs on a Pion-owned bind worker, which must
+	// not join itself. The caller's Close still joins every worker.
+	if _, err := c.startClose(); err != nil {
 		c.log.Warnf("Failed to close TURN allocation after ChannelBind 400: %s", err)
 	}
 }


### PR DESCRIPTION
## Summary

Add `Client.PrepareUDPPeer(ctx, peer)`: an opt-in way for applications to wait until a UDP peer has a confirmed permission and ChannelBind before sending application packets.

This is a rework of the original diff. It now reuses and extends the existing binding manager, with the existing mutexes covering the bind, instead of introducing a new transaction/allocation lifecycle. The non-test diff is 447 insertions / 23 deletions (~320 code lines excluding comments and blanks), plus 340 lines of tests.

## Motivation

- Today the relayed conn sends via Send Indications and asynchronously upgrades a peer to ChannelData once the background ChannelBind completes. Applications cannot observe or control when that switch happens.
- The switch changes per-packet TURN overhead (~36 bytes → 4 bytes) mid-stream, so the maximum usable payload changes at a nondeterministic point in the connection's lifetime.
- This breaks packet-size-sensitive transports layered over the relayed conn — QUIC in particular, which pads Initials to 1200 bytes and validates path MTU once, then assumes it holds. An unobservable overhead change mid-handshake produces timing-dependent failures that are very hard to reproduce.

## Rework

Rebuilt per JoTurk's suggestion on Discord (make the existing mutex cover the bind; reuse/extend the current binds; no new transaction and allocation lifecycle):

- The previous +2668/−138 approach (new operation/lifecycle types, context-aware transaction plumbing) is dropped entirely.
- An in-flight ChannelBind attempt is now tracked by a per-binding channel under the existing `muBind`. `PrepareUDPPeer` waiters select on that channel, so same-peer callers coalesce onto one shared attempt and a caller's context cancellation wakes only that waiter with its cause, leaving the shared attempt running. The binding state machine itself is unchanged.
- Two small seams were added where the existing code had none: a `terminalize` transition folded into the binding's existing mutex, so a completing bind attempt cannot resurrect a permanently failed binding, and an `onPermRefreshFailure` callback on the allocation, because permission refresh failures were previously log-only but readiness must observe them.
- Deterministic close reuses the same primitives: `PeriodicTimer` gains `StopAndWait`, and bind/permission workers are tracked by a WaitGroup gated by the existing `closeMutex`.

## Proposed behavior

- `PrepareUDPPeer(ctx, peer)` resolves once the permission and ChannelBind for that peer are confirmed. After it succeeds, writes to that peer use ChannelData or return an error for the lifetime of the allocation — never a silent fallback to Send Indications — so the packet profile is deterministic before the first application byte.
- Concurrent calls for one peer coalesce on the existing binding state; different peers prepare independently. Caller cancellation wakes only that waiter with its exact cause and does not cancel shared allocation-owned permission/ChannelBind work.
- Peer addresses are reduced to a canonical form (IPv4-mapped IPv6 unmapped, zones handled), so an alias of a prepared peer shares its permission and channel binding rather than bypassing them via Send Indication.
- UDP allocation shutdown now joins refresh timers, binding checks, and in-flight ChannelBind/permission work before `Close` returns. Socket interruption remains the caller's responsibility: the client never closes the caller-owned `ClientConfig.Conn` or mutates its deadlines, so `Close` completes once the socket owner permits or actively unblocks in-flight I/O.
- Known bound: if the server stops responding, `Close` can take up to the STUN retransmission budget (~63.5 s with defaults) while an in-flight transaction runs out, because transaction waits are not interruptible in this minimal version. Prompt interruption (context-aware transaction waits) is deliberately left out to keep this PR small.

## Compatibility

- Purely additive for applications that never call `PrepareUDPPeer`, with one intentional refinement: `WriteTo` now canonicalizes `*net.UDPAddr` aliases of the same peer so they share one permission and one channel binding.
- Transaction and refresh plumbing is untouched; TCP allocations are untouched.

## Testing

- `go test -race -count=1 ./internal/client .` passes.
- `golangci-lint run` with the repo config reports no new findings versus `main`.
- New tests (all under `-race`): readiness success then ChannelData-only writes; invalid-peer rejection (unspecified, multicast, zoned, bad port, non-UDP); peer aliases sharing the prepared binding; same-peer coalescing onto one bind and one permission; waiter-local cancellation with its cause while the shared bind survives; permission refresh failure failing writes with no Send-indication fallback; bind failure surfacing to the preparing caller; terminal failure surviving an in-flight bind success; `Close` joining in-flight bind workers.
