### PR TITLE
docs: re-audit M0 Slice 1 — Dependabot vehicle, admit import-order normalization

### DIFF
--- a/addr_family.go
+++ b/addr_family.go
@@ -3,7 +3,7 @@
 
 package turn
 
-import "github.com/pion/turn/v5/internal/proto"
+import "github.com/the-sarge/turn/v5/internal/proto"
 
 // RequestedAddressFamily represents the REQUESTED-ADDRESS-FAMILY Attribute as
 // defined in RFC 6156 Section 4.1.1.

--- a/client.go
+++ b/client.go
@@ -320,6 +320,15 @@ func (c *Client) Close() {
 	c.trMap.CloseAndDeleteAll()
 }
 
+// abortPendingTransactionsTo closes every pending transaction addressed to
+// the given destination, waking their waiters with an error.
+func (c *Client) abortPendingTransactionsTo(to net.Addr) {
+	c.mutexTrMap.Lock()
+	defer c.mutexTrMap.Unlock()
+
+	c.trMap.CloseAndDeleteAllTo(to)
+}
+
 // TransactionID & Base64: https://play.golang.org/p/EEgmJDI971P
 
 // SendBindingRequestTo sends a new STUN request to the given transport address.
@@ -506,6 +515,9 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 		PermissionRefreshInterval: c.permissionRefreshInterval,
 		BindingRefreshInterval:    c.bindingRefreshInterval,
 		BindingCheckInterval:      c.bindingCheckInterval,
+		AbortTransactions: func() {
+			c.abortPendingTransactionsTo(c.turnServerAddr)
+		},
 	})
 	c.setRelayedUDPConn(relayedConn)
 	c.setReservationToken(reservationToken)

--- a/client.go
+++ b/client.go
@@ -16,8 +16,8 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
 	"github.com/pion/transport/v4/stdnet"
-	"github.com/pion/turn/v5/internal/client"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/client"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 const (

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@
 package turn
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"fmt"
 	"math"
@@ -569,6 +570,21 @@ func (c *Client) CreatePermission(addrs ...net.Addr) error {
 	}
 
 	return nil
+}
+
+// PrepareUDPPeer creates a permission for peer on the client's UDP allocation
+// and waits until the TURN server confirms a channel binding for it. After it
+// returns nil, writes to peer use ChannelData (or fail) for the lifetime of
+// the allocation; they never fall back to Send indications. Concurrent calls
+// for the same peer share one permission and one bind; canceling ctx wakes
+// only that caller and leaves the shared work running.
+func (c *Client) PrepareUDPPeer(ctx context.Context, peer net.Addr) error {
+	conn := c.relayedUDPConn()
+	if conn == nil {
+		return errUDPAllocationNotFound
+	}
+
+	return conn.PreparePeer(ctx, peer)
 }
 
 // PerformTransaction performs STUN transaction.

--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/close_latency_test.go
+++ b/close_latency_test.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package turn
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/stun/v3"
+	"github.com/pion/turn/v5/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSilentServerAllocation builds a UDP allocation whose transactions go to a
+// server that never responds, driving the real transaction/retransmission
+// machinery. withAbort mirrors the wiring Allocate performs.
+func newSilentServerAllocation(t *testing.T, withAbort bool) *client.UDPConn {
+	t.Helper()
+
+	var listenConfig net.ListenConfig
+	serverSock, err := listenConfig.ListenPacket(context.Background(), "udp4", "127.0.0.1:0") // Never responds
+	require.NoError(t, err)
+	clientSock, err := listenConfig.ListenPacket(context.Background(), "udp4", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	cl, err := NewClient(&ClientConfig{
+		Conn:           clientSock,
+		TURNServerAddr: serverSock.LocalAddr().String(),
+		Username:       "user",
+		Password:       "secret",
+		Realm:          "realm",
+		RTO:            25 * time.Millisecond,
+		LoggerFactory:  logging.NewDefaultLoggerFactory(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, cl.Listen())
+
+	config := &client.AllocationConfig{
+		Client:      cl,
+		RelayedAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
+		ServerAddr:  cl.turnServerAddr,
+		Username:    stun.NewUsername("user"),
+		Realm:       stun.NewRealm("realm"),
+		Integrity:   stun.NewShortTermIntegrity("secret"),
+		Nonce:       stun.NewNonce("nonce"),
+		Lifetime:    time.Hour,
+		Log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
+	}
+	if withAbort {
+		config.AbortTransactions = func() {
+			cl.abortPendingTransactionsTo(cl.turnServerAddr)
+		}
+	}
+
+	conn := client.NewUDPConn(config)
+	t.Cleanup(func() {
+		_ = conn.Close()
+		cl.Close()
+		_ = clientSock.Close()
+		_ = serverSock.Close()
+	})
+
+	return conn
+}
+
+func TestCloseInterruptsTransactionWaits(t *testing.T) {
+	peer := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+
+	t.Run("without abort Close waits out the retransmission budget", func(t *testing.T) {
+		conn := newSilentServerAllocation(t, false)
+
+		prepareResult := make(chan error, 1)
+		go func() { prepareResult <- conn.PreparePeer(context.Background(), peer) }()
+		time.Sleep(150 * time.Millisecond) // Let the CreatePermission transaction get in flight
+
+		start := time.Now()
+		assert.NoError(t, conn.Close())
+		elapsed := time.Since(start)
+		t.Logf("Close took %v without abort (RTO 25ms, budget ~3.2s)", elapsed)
+		assert.Greater(t, elapsed, time.Second,
+			"without abort, Close should block until the in-flight transaction exhausts its retransmissions")
+
+		select {
+		case err := <-prepareResult:
+			assert.Error(t, err)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "PreparePeer waiter did not unblock")
+		}
+	})
+
+	t.Run("with abort Close returns promptly and cancellation stays waiter-local", func(t *testing.T) {
+		conn := newSilentServerAllocation(t, true)
+
+		resultA := make(chan error, 1)
+		go func() { resultA <- conn.PreparePeer(context.Background(), peer) }()
+
+		ctxB, cancelB := context.WithCancelCause(context.Background())
+		defer cancelB(nil)
+		resultB := make(chan error, 1)
+		go func() { resultB <- conn.PreparePeer(ctxB, peer) }()
+
+		time.Sleep(150 * time.Millisecond) // Let the CreatePermission transaction get in flight
+
+		// Canceling one waiter must not abort the shared transaction work.
+		cause := errors.New("waiter B gave up") //nolint:err113 // test-local cause
+		cancelB(cause)
+		select {
+		case err := <-resultB:
+			assert.ErrorIs(t, err, cause)
+		case <-time.After(time.Second):
+			assert.Fail(t, "canceled waiter did not wake promptly")
+		}
+		select {
+		case err := <-resultA:
+			assert.Failf(t, "surviving waiter finished early", "err: %v", err)
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		start := time.Now()
+		assert.NoError(t, conn.Close())
+		elapsed := time.Since(start)
+		t.Logf("Close took %v with abort", elapsed)
+		assert.Less(t, elapsed, time.Second,
+			"with abort, Close must not wait out the retransmission budget")
+
+		select {
+		case err := <-resultA:
+			assert.Error(t, err)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "surviving waiter did not unblock on close")
+		}
+	})
+}

--- a/close_latency_test.go
+++ b/close_latency_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/client"
+	"github.com/the-sarge/turn/v5/internal/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/docs/adr/2026-08-14-cut-and-stabilize-plan.md
+++ b/docs/adr/2026-08-14-cut-and-stabilize-plan.md
@@ -47,7 +47,7 @@ Grilled and settled in the [scope doc](2026-08-14-molding-program-scope.md); bin
 
 ### Slice 1 — Replace inherited CI with the fork-owned portfolio gate
 
-**What it delivers:** All ten inherited pion workflow configs removed; a fork-owned CI gate per the portfolio standard (`standardize-github-ci` flow, implementation approved by this plan) covering build, format, lint/vet, race tests, and dependency hygiene; plus a fuzz job running the three existing `internal/proto` fuzz targets with a bounded per-target fuzztime. All jobs green on the current full (pre-cut) tree. Dependency-update automation (Renovate) remains functional — D2's security posture depends on that flow.
+**What it delivers:** All ten inherited pion workflow configs removed; a fork-owned CI gate per the portfolio standard (`standardize-github-ci` flow, implementation approved by this plan) covering build, format, lint/vet, race tests, and dependency hygiene; plus a fuzz job running the three existing `internal/proto` fuzz targets with a bounded per-target fuzztime. All jobs green on the current full (pre-cut) tree. Dependency-update automation functions fork-owned via the portfolio-standard Dependabot config (`.github/dependabot.yml`) — D2's security posture depends on that flow. (Re-audited 2026-08-14: the inherited Renovate coupling was never functional on this fork — zero Actions runs, no Renovate PRs or dashboard issue, and `renovate-go-sum-fix` requires a pion-org secret absent here — so there is nothing to preserve; Dependabot is the portfolio vehicle, per wiremux precedent.)
 
 **Existing-work disposition:** new slice. The inherited configs are auto-synced upstream copies, not fork work; none is retained.
 
@@ -59,7 +59,7 @@ Grilled and settled in the [scope doc](2026-08-14-molding-program-scope.md); bin
 
 **Transitional-seam budget:** none introduced. Removes the pion/.goassets coupling seam.
 
-**Blast radius:** `.github/` only; no Go code changes. Traced effects: branch-protection/required-check names change with the workflow set (update rulesets in the same slice if present); the fuzz schedule consumes Actions minutes (bound it); CodeQL/reuse/release job dispositions follow the portfolio policy — record each kept/dropped job in the PR description. Untraced effects: none identified.
+**Blast radius:** `.github/`, plus `Taskfile.yml` and `scripts/ci/` (portable lane commands, per the portfolio responsibility boundary that D4's flow mandates), plus a mechanical import-order normalization (gofmt/gci) of the Go files the module rename (`e8db91a`) left unsorted; that normalization diff must contain only import-line reordering — zero semantic Go changes. Traced effects: branch-protection/required-check names change with the workflow set (update rulesets in the same slice if present); the fuzz schedule consumes Actions minutes (bound it); CodeQL/reuse/release job dispositions follow the portfolio policy — record each kept/dropped job in the PR description. Untraced effects: none identified.
 
 **Artifact classification:** all artifacts are verification aids or process metadata. The CI gate is an approved maintained deliverable: payoff = merge gating for every subsequent slice; domain = this repository's Go tree; owner = fork maintainer; retirement = none while the repo lives. The proto fuzz job is part of that maintained gate (D4 approval in the scope doc).
 
@@ -69,13 +69,13 @@ Grilled and settled in the [scope doc](2026-08-14-molding-program-scope.md); bin
 
 **Evidence budget:** one green run per job on the slice PR head; one observed red on a deliberately failing check (any single job) to prove the gate actually gates, reverted before merge or shown on a scratch branch; fuzz targets run with bounded fuzztime (minutes, not hours). Terminating rule: all required checks green on the PR head plus the one observed-red demonstration. One review; at most one replacement review.
 
-**TDD and preservation evidence:** characterization first — enumerate the inherited jobs and their dispositions (kept-equivalent/dropped/replaced) in the PR before deleting configs; the observed-red demonstration is the failing-test analogue for a CI gate. Preservation: `task`/test invocations unchanged for developers (no Go changes).
+**TDD and preservation evidence:** characterization first — enumerate the inherited jobs and their dispositions (kept-equivalent/dropped/replaced) in the PR before deleting configs; the observed-red demonstration is the failing-test analogue for a CI gate. Preservation: developer test invocations unchanged; the only Go edits are the import-order normalization, verified by diff inspection (import lines only) and a green suite.
 
 **Dispatch context budget:** this slice contract, the scope doc's D4 paragraph, the `.github/workflows` tree (10 small YAML files), and the `standardize-github-ci` skill flow. No Go source context needed. Implementation plus review fits one fresh context comfortably.
 
 **Slice decision audit:** strongest further split — separate "remove inherited" from "add portfolio gate"; rejected because the intermediate state (no CI at all) gates nothing and both halves are small. Strongest merge — fold into the cut slice; rejected because the cut depends on this gate being green first (see edge evidence) and merging makes the observed-red demonstration entangle with mass deletions. Blocking-edge evidence: none inbound.
 
-**Stop conditions:** the portfolio standard proves inapplicable to a Go library repo in some structural way; required checks cannot be made green on the pre-cut tree without code changes (this slice may not change Go code); Renovate/dependency automation cannot be preserved.
+**Stop conditions:** the portfolio standard proves inapplicable to a Go library repo in some structural way; required checks cannot be made green on the pre-cut tree without semantic Go changes (only import-order normalization is admitted); dependency-update automation cannot be made functional.
 
 ### Slice 2 — Cut to the kept surface and tag v5.1.0-gs.1
 

--- a/docs/adr/2026-08-14-cut-and-stabilize-plan.md
+++ b/docs/adr/2026-08-14-cut-and-stabilize-plan.md
@@ -1,0 +1,127 @@
+# Cut and Stabilize (M0) Implementation Plan
+
+**Date:** 2026-08-14
+**Status:** Accepted; not yet implemented
+**Track:** 1 of 3 in the 2026-08-14 TURN fork molding program
+**Depends on:** nothing — safe to start first
+**Related:** [Molding program scope](2026-08-14-molding-program-scope.md) (grilled decisions D1–D5), [Owned-library ADR](2026-08-14-owned-library-fork.md), wiremux fork-pivot amendment (GridSwarm/wiremux#1161)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Grill record in the scope doc; pre-pivot upstream history in pion/turn#585 and GridSwarm/wiremux#1054
+
+## Goal
+
+Reduce `the-sarge/turn` to the kept surface wiremux consumes — root `Client` UDP allocation plus its internal support — under a fork-owned CI gate, tagged `v5.1.0-gs.1`. The module becomes a single-purpose TURN client library whose entire tree is surface one consumer actually exercises.
+
+## Current Shape (verified 2026-08-14 at `44cecae`)
+
+- Root package mixes client and server: `client.go` (UDP client, `PrepareUDPPeer` at `client.go:593`) plus server surface — `server.go`, `server_config.go`, three `relay_address_generator_*.go` files, `lt_cred.go`, `stun_conn.go`.
+- Client TCP allocation surface: `client.go:81` (`tcpAllocation` field), `client.go:117`, `client.go:528-568` (`AllocateTCP`), `client.go:578`, and `internal/client/tcp_alloc.go`, `internal/client/tcp_conn.go`.
+- `lt_cred.go` has no non-example consumer; root `stun_conn.go` (`NewSTUNConn`) is consumed only by `server.go`, `internal/server/turn.go`, and TCP/TLS client examples.
+- Only root `client_test.go` (8 `NewServer` uses) and `e2e/` (coturn Docker fixture, `e2e/Dockerfile:6`) depend on a TURN server; all `internal/client` tests and `close_latency_test.go` are mock-based.
+- CI is ten auto-synced pion configs (`.github/workflows/*.yaml`, marked "DO NOT EDIT … copied from pion/.goassets") calling `pion/.goassets` reusable workflows: api, codeql, e2e, fuzz, lint, release, renovate-go-sum-fix, reuse, test, tidy-check.
+- Fuzz targets exist in kept surface: `internal/proto/fuzz_test.go:34,94,127` (`FuzzSetters`, `FuzzChannelData`, `FuzzIsChannelData`).
+- Direct dependencies: `pion/logging`, `pion/randutil`, `pion/stun/v3`, `pion/transport/v4`, `testify`, `x/sys`, `x/time`. Non-example consumers of `randutil` are all cut surface (`relay_address_generator_range.go`, `internal/server/turn.go`, `internal/allocation/allocation_manager.go`); `x/time` and direct `x/sys` have example-only consumers.
+- Known pre-existing macOS-local failures: `TestCreateTCPConnectionInvalid` (`internal/allocation`), `TestConnectRequest` (`internal/server`) — both in cut surface; both pass in upstream Linux CI at base `b374908`.
+
+## Decision
+
+Grilled and settled in the [scope doc](2026-08-14-molding-program-scope.md); binding facts for this track:
+
+- The fork is an owned library (ADR); API breakage is intended and versioned as `v5.1.0-gs.1` (permanent `-gs` pre-release suffix keeps consumer bumps deliberate).
+- D1: delete the server half; root integration tests keep a real-server fixture by pinning upstream `github.com/pion/turn/v5@v5.0.12` **test-only** (collision-free due to the module rename). Transitional seam; exit = fork-owned receipt coverage (Track 2 era).
+- D4: replace all inherited pion CI with the portfolio standard via the `standardize-github-ci` flow, retaining a fuzz job over `internal/proto` (complement of D2's proto-only security watch). This plan records operator approval for that flow's implementation phase, scoped to this repository.
+- CI replacement precedes the cut: the inherited `api` (API-compat) and `e2e` workflows turn red under the cut, so cutting first leaves the default branch gated by failing checks.
+
+**Rejected alternative (do not do this):** cutting under inherited CI and patching pion's auto-synced configs in place — they are overwritten by upstream sync tooling and keep the fork coupled to `pion/.goassets`. Also rejected: trimming `internal/proto` in this track (kept wholesale; trimming deferred past M0) and splitting the cut into per-package PRs (deletions are one coherent behavior and fit one context; per-package PRs multiply review cycles with no independent value).
+
+**Non-goals:** API reshaping (Track 2, gated on wiremux Slice 1.3 merge); packet-path optimization (Track 3, gated on production profiles); `internal/proto` trimming; replacing the transitional upstream fixture; any behavior change to kept code.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| 1 | new | Fork-owned portfolio CI gate (+ proto fuzz) green on the full pre-cut tree | None | Coupling to pion/.goassets auto-synced CI |
+| 2 | new | Kept-surface-only tree, upstream test fixture pinned, deps re-audited, tag `v5.1.0-gs.1` | Slice 1 | n/a (introduces documented transitional fixture seam) |
+
+## Implementation Slices
+
+### Slice 1 — Replace inherited CI with the fork-owned portfolio gate
+
+**What it delivers:** All ten inherited pion workflow configs removed; a fork-owned CI gate per the portfolio standard (`standardize-github-ci` flow, implementation approved by this plan) covering build, format, lint/vet, race tests, and dependency hygiene; plus a fuzz job running the three existing `internal/proto` fuzz targets with a bounded per-target fuzztime. All jobs green on the current full (pre-cut) tree. Dependency-update automation (Renovate) remains functional — D2's security posture depends on that flow.
+
+**Existing-work disposition:** new slice. The inherited configs are auto-synced upstream copies, not fork work; none is retained.
+
+**Blocked by:** none.
+
+**Single owner after merge:** the fork's `.github/workflows` tree, owned by this repository (no external sync source). No durable runtime fact changes ownership.
+
+**Authority completeness:** n/a — no persisted runtime fact becomes authoritative.
+
+**Transitional-seam budget:** none introduced. Removes the pion/.goassets coupling seam.
+
+**Blast radius:** `.github/` only; no Go code changes. Traced effects: branch-protection/required-check names change with the workflow set (update rulesets in the same slice if present); the fuzz schedule consumes Actions minutes (bound it); CodeQL/reuse/release job dispositions follow the portfolio policy — record each kept/dropped job in the PR description. Untraced effects: none identified.
+
+**Artifact classification:** all artifacts are verification aids or process metadata. The CI gate is an approved maintained deliverable: payoff = merge gating for every subsequent slice; domain = this repository's Go tree; owner = fork maintainer; retirement = none while the repo lives. The proto fuzz job is part of that maintained gate (D4 approval in the scope doc).
+
+**Representation contract:** supported domain = this repository's workflow set and Go tree as of the plan commit; owner = the workflow files themselves; guarantee = example-level (observed green runs), which is the correct level for CI plumbing.
+
+**Contract closure:** not triggered — verification-aid replacement with no runtime invariant; single reachable path (Actions trigger).
+
+**Evidence budget:** one green run per job on the slice PR head; one observed red on a deliberately failing check (any single job) to prove the gate actually gates, reverted before merge or shown on a scratch branch; fuzz targets run with bounded fuzztime (minutes, not hours). Terminating rule: all required checks green on the PR head plus the one observed-red demonstration. One review; at most one replacement review.
+
+**TDD and preservation evidence:** characterization first — enumerate the inherited jobs and their dispositions (kept-equivalent/dropped/replaced) in the PR before deleting configs; the observed-red demonstration is the failing-test analogue for a CI gate. Preservation: `task`/test invocations unchanged for developers (no Go changes).
+
+**Dispatch context budget:** this slice contract, the scope doc's D4 paragraph, the `.github/workflows` tree (10 small YAML files), and the `standardize-github-ci` skill flow. No Go source context needed. Implementation plus review fits one fresh context comfortably.
+
+**Slice decision audit:** strongest further split — separate "remove inherited" from "add portfolio gate"; rejected because the intermediate state (no CI at all) gates nothing and both halves are small. Strongest merge — fold into the cut slice; rejected because the cut depends on this gate being green first (see edge evidence) and merging makes the observed-red demonstration entangle with mass deletions. Blocking-edge evidence: none inbound.
+
+**Stop conditions:** the portfolio standard proves inapplicable to a Go library repo in some structural way; required checks cannot be made green on the pre-cut tree without code changes (this slice may not change Go code); Renovate/dependency automation cannot be preserved.
+
+### Slice 2 — Cut to the kept surface and tag v5.1.0-gs.1
+
+**What it delivers:** One PR deleting all cut surface: `server.go`, `server_config.go`, `relay_address_generator_range.go`, `relay_address_generator_static.go`, `relay_address_generator_none.go`, `lt_cred.go`, root `stun_conn.go`, `internal/server`, `internal/allocation`, `internal/auth`, `internal/client/tcp_alloc.go`, `internal/client/tcp_conn.go`, the TCP surface in `client.go` (`:81`, `:117`, `:528-568`, `:578`), `examples/`, `e2e/`. Root `client_test.go` re-pins its server fixture to upstream `github.com/pion/turn/v5@v5.0.12` as a test-only dependency. `go.mod` re-audited: `randutil`, `x/time`, and direct `x/sys` expected removable; `logging`, `stun/v3`, `transport/v4`, `testify` remain; upstream `pion/turn/v5` enters test-only. README rewritten to describe the owned library (one short pass; no docs program). After merge and green default-branch CI: annotated tag `v5.1.0-gs.1`.
+
+**Existing-work disposition:** new slice. The two macOS-failing tests are deleted with their packages (settled D5) — record their deletion in the PR body so the disposition is auditable.
+
+**Blocked by:** Slice 1.
+
+**Single owner after merge:** unchanged — no durable fact or lifecycle transition changes owner; deletions only. The public module API's single owner becomes root `Client` (UDP path) alone.
+
+**Authority completeness:** n/a — no fact becomes newly authoritative.
+
+**Transitional-seam budget:** one seam introduced and documented: upstream `pion/turn/v5` as test-only integration fixture. Coherent because it is a verification aid outside shipped behavior, pinned to an exact upstream tag, and collision-free by module path. Removal owner: the Track 2 "fixture replacement" slice, gated on fork-owned receipt coverage (wiremux Slice 1.3 receipts); this program's overview carries that edge. No other duplicate representation, generic mutation path, or double-open lifetime remains.
+
+**Blast radius:** public API (intended break, versioned `v5.1.0-gs.1`, sole consumer pins deliberately — wiremux currently pins `v5.0.13-gs.1` and is unaffected until it deliberately bumps); `go.mod`/`go.sum` (dependency removals plus the test-only addition — license/vuln posture improves monotonically except the upstream test dep, which is MIT and test-scoped); CI (Slice 1 gate must stay green; fuzz targets are kept surface and unaffected); developer docs (README). Concurrency/ordering, persistence, and failure-mode surfaces: untouched — kept code is byte-identical except the `client.go` TCP-surface deletion. Untraced effects: none identified; the `client.go` edit is the only kept-file modification and its TCP members have no UDP-path callers (verified by the consumer greps in Current Shape).
+
+**Artifact classification:** deletions are shipped-behavior removal (intended); the rewired `client_test.go` and the upstream fixture dependency are verification aids (the fixture is the documented transitional seam, maintained until its removal slice); the tag is process metadata; README is process/traceability documentation.
+
+**Representation contract:** supported domain = the kept surface enumerated above at the plan commit; representation owner = the Go compiler and module graph (`go build ./...`, `go vet ./...` prove no dangling references — a finite, mechanical check); guarantee = universal over the enumerated cut/keep lists (finite file sets), example-level for "wiremux needs nothing else" (owned-library ADR accepts this; Track 2 sharpens it with real adoption feedback).
+
+**Contract closure:** not triggered — no invariant with multiple independently reachable paths is created; the material consequence (API break) is a single intended, versioned event with one consumer. Evidence: the criteria below are compiler-verifiable or single-path.
+
+**Evidence budget:** existing test suite green (mock-based `internal/client` suite, `close_latency_test.go`, rewired `client_test.go` against the upstream fixture) with `-race`; `go build ./...` + `go vet ./...` on the kept tree; one negative build check that a representative deleted symbol (`turn.NewServer`) no longer resolves; `go mod tidy` diff reviewed against the expected dependency dispositions. No new tests beyond the fixture rewire. Terminating rule: green CI on PR head plus the criteria checklist. One review; at most one replacement review.
+
+**TDD and preservation evidence:** the fixture rewire lands first within the PR (rewired `client_test.go` green against upstream `v5.0.12` before deletions), so integration coverage never goes dark; deletions follow with the suite kept green at each logical step. Preservation gate: kept-surface tests are unmodified except the fixture import — any other kept-test edit is a stop signal.
+
+**Dispatch context budget:** this slice contract, the cut/keep lists (which duplicate the scope doc's — this plan is normative), `client.go` (~900 lines), `client_test.go`, `go.mod`, and the fixture-rewire pattern. The deletions themselves need no reading beyond confirming the file lists. Fits one fresh context; the only judgment call is the `client.go` TCP-surface excision, which is small and anchored.
+
+**Slice decision audit:** strongest further split — separate "fixture rewire" PR before a "deletions" PR; rejected because the rewire alone has no independent value (the in-repo server still exists) and the two-PR version doubles review for a single coherent behavior. Strongest merge — fold Slice 1 in; rejected per Slice 1's audit. Blocking-edge evidence: under inherited CI the cut turns `api` (API-compat) and `e2e` workflows red, so the edge to Slice 1 is genuine, not convenience.
+
+**Stop conditions:** any kept-surface test requires a semantic change to stay green (indicates a hidden kept→cut dependency); the upstream `v5.0.12` fixture cannot express what the in-repo server fixture provided for an existing root test (indicates D1's fixture decision needs re-grilling); `go mod tidy` retains a cut-only dependency (untraced consumer); the `client.go` TCP excision touches any UDP-path code path.
+
+## Acceptance Criteria
+
+- [ ] `go build ./...` and the full `-race` suite are green on a tree containing only the kept surface (enumerated file list above — finite domain, compiler-owned, universal).
+- [ ] `turn.NewServer`, `turn.ServerConfig`, and `Client.AllocateTCP` do not resolve (negative criterion; compiler-owned).
+- [ ] Root integration tests run against upstream `pion/turn/v5@v5.0.12` test-only; the dependency does not appear in any non-test import (finite import scan).
+- [ ] CI is fork-owned: no workflow references `pion/.goassets`; proto fuzz job present and green (finite workflow-file scan).
+- [ ] Tag `v5.1.0-gs.1` exists on the merged default-branch head and `go get github.com/the-sarge/turn/v5@v5.1.0-gs.1` resolves.
+- [ ] Wiremux's pinned `v5.0.13-gs.1` build is unaffected (no retro-tag mutation; old tag untouched).
+
+## Validation Gates
+
+Slice 1: all portfolio-gate jobs green on PR head; one observed-red demonstration. Slice 2: `go build ./...`, `go vet ./...`, full suite with `-race`, `go mod tidy` clean, fork CI green on PR head; tag resolution check post-merge. No macOS gate (known-local failures are cut surface; CI is Linux per portfolio standard).
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice` for every slice/PR; this repository has no overlay docs, so the shared baselines govern directly. Track-specific stops: do not modify kept-surface behavior; do not trim `internal/proto`; do not touch tag `v5.0.13-gs.1`; vocabulary per `notes/grill-allocation-lifecycle-CONTEXT.md` and `notes/grill-request-processing-CONTEXT.md` (allocation, five-tuple, permission, channel binding — never "session"/"connection ID").

--- a/docs/adr/2026-08-14-molding-program-scope.md
+++ b/docs/adr/2026-08-14-molding-program-scope.md
@@ -1,0 +1,48 @@
+# TURN Fork Molding Program — Scope
+
+**Status:** Grilled and resolved 2026-08-14. Decisions D1–D5 are settled below; ready for `architecture-handoff` packaging.
+**Date:** 2026-08-14 (drafted and grilled same day)
+**Baseline:** `main` @ `cca6b57` (payload = pion/turn#585 head `c7dcea7` + `4b818fc` transaction-wait abort + `/v5` module rename), published as tag `v5.0.13-gs.1` (at `e8db91a`, same payload).
+**Context:** `the-sarge/turn` is a permanent fork of `pion/turn`, per the fork-pivot amendment in wiremux's `docs/adr/2026-08-09-turn-carrier-prerequisites-plan.md` (GridSwarm/wiremux#1161). This program molds the fork into exactly what wiremux needs: cut unused surface, modernize, refactor, and optimize for wiremux's consumption alone.
+
+## Identity
+
+The fork is an **owned library** — wiremux's TURN client, full stop. Upstream is a read-only reference, never a compatibility target. See [the owned-library ADR](2026-08-14-owned-library-fork.md) for rationale and consequences (security posture, versioning, transitional fixture seam).
+
+## Consumer contract
+
+Wiremux's sole consumer is the Slice 1.3 allocator/composite: root `Client` performing UDP allocation over a caller-owned `net.PacketConn`, `Client.PrepareUDPPeer` deterministic readiness, the lifetime ChannelData-only write invariant, waiter-local cancellation, and joined Pion-worker allocation close after socket-owner unblock. Wiremux does not consume the TURN server, TCP/TLS transports, ICE, or credential-generation helpers.
+
+## Resolved decisions
+
+- **D1 — Server cut with transitional upstream fixture.** Delete the server half entirely. Verified: `internal/client` tests (all PR-585 work) and `close_latency_test.go` are mock-based; only root `client_test.go` (8 `NewServer` uses) and `e2e/` touch the in-repo server. Root integration tests keep their server fixture by pinning upstream `github.com/pion/turn/v5@v5.0.12` as a **test-only** dependency — no import collision thanks to the module rename. This seam is transitional: exit criterion is fork-owned receipt coverage (wiremux Slice 1.3 receipts plus any minimal fork fixture), after which the upstream test dependency is dropped.
+- **D2 — Security posture: watch proto-only.** Watch upstream `pion/turn` releases solely for `internal/proto` (wire-parsing) changes and port those; ignore upstream client-side fixes — the fork's client had already diverged before the pivot. Dependency CVEs (`pion/stun`, `pion/transport`, `x/crypto`) flow through normal dependency updates.
+- **D3 — Versioning: `v5.N.0-gs.1` minors.** M0 tags `v5.1.0-gs.1`; each milestone bumps the minor; the `-gs` suffix is permanent so Go's version selection never auto-upgrades the consumer — every wiremux bump is deliberate.
+- **D4 — CI: portfolio standard plus proto fuzz.** Replace all ten inherited pion reusable-workflow configs by running the `standardize-github-ci` audit/plan/implement flow against the fork inside M0, with one fork-specific addition: retain a fuzz job over `internal/proto`, the complement of D2's proto-focused security bet.
+- **D5 — Pre-existing macOS failures: dissolved by D1.** `TestCreateTCPConnectionInvalid` (`internal/allocation`) and `TestConnectRequest` (`internal/server`) are deleted with their packages.
+
+## Sequencing
+
+Wiremux Slice 1.3 adopts `v5.0.13-gs.1` **now** — its adoption audit covers the pre-cut tree (the post-M0 re-pin is a cheap deletion-heavy re-audit), and its consumer experience is the required input for M1. M0 follows adoption kickoff; M1 does not start until Slice 1.3 merges.
+
+## Cut and keep lists (M0)
+
+**Delete:** `server.go`, `server_config.go`, `relay_address_generator_range.go`, `relay_address_generator_static.go`, `relay_address_generator_none.go`, `lt_cred.go` (no non-example consumer), root `stun_conn.go` (consumed only by server and TCP/TLS examples), `internal/server`, `internal/allocation`, `internal/auth`, `internal/client/tcp_alloc.go`, `internal/client/tcp_conn.go` plus the TCP-allocation entry points in root `client.go`, all of `examples/`, all of `e2e/`, and the ten inherited `.github/workflows` configs (replaced per D4).
+
+**Keep:** root `client.go` (UDP paths) and `errors.go`; `internal/client` UDP path (`allocation.go`, `binding.go`, `client.go`, `errors.go`, `periodic_timer.go`, `permission.go`, `transaction.go`, `trylock.go`, `udp_conn.go`); `internal/proto` wholesale (trimming deferred past M0); `internal/ipnet`. Approximately 6,600 LOC.
+
+**Dependency re-audit at cut time:** expect `golang.org/x/time` and parts of `pion/transport/v4` to become removable; `stretchr/testify` stays; upstream `pion/turn/v5` enters as test-only.
+
+## Program shape
+
+1. **Slice M0 — Cut and stabilize:** execute the cut and keep lists, land portfolio CI with proto fuzz, green gate on the kept surface, tag `v5.1.0-gs.1`. No behavior change to kept code.
+2. **Slice M1 — Modernize the kept API** for the one consumer (context-first cancellation is already half-arrived via `PrepareUDPPeer`; extend rather than keep two idioms). Gated on Slice 1.3 merging — its adoption experience defines M1's content.
+3. **Slice M2 — Optimize the packet path** (read pump, ChannelData encode/decode in `internal/proto`). Gated on profiles from real wiremux traffic; no speculative optimization.
+
+## Tracking
+
+The program is packaged through `architecture-handoff`: program issues live in `the-sarge/turn` (wiremux issues remain consumer-side only), mirrored to OmniFocus per that workflow.
+
+## Grill record
+
+Grilled 2026-08-14 (fork-identity, D1–D5, sequencing all put to the owner; facts verified against the tree at `cca6b57`). Superseded draft framing: the original draft treated the fixture problem as gating "the size of the entire cut" — verification showed the mock-based test coverage already carries the PR-585 surface, shrinking D1 to the root integration tests and wiremux receipts only.

--- a/docs/adr/2026-08-14-owned-library-fork.md
+++ b/docs/adr/2026-08-14-owned-library-fork.md
@@ -1,0 +1,9 @@
+# The fork is an owned library, not a tracked fork
+
+`the-sarge/turn` exists to be wiremux's TURN client library; after the 2026-08-14 fork pivot we decided it is fully owned — free to break API, delete surface, and diverge from `pion/turn` without limit — rather than a trimmed fork that preserves upstream shape for cheap patch flow. Wiremux pins exact `-gs` pre-release versions, so divergence costs the one consumer nothing, and the alternative (upstream compatibility) would have blocked the entire molding program's purpose.
+
+## Consequences
+
+- Upstream is a read-only reference. Security posture is deliberately narrow: we watch upstream releases for `internal/proto` (wire-parsing) changes only; client-side upstream fixes are ignored because the client had already diverged (pion/turn#585 plus the `4b818fc` transaction-wait abort live only here). Dependency CVEs still arrive through normal dependency updates.
+- Versioning: minors bump per milestone (`v5.1.0-gs.1`, `v5.2.0-gs.1`, …) and the `-gs` suffix is permanent — Go never auto-selects pre-releases, so every consumer bump is deliberate.
+- The upstream `pion/turn/v5` test-only dependency (integration-test server fixture, possible only because the module rename removed the import-path collision) is a transitional seam, not a compatibility statement; it exits when fork-owned receipt coverage replaces it.

--- a/docs/adr/2026-08-14-turn-molding-program.md
+++ b/docs/adr/2026-08-14-turn-molding-program.md
@@ -1,0 +1,33 @@
+# TURN Fork Molding Program — 2026-08-14
+
+**Status:** Accepted; Track 1 not yet implemented; Tracks 2–3 gated, plans pending
+
+## What this is
+
+The program that molds `the-sarge/turn` into wiremux's minimal owned TURN client library. Plan docs in `docs/adr/` are the normative source of truth; issues, task-manager mirrors, and this index carry pointers and current state only. Grill and pivot history: [scope doc](2026-08-14-molding-program-scope.md), [owned-library ADR](2026-08-14-owned-library-fork.md), wiremux fork-pivot amendment (GridSwarm/wiremux#1161).
+
+## Outcomes that require no implementation
+
+- Fork identity settled: owned library, upstream read-only ([ADR](2026-08-14-owned-library-fork.md)).
+- Security posture settled: proto-only upstream watch; dependency CVEs via normal updates (scope doc D2).
+- Versioning settled: `v5.N.0-gs.1` minors, permanent `-gs` suffix (scope doc D3).
+- Pre-existing macOS test failures closed with no fix: deleted with cut surface (scope doc D5).
+- Upstream PR pion/turn#585 left open passively; its outcome gates nothing.
+
+## Tracks, dependencies, and frontier
+
+| # | Track | Plan | Parent issue | Blocked by | Slices | Status |
+|---|---|---|---|---|---|---|
+| 1 | Cut and stabilize (M0) | [plan](2026-08-14-cut-and-stabilize-plan.md) | pending | None | 2 | FRONTIER |
+| 2 | Modernize the kept API (M1) | plan pending | pending | Track 1; wiremux Slice 1.3 merged (GridSwarm/wiremux#1056) | TBD | GATED — requires a future `$architecture-handoff` run once its gate opens; content defined by 1.3 adoption experience |
+| 3 | Optimize the packet path (M2) | plan pending | pending | Track 2; profiles from production wiremux traffic | TBD | GATED — same; no speculative optimization |
+
+Cross-track slice edge: the transitional upstream-fixture seam introduced by Track 1 Slice 2 is removed by a Track 2 fixture-replacement slice, gated on fork-owned receipt coverage from wiremux Slice 1.3. Parallel-safe: Track 1 proceeds independently of wiremux Slice 1.3 adoption (which pins the already-published `v5.0.13-gs.1`). Recommended starter: Track 1 Slice 1.
+
+## Rules that bind every track
+
+- No behavior change to kept code except through an accepted track plan; kept-surface preservation gates per plan.
+- Single-owner and authority-complete invariants, transitional-seam budgets, artifact classification, and evidence budgets per the shared contract-closure baseline (no repository overlay exists).
+- Shared review-loop baseline governs every PR; post-merge ritual per slice: review loop → merge → append-dev-journal → complete the OmniFocus slice task.
+- Versioning and tag hygiene: never mutate published `-gs` tags; new capability ships as the next `v5.N.0-gs.1`.
+- Vocabulary: `notes/grill-allocation-lifecycle-CONTEXT.md`, `notes/grill-request-processing-CONTEXT.md`.

--- a/e2e/e2e_coturn_channelbind_test.go
+++ b/e2e/e2e_coturn_channelbind_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/test"
-	"github.com/pion/turn/v5"
-	"github.com/pion/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5"
+	"github.com/the-sarge/turn/v5/internal/auth"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/errors.go
+++ b/errors.go
@@ -24,6 +24,7 @@ var (
 	errSTUNServerAddressNotSet       = errors.New("STUN server address is not set for the client")
 	errOneAllocateOnly               = errors.New("only one Allocate() caller is allowed")
 	errAlreadyAllocated              = errors.New("already allocated")
+	errUDPAllocationNotFound         = errors.New("UDP allocation not found")
 	errNonSTUNMessage                = errors.New("non-STUN message from STUN server")
 	errFailedToDecodeSTUN            = errors.New("failed to decode STUN message")
 	errUnexpectedSTUNRequestMessage  = errors.New("unexpected STUN request message")

--- a/examples/lt-cred-generator/main.go
+++ b/examples/lt-cred-generator/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 // Outputs username & password according to the

--- a/examples/mutual-tls-auth/turn-client/main.go
+++ b/examples/mutual-tls-auth/turn-client/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/mutual-tls-auth/turn-server/main.go
+++ b/examples/mutual-tls-auth/turn-server/main.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 // getClientTLSAuthHandler returns an AuthHandler that validates client TLS certificates

--- a/examples/stun-only-server/main.go
+++ b/examples/stun-only-server/main.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-client/ipv6/main.go
+++ b/examples/turn-client/ipv6/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-client/tcp-alloc/main.go
+++ b/examples/turn-client/tcp-alloc/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func setupSignalingChannel(addrCh chan string, signaling bool, relayAddr string) {

--- a/examples/turn-client/tcp/main.go
+++ b/examples/turn-client/tcp/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-client/tls/main.go
+++ b/examples/turn-client/tls/main.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-client/udp/main.go
+++ b/examples/turn-client/udp/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() { //nolint:cyclop

--- a/examples/turn-server/add-software-attribute/main.go
+++ b/examples/turn-server/add-software-attribute/main.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 // attributeAdder wraps a PacketConn and appends the SOFTWARE attribute to STUN packets.

--- a/examples/turn-server/bw-quota/main.go
+++ b/examples/turn-server/bw-quota/main.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 	"golang.org/x/time/rate"
 )
 

--- a/examples/turn-server/ipv6/main.go
+++ b/examples/turn-server/ipv6/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() { //nolint:gocyclo,cyclop

--- a/examples/turn-server/log/main.go
+++ b/examples/turn-server/log/main.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 // stunLogger wraps a PacketConn and prints incoming/outgoing STUN packets

--- a/examples/turn-server/lt-cred-turn-rest/main.go
+++ b/examples/turn-server/lt-cred-turn-rest/main.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/lt-cred/main.go
+++ b/examples/turn-server/lt-cred/main.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/perm-filter/main.go
+++ b/examples/turn-server/perm-filter/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/port-range/main.go
+++ b/examples/turn-server/port-range/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/simple-multithreaded/main.go
+++ b/examples/turn-server/simple-multithreaded/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 	"golang.org/x/sys/unix"
 )
 

--- a/examples/turn-server/simple-quota/main.go
+++ b/examples/turn-server/simple-quota/main.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 const maxAllocationsPerUser = 1

--- a/examples/turn-server/simple/main.go
+++ b/examples/turn-server/simple/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/tcp/main.go
+++ b/examples/turn-server/tcp/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/examples/turn-server/tls/main.go
+++ b/examples/turn-server/tls/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pion/turn/v5"
+	"github.com/the-sarge/turn/v5"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pion/turn/v5
+module github.com/the-sarge/turn/v5
 
 go 1.24.0
 

--- a/internal/allocation/allocation.go
+++ b/internal/allocation/allocation.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/ipnet"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/ipnet"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 type allocationResponse struct {

--- a/internal/allocation/allocation_manager.go
+++ b/internal/allocation/allocation_manager.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/randutil"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 // If no ConnectionBind request associated with this peer data

--- a/internal/allocation/allocation_manager_test.go
+++ b/internal/allocation/allocation_manager_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4/reuseport"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/allocation/allocation_test.go
+++ b/internal/allocation/allocation_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4/reuseport"
-	"github.com/pion/turn/v5/internal/ipnet"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/ipnet"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/allocation/channel_bind.go
+++ b/internal/allocation/channel_bind.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 // ChannelBind represents a TURN Channel

--- a/internal/allocation/channel_bind_test.go
+++ b/internal/allocation/channel_bind_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -31,6 +31,12 @@ type AllocationConfig struct {
 	PermissionRefreshInterval time.Duration
 	BindingRefreshInterval    time.Duration
 	BindingCheckInterval      time.Duration
+
+	// AbortTransactions, when set, interrupts the allocation's pending
+	// transaction waits. Called once by UDPConn when it starts closing, so
+	// Close does not wait out the retransmission budget of in-flight
+	// transactions against an unresponsive server.
+	AbortTransactions func()
 }
 
 type allocation struct {
@@ -53,6 +59,10 @@ type allocation struct {
 	// onPermRefreshFailure, when set, observes a permission refresh that kept
 	// failing after retries. Read-only after construction.
 	onPermRefreshFailure func(error)
+
+	// abortTransactions, when set, interrupts the allocation's pending
+	// transaction waits. Read-only after construction.
+	abortTransactions func()
 }
 
 func (a *allocation) setNonceFromMsg(msg *stun.Message) {

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 // AllocationConfig is a set of configuration params use by NewUDPConn and NewTCPAllocation.

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -49,6 +49,10 @@ type allocation struct {
 	readTimer         *time.Timer           // Thread-safe
 	mutex             sync.RWMutex          // Thread-safe
 	log               logging.LeveledLogger // Read-only
+
+	// onPermRefreshFailure, when set, observes a permission refresh that kept
+	// failing after retries. Read-only after construction.
+	onPermRefreshFailure func(error)
 }
 
 func (a *allocation) setNonceFromMsg(msg *stun.Message) {
@@ -166,6 +170,9 @@ func (a *allocation) onRefreshTimers(id int) {
 		}
 		if err != nil {
 			a.log.Warnf("Failed to refresh permissions: %s", err)
+			if a.onPermRefreshFailure != nil {
+				a.onPermRefreshFailure(err)
+			}
 		}
 	}
 }

--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -37,12 +37,52 @@ type binding struct {
 	addr         net.Addr        // Read-only
 	mgr          *bindingManager // Read-only
 	muBind       sync.Mutex      // Thread-safe, for ChannelBind ops
+	attemptDone  chan struct{}   // Protected by muBind; non-nil while a bind attempt is in flight
+	prepared     atomic.Bool     // Thread-safe; peer promised ChannelData-only writes
 	_refreshedAt time.Time       // Protected by mutex
+	_bindErr     error           // Protected by mutex; last failed bind attempt or terminal cause
+	_terminal    bool            // Protected by mutex; binding failed permanently
 	mutex        sync.RWMutex    // Thread-safe
 }
 
 func (b *binding) setState(state bindingState) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if b._terminal {
+		state = bindingStateFailed
+	}
 	atomic.StoreInt32((*int32)(&b.st), int32(state))
+}
+
+// terminalize permanently fails the binding: every later setState collapses to
+// bindingStateFailed so an in-flight bind attempt cannot resurrect it.
+func (b *binding) terminalize(err error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if b._terminal {
+		return
+	}
+	b._terminal = true
+	b._bindErr = err
+	atomic.StoreInt32((*int32)(&b.st), int32(bindingStateFailed))
+}
+
+func (b *binding) setBindErr(err error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if !b._terminal {
+		b._bindErr = err
+	}
+}
+
+func (b *binding) bindErr() error {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	return b._bindErr
 }
 
 func (b *binding) state() bindingState {
@@ -97,8 +137,18 @@ func (mgr *bindingManager) assignChannelNumber() uint16 {
 }
 
 func (mgr *bindingManager) create(addr net.Addr) *binding {
+	return mgr.getOrCreate(addr)
+}
+
+// getOrCreate returns the existing binding for addr, or creates one, so that
+// concurrent callers for the same peer share a single channel number.
+func (mgr *bindingManager) getOrCreate(addr net.Addr) *binding {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
+
+	if b, ok := mgr.addrMap[addr.String()]; ok {
+		return b
+	}
 
 	b := &binding{
 		number:       mgr.assignChannelNumber(),

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -23,6 +23,11 @@ var (
 	errCannotBindChannel                   = errors.New("cannot bind channel")
 	errChannelBindBadRequest               = errors.New("channel bind bad request")
 	errChannelBindTransactionFailed        = errors.New("channel bind transaction failed")
+	errChannelBindFailed                   = errors.New("channel bind failed")
+	errChannelBindingExpired               = errors.New("confirmed channel binding expired")
+	errPermissionRefreshFailed             = errors.New("permission refresh failed")
+	errInvalidUDPAddr                      = errors.New("invalid UDP address")
+	errNilContext                          = errors.New("context must not be nil")
 )
 
 type timeoutError struct {

--- a/internal/client/periodic_timer.go
+++ b/internal/client/periodic_timer.go
@@ -17,6 +17,7 @@ type PeriodicTimer struct {
 	interval       time.Duration
 	timeoutHandler PeriodicTimerTimeoutHandler
 	stopFunc       func()
+	doneCh         chan struct{}
 	mutex          sync.RWMutex
 }
 
@@ -40,8 +41,10 @@ func (t *PeriodicTimer) Start() bool {
 	}
 
 	cancelCh := make(chan struct{})
+	doneCh := make(chan struct{})
 
 	go func() {
+		defer close(doneCh)
 		canceling := false
 
 		for !canceling {
@@ -60,6 +63,7 @@ func (t *PeriodicTimer) Start() bool {
 	t.stopFunc = func() {
 		close(cancelCh)
 	}
+	t.doneCh = doneCh
 
 	return true
 }
@@ -72,6 +76,22 @@ func (t *PeriodicTimer) Stop() {
 	if t.stopFunc != nil {
 		t.stopFunc()
 		t.stopFunc = nil
+	}
+}
+
+// StopAndWait stops the timer and waits for its handler goroutine to return.
+// It must not be called from the timer's own timeout handler.
+func (t *PeriodicTimer) StopAndWait() {
+	t.mutex.Lock()
+	if t.stopFunc != nil {
+		t.stopFunc()
+		t.stopFunc = nil
+	}
+	doneCh := t.doneCh
+	t.mutex.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
 	}
 }
 

--- a/internal/client/periodic_timer_test.go
+++ b/internal/client/periodic_timer_test.go
@@ -45,10 +45,12 @@ func TestPeriodicTimer(t *testing.T) {
 
 	t.Run("stop inside handler", func(t *testing.T) {
 		timerID := 4
+		stopped := make(chan struct{})
 		var rt *PeriodicTimer
 		rt = NewPeriodicTimer(timerID, func(id int) {
 			assert.Equal(t, timerID, id)
 			rt.Stop()
+			close(stopped)
 		}, 20*time.Millisecond)
 
 		assert.False(t, rt.IsRunning(), "should not be running yet")
@@ -56,7 +58,14 @@ func TestPeriodicTimer(t *testing.T) {
 		ok := rt.Start()
 		assert.True(t, ok, "should be true")
 		assert.True(t, rt.IsRunning(), "should be running")
-		time.Sleep(30 * time.Millisecond)
+
+		// Wait for the handler's Stop instead of calibrating a sleep against
+		// the timer interval, which is racy on slow runners.
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for handler to stop the timer")
+		}
 		assert.False(t, rt.IsRunning(), "should not be running")
 	})
 }

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -19,9 +19,11 @@ const (
 )
 
 type permission struct {
-	addr  net.Addr
-	st    permState    // Thread-safe (atomic op)
-	mutex sync.RWMutex // Thread-safe
+	addr        net.Addr
+	st          permState     // Thread-safe (atomic op)
+	attemptDone chan struct{} // Protected by mutex; non-nil while a create attempt is in flight
+	attemptErr  error         // Protected by mutex; result of the last create attempt
+	mutex       sync.RWMutex  // Thread-safe
 }
 
 func (p *permission) setState(state permState) {
@@ -45,6 +47,23 @@ func (m *permissionMap) insert(addr net.Addr, p *permission) bool {
 	m.permMap[ipnet.FingerprintAddr(addr)] = p
 
 	return true
+}
+
+// getOrCreate returns the existing permission for addr, or creates one, so
+// that concurrent callers for the same peer share a single permission.
+func (m *permissionMap) getOrCreate(addr net.Addr) *permission {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	key := ipnet.FingerprintAddr(addr)
+	if p, ok := m.permMap[key]; ok {
+		return p
+	}
+
+	p := &permission{addr: addr}
+	m.permMap[key] = p
+
+	return p
 }
 
 func (m *permissionMap) find(addr net.Addr) (*permission, bool) {

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/pion/turn/v5/internal/ipnet"
+	"github.com/the-sarge/turn/v5/internal/ipnet"
 )
 
 type permState int32

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -21,9 +21,15 @@ const (
 type permission struct {
 	addr        net.Addr
 	st          permState     // Thread-safe (atomic op)
-	attemptDone chan struct{} // Protected by mutex; non-nil while a create attempt is in flight
-	attemptErr  error         // Protected by mutex; result of the last create attempt
-	mutex       sync.RWMutex  // Thread-safe
+	attemptDone chan struct{} // Protected by attemptMutex; non-nil while a create attempt is in flight
+	attemptErr  error         // Protected by attemptMutex; result of the last create attempt
+
+	// attemptMutex guards the attempt bookkeeping only. It is never held
+	// across a transaction, unlike mutex, which createPermission holds for
+	// the duration of the CreatePermission transaction; waiters joining an
+	// attempt must not block behind that transaction.
+	attemptMutex sync.Mutex   // Thread-safe
+	mutex        sync.RWMutex // Thread-safe
 }
 
 func (p *permission) setState(state permState) {

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -25,6 +25,7 @@ type prepareHarness struct {
 	permCount atomic.Int32
 	bindCount atomic.Int32
 	bindGate  chan struct{} // If non-nil, ChannelBind transactions block on it
+	permGate  chan struct{} // If non-nil, CreatePermission transactions block on it
 	failPerms atomic.Bool   // If set, CreatePermission transactions return 403
 	writes    struct {
 		sync.Mutex
@@ -47,6 +48,9 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
 				harness.permCount.Add(1)
+				if harness.permGate != nil {
+					<-harness.permGate
+				}
 				if harness.failPerms.Load() {
 					return TransactionResult{Msg: stun.MustBuild(
 						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
@@ -259,6 +263,46 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			assert.Fail(t, "timed out waiting for surviving waiter")
 		}
 		assert.Equal(t, int32(1), harness.bindCount.Load(), "cancellation must not restart or cancel the shared bind")
+	})
+
+	t.Run("cancellation wakes waiter during in-flight permission transaction", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		harness.permGate = make(chan struct{})
+
+		// First caller's CreatePermission transaction is in flight (and holds
+		// the permission mutex for its duration, as createPermission does).
+		resultA := make(chan error, 1)
+		go func() { resultA <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+		assert.Eventually(t, func() bool {
+			return harness.permCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// A second caller for the same peer must wait on the attempt channel,
+		// where its cancellation can wake it — not on the permission mutex.
+		ctxB, cancelB := context.WithCancelCause(context.Background())
+		defer cancelB(nil)
+		resultB := make(chan error, 1)
+		go func() { resultB <- harness.conn.PreparePeer(ctxB, harness.peer) }()
+		time.Sleep(100 * time.Millisecond)
+
+		cause := errors.New("waiter B gave up") //nolint:err113 // test-local cause
+		cancelB(cause)
+		select {
+		case err := <-resultB:
+			assert.ErrorIs(t, err, cause,
+				"waiter must be cancelable while the permission transaction is in flight")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "canceled waiter did not wake during in-flight permission transaction")
+		}
+
+		close(harness.permGate)
+		select {
+		case err := <-resultA:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for first caller")
+		}
+		assert.Equal(t, int32(1), harness.permCount.Load(), "permission transactions should coalesce")
 	})
 
 	t.Run("permission refresh failure fails writes, never Send indication", func(t *testing.T) {

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/pion/stun/v3"
+	"github.com/pion/turn/v5/internal/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+// prepareHarness drives a NewUDPConn against a scripted mock TURN server.
+type prepareHarness struct {
+	conn      *UDPConn
+	peer      *net.UDPAddr
+	permCount atomic.Int32
+	bindCount atomic.Int32
+	bindGate  chan struct{} // If non-nil, ChannelBind transactions block on it
+	failPerms atomic.Bool   // If set, CreatePermission transactions return 403
+	writes    struct {
+		sync.Mutex
+		data [][]byte
+	}
+}
+
+func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
+	t.Helper()
+
+	harness := &prepareHarness{
+		peer: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234},
+	}
+	if gateBinds {
+		harness.bindGate = make(chan struct{})
+	}
+
+	mock := &mockClient{
+		performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
+			switch msg.Type.Method {
+			case stun.MethodCreatePermission:
+				harness.permCount.Add(1)
+				if harness.failPerms.Load() {
+					return TransactionResult{Msg: stun.MustBuild(
+						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
+						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
+					)}, nil
+				}
+
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
+				)}, nil
+			case stun.MethodChannelBind:
+				harness.bindCount.Add(1)
+				if harness.bindGate != nil {
+					<-harness.bindGate
+				}
+
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
+				)}, nil
+			case stun.MethodRefresh:
+				return TransactionResult{}, nil
+			default:
+				return TransactionResult{}, errFake
+			}
+		},
+		writeTo: func(data []byte, _ net.Addr) (int, error) {
+			harness.writes.Lock()
+			harness.writes.data = append(harness.writes.data, append([]byte(nil), data...))
+			harness.writes.Unlock()
+
+			return len(data), nil
+		},
+	}
+
+	harness.conn = NewUDPConn(&AllocationConfig{
+		Client:      mock,
+		RelayedAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
+		ServerAddr:  &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
+		Username:    stun.NewUsername("user"),
+		Realm:       stun.NewRealm("realm"),
+		Integrity:   stun.NewShortTermIntegrity("pass"),
+		Nonce:       stun.NewNonce("nonce"),
+		Lifetime:    time.Hour,
+		Log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
+	})
+	t.Cleanup(func() { _ = harness.conn.Close() })
+
+	return harness
+}
+
+func (harness *prepareHarness) writeCount() int {
+	harness.writes.Lock()
+	defer harness.writes.Unlock()
+
+	return len(harness.writes.data)
+}
+
+func (harness *prepareHarness) lastWrite() []byte {
+	harness.writes.Lock()
+	defer harness.writes.Unlock()
+
+	if len(harness.writes.data) == 0 {
+		return nil
+	}
+
+	return harness.writes.data[len(harness.writes.data)-1]
+}
+
+func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
+	t.Run("readiness success then ChannelData writes", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Equal(t, int32(1), harness.permCount.Load())
+		assert.Equal(t, int32(1), harness.bindCount.Load())
+
+		n, err := harness.conn.WriteTo([]byte("hello"), harness.peer)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.True(t, proto.IsChannelData(harness.lastWrite()),
+			"write after successful PreparePeer must be ChannelData, not Send indication")
+	})
+
+	t.Run("invalid peers rejected", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}), errUDPAddrCast)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 1234}), errInvalidUDPAddr)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}), errInvalidUDPAddr)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("224.0.0.1"), Port: 1234}), errInvalidUDPAddr)
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(),
+			&net.UDPAddr{IP: net.ParseIP("fe80::1"), Port: 1234, Zone: "en0"}), errInvalidUDPAddr)
+	})
+
+	t.Run("peer aliases share the prepared binding", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		peer := &net.UDPAddr{IP: net.ParseIP("::1"), Port: 5678}
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), peer))
+		assert.Equal(t, int32(1), harness.bindCount.Load())
+
+		// A zoned alias of the prepared peer must map onto its channel binding
+		// instead of bypassing it via Send indication.
+		alias := &net.UDPAddr{IP: net.ParseIP("::1"), Port: 5678, Zone: "en0"}
+		_, err := harness.conn.WriteTo([]byte("via alias"), alias)
+		assert.NoError(t, err)
+		assert.True(t, proto.IsChannelData(harness.lastWrite()),
+			"write to an alias of a prepared peer must be ChannelData")
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "alias must not create a second binding")
+	})
+
+	t.Run("terminal failure survives an in-flight bind success", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		harness.conn.maybeBind(bound)
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// Terminalize while the bind transaction is still in flight, then let
+		// it succeed: the binding must stay failed.
+		bound.prepared.Store(true)
+		bound.terminalize(errFake)
+		close(harness.bindGate)
+
+		assert.Eventually(t, func() bool {
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return bound.attemptDone == nil
+		}, 5*time.Second, 10*time.Millisecond)
+		assert.Equal(t, bindingStateFailed, bound.state(),
+			"completed bind attempt must not resurrect a terminalized binding")
+
+		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
+		assert.ErrorIs(t, err, errFake)
+	})
+
+	t.Run("same-peer callers coalesce onto one bind", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		const waiters = 4
+		results := make(chan error, waiters)
+		for range waiters {
+			go func() {
+				results <- harness.conn.PreparePeer(context.Background(), harness.peer)
+			}()
+		}
+
+		// Let the first attempt start and the rest pile onto it.
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
+		close(harness.bindGate)
+
+		for range waiters {
+			select {
+			case err := <-results:
+				assert.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				assert.Fail(t, "timed out waiting for PreparePeer")
+			}
+		}
+		assert.Equal(t, int32(1), harness.permCount.Load(), "permission transactions should coalesce")
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "ChannelBind transactions should coalesce")
+	})
+
+	t.Run("cancellation wakes only that waiter", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		ctxA, cancelA := context.WithCancelCause(context.Background())
+		defer cancelA(nil)
+		causeA := errors.New("waiter A gave up") //nolint:err113 // test-local cause
+
+		resultA := make(chan error, 1)
+		resultB := make(chan error, 1)
+		go func() { resultA <- harness.conn.PreparePeer(ctxA, harness.peer) }()
+		go func() { resultB <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		cancelA(causeA)
+		select {
+		case err := <-resultA:
+			assert.ErrorIs(t, err, causeA, "canceled waiter must observe its cause")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "canceled waiter did not wake promptly")
+		}
+
+		// The shared bind attempt must survive waiter A's cancellation.
+		select {
+		case err := <-resultB:
+			assert.Failf(t, "waiter B finished early", "err: %v", err)
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		close(harness.bindGate)
+		select {
+		case err := <-resultB:
+			assert.NoError(t, err, "surviving waiter should complete via the shared bind")
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "timed out waiting for surviving waiter")
+		}
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "cancellation must not restart or cancel the shared bind")
+	})
+
+	t.Run("permission refresh failure fails writes, never Send indication", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+
+		// Simulate the permission-refresh timer firing against a server that
+		// now rejects the refresh.
+		harness.failPerms.Store(true)
+		harness.conn.onRefreshTimers(timerIDRefreshPerms)
+
+		writesBefore := harness.writeCount()
+		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
+		assert.ErrorIs(t, err, errPermissionRefreshFailed)
+		assert.Equal(t, writesBefore, harness.writeCount(),
+			"failed write for a prepared peer must not emit anything (no Send indication fallback)")
+
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), errPermissionRefreshFailed,
+			"readiness must be terminal after permission refresh failure")
+	})
+
+	t.Run("bind failure surfaces to preparing caller", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		// First permission succeeds, but every ChannelBind transaction fails.
+		mock, ok := harness.conn.client.(*mockClient)
+		assert.True(t, ok)
+		inner := mock.performTransaction
+		mock.performTransaction = func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+			if msg.Type.Method == stun.MethodChannelBind {
+				harness.bindCount.Add(1)
+
+				return TransactionResult{}, errFake
+			}
+
+			return inner(msg, to, dontWait)
+		}
+
+		err := harness.conn.PreparePeer(context.Background(), harness.peer)
+		assert.ErrorIs(t, err, errChannelBindTransactionFailed)
+		assert.False(t, harness.conn.isClosed())
+	})
+
+	t.Run("close joins in-flight bind workers", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+
+		prepareResult := make(chan error, 1)
+		go func() { prepareResult <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+
+		assert.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		closeResult := make(chan error, 1)
+		go func() { closeResult <- harness.conn.Close() }()
+
+		// The waiter unblocks promptly; Close must keep waiting for the worker.
+		select {
+		case err := <-prepareResult:
+			assert.ErrorIs(t, err, errClosed)
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "PreparePeer waiter did not unblock on close")
+		}
+		select {
+		case <-closeResult:
+			assert.Fail(t, "Close returned while a bind worker was still in flight")
+		case <-time.After(300 * time.Millisecond):
+		}
+
+		close(harness.bindGate)
+		select {
+		case err := <-closeResult:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "Close did not return after the bind worker finished")
+		}
+	})
+}

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/client/tcp_alloc.go
+++ b/internal/client/tcp_alloc.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 var (

--- a/internal/client/tcp_conn.go
+++ b/internal/client/tcp_conn.go
@@ -8,7 +8,7 @@ import (
 	"net"
 
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 var (

--- a/internal/client/tcp_conn_test.go
+++ b/internal/client/tcp_conn_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -182,6 +182,22 @@ func (m *TransactionMap) CloseAndDeleteAll() {
 	}
 }
 
+// CloseAndDeleteAllTo closes and deletes all transactions addressed to the
+// given destination, waking their waiters with errTransactionClosed.
+func (m *TransactionMap) CloseAndDeleteAllTo(to net.Addr) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for trKey, tr := range m.trMap {
+		if tr.To.String() != to.String() {
+			continue
+		}
+		tr.StopRtxTimer()
+		tr.Close()
+		delete(m.trMap, trKey)
+	}
+}
+
 // Size returns the length of the transaction map.
 func (m *TransactionMap) Size() int {
 	m.mutex.RLock()

--- a/internal/client/transaction_test.go
+++ b/internal/client/transaction_test.go
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransactionClose(t *testing.T) {
+	serverA := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
+	serverB := &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 3478}
+
+	t.Run("Close unblocks WaitForResult with a clean error", func(t *testing.T) {
+		tr := NewTransaction(&TransactionConfig{
+			Key:      "k",
+			To:       serverA,
+			Interval: time.Second,
+		})
+
+		resCh := make(chan TransactionResult, 1)
+		go func() { resCh <- tr.WaitForResult() }()
+
+		tr.Close()
+
+		select {
+		case res := <-resCh:
+			assert.True(t, errors.Is(res.Err, errTransactionClosed))
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "WaitForResult did not unblock on Close")
+		}
+	})
+
+	t.Run("CloseAndDeleteAllTo scopes by destination", func(t *testing.T) {
+		trMap := NewTransactionMap()
+		trA := NewTransaction(&TransactionConfig{Key: "a", To: serverA, Interval: time.Second})
+		trB := NewTransaction(&TransactionConfig{Key: "b", To: serverB, Interval: time.Second})
+		trMap.Insert("a", trA)
+		trMap.Insert("b", trB)
+
+		resA := make(chan TransactionResult, 1)
+		resB := make(chan TransactionResult, 1)
+		go func() { resA <- trA.WaitForResult() }()
+		go func() { resB <- trB.WaitForResult() }()
+
+		trMap.CloseAndDeleteAllTo(serverA)
+
+		select {
+		case res := <-resA:
+			assert.True(t, errors.Is(res.Err, errTransactionClosed))
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "transaction to the aborted destination did not unblock")
+		}
+
+		select {
+		case res := <-resB:
+			assert.Failf(t, "transaction to another destination was aborted", "err: %v", res.Err)
+		case <-time.After(200 * time.Millisecond):
+		}
+		assert.Equal(t, 1, trMap.Size())
+
+		trMap.CloseAndDeleteAll()
+		select {
+		case res := <-resB:
+			assert.True(t, errors.Is(res.Err, errTransactionClosed))
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "remaining transaction did not unblock")
+		}
+	})
+}

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -261,9 +261,9 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer net.Addr) error {
 		if perm.state() == permStatePermitted {
 			return nil
 		}
-		perm.mutex.RLock()
+		perm.attemptMutex.Lock()
 		err := perm.attemptErr
-		perm.mutex.RUnlock()
+		perm.attemptMutex.Unlock()
 		if err != nil {
 			return err
 		}
@@ -275,8 +275,8 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer net.Addr) error {
 // CreatePermission attempt (existing or newly started) completes. It returns
 // nil once the allocation is closing.
 func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan struct{} {
-	perm.mutex.Lock()
-	defer perm.mutex.Unlock()
+	perm.attemptMutex.Lock()
+	defer perm.attemptMutex.Unlock()
 
 	if perm.attemptDone != nil {
 		return perm.attemptDone
@@ -295,10 +295,10 @@ func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan 
 				break
 			}
 		}
-		perm.mutex.Lock()
+		perm.attemptMutex.Lock()
 		perm.attemptDone = nil
 		perm.attemptErr = err
-		perm.mutex.Unlock()
+		perm.attemptMutex.Unlock()
 		close(done)
 	}()
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -5,11 +5,13 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -22,6 +24,7 @@ const (
 	defaultPermRefreshInterval    = 120 * time.Second
 	defaultBindingRefreshInterval = 5 * time.Minute
 	defaultBindingCheckInterval   = 30 * time.Second
+	channelBindingLifetime        = 10 * time.Minute
 	maxRetryAttempts              = 3
 )
 
@@ -43,7 +46,8 @@ type UDPConn struct {
 	checkBindingsTimer     *PeriodicTimer    // Thread-safe
 	readCh                 chan *inboundData // Thread-safe
 	closeCh                chan struct{}     // Thread-safe
-	closeMutex             sync.Mutex        // Thread-safe
+	closeMutex             sync.Mutex        // Thread-safe; also gates workerWG.Add vs close
+	workerWG               sync.WaitGroup    // Joins bind/permission workers on Close
 	bindingRefreshInterval time.Duration     // Read-only
 	allocation
 }
@@ -74,6 +78,7 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 	if config.BindingRefreshInterval != 0 {
 		conn.bindingRefreshInterval = config.BindingRefreshInterval
 	}
+	conn.onPermRefreshFailure = conn.failPreparedBindings
 
 	conn.log.Debugf("Initial lifetime: %d seconds", int(conn.lifetime().Seconds()))
 
@@ -179,6 +184,252 @@ func (a *allocation) createPermission(perm *permission, addr net.Addr) error {
 	return nil
 }
 
+// PreparePeer creates a permission for peer and waits until the TURN server
+// confirms a channel binding for it. After it returns nil, writes to peer use
+// ChannelData (or fail) for the lifetime of the allocation; they never fall
+// back to Send indications. Concurrent callers for the same peer share one
+// permission and one bind attempt; canceling ctx wakes only that caller (with
+// its cause) and leaves the shared work running.
+func (c *UDPConn) PreparePeer(ctx context.Context, peer net.Addr) error {
+	if ctx == nil {
+		return errNilContext
+	}
+	udpPeer, err := canonicalUDPPeer(peer)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return context.Cause(ctx)
+	}
+	if c.isClosed() {
+		return errClosed
+	}
+
+	if err := c.awaitPermission(ctx, udpPeer); err != nil {
+		return err
+	}
+
+	return c.awaitBinding(ctx, c.bindingMgr.getOrCreate(udpPeer))
+}
+
+// canonicalUDPPeer validates peer and reduces it to a canonical form so that
+// aliases of the same peer (IPv4-mapped IPv6, zoned addresses) share one
+// permission and one channel binding.
+func canonicalUDPPeer(peer net.Addr) (*net.UDPAddr, error) {
+	udpPeer, ok := peer.(*net.UDPAddr)
+	if !ok || udpPeer == nil {
+		return nil, errUDPAddrCast
+	}
+	if udpPeer.Port <= 0 || udpPeer.Port > math.MaxUint16 || udpPeer.Zone != "" {
+		return nil, errInvalidUDPAddr
+	}
+
+	addr, ok := netip.AddrFromSlice(udpPeer.IP)
+	if !ok {
+		return nil, errInvalidUDPAddr
+	}
+	addr = addr.Unmap()
+	if addr.IsUnspecified() || addr.IsMulticast() {
+		return nil, errInvalidUDPAddr
+	}
+
+	return &net.UDPAddr{IP: net.IP(addr.AsSlice()), Port: udpPeer.Port}, nil
+}
+
+// awaitPermission blocks until a permission for peer is installed, the shared
+// create attempt fails, or ctx is canceled.
+func (c *UDPConn) awaitPermission(ctx context.Context, peer net.Addr) error {
+	for {
+		perm := c.permMap.getOrCreate(peer)
+		if perm.state() == permStatePermitted {
+			return nil
+		}
+
+		done := c.ensurePermissionAttempt(perm, peer)
+		if done == nil {
+			return errClosed
+		}
+
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-c.closeCh:
+			return errClosed
+		}
+
+		if perm.state() == permStatePermitted {
+			return nil
+		}
+		perm.mutex.RLock()
+		err := perm.attemptErr
+		perm.mutex.RUnlock()
+		if err != nil {
+			return err
+		}
+		// The attempt we joined predates our loop iteration; re-evaluate.
+	}
+}
+
+// ensurePermissionAttempt returns a channel that closes when the in-flight
+// CreatePermission attempt (existing or newly started) completes. It returns
+// nil once the allocation is closing.
+func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan struct{} {
+	perm.mutex.Lock()
+	defer perm.mutex.Unlock()
+
+	if perm.attemptDone != nil {
+		return perm.attemptDone
+	}
+	if !c.addWorker() {
+		return nil
+	}
+
+	done := make(chan struct{})
+	perm.attemptDone = done
+	go func() {
+		defer c.workerWG.Done()
+		var err error
+		for range maxRetryAttempts {
+			if err = c.createPermission(perm, peer); !errors.Is(err, errTryAgain) {
+				break
+			}
+		}
+		perm.mutex.Lock()
+		perm.attemptDone = nil
+		perm.attemptErr = err
+		perm.mutex.Unlock()
+		close(done)
+	}()
+
+	return done
+}
+
+// awaitBinding blocks until the server confirms the channel binding, the
+// binding fails, or ctx is canceled.
+func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //nolint:cyclop
+	for {
+		if final, err := bindingResult(bound); final {
+			return err
+		}
+
+		bound.muBind.Lock()
+		done := bound.attemptDone
+		if done == nil {
+			done = c.startBindAttemptLocked(bound)
+		}
+		bound.muBind.Unlock()
+
+		if done == nil {
+			// No attempt is needed (state already decisive) or none can start (closing).
+			if final, err := bindingResult(bound); final {
+				return err
+			}
+			if c.isClosed() {
+				return errClosed
+			}
+
+			return errChannelBindFailed
+		}
+
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-c.closeCh:
+			return errClosed
+		}
+
+		if final, err := bindingResult(bound); final {
+			return err
+		}
+		// The joined attempt ended without confirming; surface its error rather
+		// than retrying forever on the caller's behalf.
+		if err := bound.bindErr(); err != nil {
+			return err
+		}
+	}
+}
+
+// bindingResult reports whether the binding reached a decisive state for a
+// preparing caller: (true, nil) once the server has confirmed the channel
+// mapping, (true, err) once the binding failed or its confirmation expired.
+func bindingResult(bound *binding) (bool, error) {
+	if bound.ok() {
+		if time.Since(bound.refreshedAt()) >= channelBindingLifetime {
+			bound.terminalize(errChannelBindingExpired)
+
+			return true, errChannelBindingExpired
+		}
+		bound.prepared.Store(true)
+
+		return true, nil
+	}
+	if bound.state() == bindingStateFailed {
+		if err := bound.bindErr(); err != nil {
+			return true, err
+		}
+
+		return true, errChannelBindFailed
+	}
+
+	return false, nil
+}
+
+// startBindAttemptLocked starts a tracked bind attempt if the binding state
+// calls for one. It requires bound.muBind to be held and returns the channel
+// that closes when the attempt completes, or nil if no attempt was started.
+func (c *UDPConn) startBindAttemptLocked(bound *binding) chan struct{} {
+	if !c.addWorker() {
+		return nil
+	}
+	startState, ok := c.startBinding(bound)
+	if !ok {
+		c.workerWG.Done()
+
+		return nil
+	}
+
+	done := make(chan struct{})
+	bound.attemptDone = done
+	go func() {
+		defer c.workerWG.Done()
+		err := c.bindChannel(bound, startState)
+		bound.setBindErr(err)
+		bound.muBind.Lock()
+		bound.attemptDone = nil
+		bound.muBind.Unlock()
+		close(done)
+	}()
+
+	return done
+}
+
+// addWorker registers an allocation-owned goroutine with the close join.
+// It returns false once the allocation has begun closing.
+func (c *UDPConn) addWorker() bool {
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
+
+	if c.isClosed() {
+		return false
+	}
+	c.workerWG.Add(1)
+
+	return true
+}
+
+// failPreparedBindings terminalizes every prepared binding: once a peer is
+// prepared, losing its permission must fail writes rather than fall back to
+// Send indications.
+func (c *UDPConn) failPreparedBindings(err error) {
+	for _, bound := range c.bindingMgr.all() {
+		if bound.prepared.Load() {
+			bound.terminalize(fmt.Errorf("%w: %w", errPermissionRefreshFailed, err))
+		}
+	}
+}
+
 // WriteTo writes a packet with payload to addr.
 // WriteTo can be made to time out and return
 // an Error with Timeout() == true after a fixed time limit;
@@ -186,9 +437,21 @@ func (a *allocation) createPermission(perm *permission, addr net.Addr) error {
 // On packet-oriented connections, write timeouts are rare.
 func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint:gocognit,cyclop
 	var err error
-	_, ok := addr.(*net.UDPAddr)
-	if !ok {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if !ok || udpAddr == nil {
 		return 0, errUDPAddrCast
+	}
+	// Reduce aliases (IPv4-mapped IPv6, zoned addresses) to the canonical peer
+	// so they share its permission and channel binding. Peers that cannot be
+	// canonicalized are left as-is.
+	if canonical, cerr := canonicalUDPPeer(udpAddr); cerr == nil {
+		addr = canonical
+	} else if udpAddr.Zone != "" {
+		unzoned := *udpAddr
+		unzoned.Zone = ""
+		if canonical, cerr = canonicalUDPPeer(&unzoned); cerr == nil {
+			addr = canonical
+		}
 	}
 	if c.isClosed() {
 		return 0, &net.OpError{
@@ -226,6 +489,21 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 	bound, ok := c.bindingMgr.findByAddr(addr)
 	if !ok {
 		bound = c.bindingMgr.create(addr)
+	}
+
+	// A prepared peer promised ChannelData-only writes: fail instead of ever
+	// falling back to Send indications.
+	if bound.prepared.Load() {
+		if bound.ok() && time.Since(bound.refreshedAt()) >= channelBindingLifetime {
+			bound.terminalize(errChannelBindingExpired)
+		}
+		if !bound.ok() {
+			if bindErr := bound.bindErr(); bindErr != nil {
+				return 0, bindErr
+			}
+
+			return 0, errChannelBindFailed
+		}
 	}
 
 	//nolint:nestif
@@ -266,7 +544,28 @@ func (c *UDPConn) WriteTo(payload []byte, addr net.Addr) (int, error) { //nolint
 
 // Close closes the connection.
 // Any blocked ReadFrom or WriteTo operations will be unblocked and return errors.
+// Close returns only after allocation-owned goroutines (refresh timers and
+// bind/permission workers) have finished. It never closes or sets deadlines on
+// the caller-owned base socket, so a worker blocked on that socket is joined
+// only once the caller unblocks its I/O.
 func (c *UDPConn) Close() error {
+	first, err := c.startClose()
+
+	c.refreshAllocTimer.StopAndWait()
+	c.refreshPermsTimer.StopAndWait()
+	c.checkBindingsTimer.StopAndWait()
+	c.workerWG.Wait()
+
+	if !first {
+		return errAlreadyClosed
+	}
+
+	return err
+}
+
+// startClose makes the allocation refuse new work and emits the deallocate
+// refresh. It performs no joins, so allocation-owned workers may call it safely.
+func (c *UDPConn) startClose() (bool, error) {
 	c.closeMutex.Lock()
 	defer c.closeMutex.Unlock()
 
@@ -276,14 +575,14 @@ func (c *UDPConn) Close() error {
 
 	select {
 	case <-c.closeCh:
-		return errAlreadyClosed
+		return false, nil
 	default:
 		close(c.closeCh)
 	}
 
 	c.client.OnDeallocated(c.relayedAddr)
 
-	return c.refreshAllocation(0, true /* dontWait=true */)
+	return true, c.refreshAllocation(0, true /* dontWait=true */)
 }
 
 // LocalAddr returns the local network address.
@@ -438,18 +737,14 @@ func (c *UDPConn) FindAddrByChannelNumber(chNum uint16) (net.Addr, bool) {
 
 func (c *UDPConn) maybeBind(bound *binding) {
 	// Block only callers with the same binding until
-	// the binding transaction has been complete
+	// the binding transaction has been started
 	bound.muBind.Lock()
 	defer bound.muBind.Unlock()
 
-	startState, ok := c.startBinding(bound)
-	if !ok {
-		return
+	if bound.attemptDone == nil {
+		// Establish binding with the server if the state machine allows it.
+		c.startBindAttemptLocked(bound)
 	}
-
-	// Establish binding with the server if eligible
-	// with regard to cases right above.
-	go c.bindChannel(bound, startState)
 }
 
 func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
@@ -468,7 +763,9 @@ func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
 	return startState, true
 }
 
-func (c *UDPConn) bindChannel(bound *binding, startState bindingState) {
+// bindChannel performs one ChannelBind attempt. It returns nil when the
+// binding was confirmed or recovered, and the attempt's error otherwise.
+func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
 	var err error
 	for range maxRetryAttempts {
 		if err = c.bind(bound); !errors.Is(err, errTryAgain) {
@@ -476,18 +773,23 @@ func (c *UDPConn) bindChannel(bound *binding, startState bindingState) {
 		}
 	}
 	if err != nil {
-		c.handleBindChannelError(bound, startState, err)
+		if c.handleBindChannelError(bound, startState, err) {
+			return nil
+		}
 
-		return
+		return err
 	}
 
 	bound.setRefreshedAt(time.Now())
 	bound.setState(bindingStateReady)
+
+	return nil
 }
 
-func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState, err error) {
+// handleBindChannelError reports whether the binding recovered (kept usable).
+func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState, err error) bool {
 	if c.recoverChannelBindBadRequest(bound, startState, err) {
-		return
+		return true
 	}
 
 	c.log.Warnf("Failed to bind channel %d: %s", bound.number, err)
@@ -498,13 +800,15 @@ func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState
 			bound.setState(bindingStateUnknown)
 		}
 
-		return
+		return false
 	}
 
 	bound.setState(bindingStateFailed)
 	if errors.Is(err, errChannelBindBadRequest) {
 		c.closeAfterChannelBindBadRequest(bound)
 	}
+
+	return false
 }
 
 func (c *UDPConn) recoverChannelBindBadRequest(bound *binding, startState bindingState, err error) bool {
@@ -541,7 +845,9 @@ func (c *UDPConn) closeAfterChannelBindBadRequest(bound *binding) {
 		bound.number,
 	)
 
-	if err := c.Close(); err != nil && !errors.Is(err, errAlreadyClosed) {
+	// startClose, not Close: this runs on a Pion-owned bind worker, which must
+	// not join itself. The caller's Close still joins every worker.
+	if _, err := c.startClose(); err != nil {
 		c.log.Warnf("Failed to close TURN allocation after ChannelBind 400: %s", err)
 	}
 }

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 const (

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -60,18 +60,19 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 		closeCh:                make(chan struct{}),
 		bindingRefreshInterval: defaultBindingRefreshInterval,
 		allocation: allocation{
-			client:      config.Client,
-			relayedAddr: config.RelayedAddr,
-			serverAddr:  config.ServerAddr,
-			readTimer:   time.NewTimer(time.Duration(math.MaxInt64)),
-			permMap:     newPermissionMap(),
-			username:    config.Username,
-			realm:       config.Realm,
-			integrity:   config.Integrity,
-			_nonce:      config.Nonce,
-			_lifetime:   config.Lifetime,
-			net:         config.Net,
-			log:         config.Log,
+			client:            config.Client,
+			relayedAddr:       config.RelayedAddr,
+			serverAddr:        config.ServerAddr,
+			readTimer:         time.NewTimer(time.Duration(math.MaxInt64)),
+			permMap:           newPermissionMap(),
+			username:          config.Username,
+			realm:             config.Realm,
+			integrity:         config.Integrity,
+			_nonce:            config.Nonce,
+			_lifetime:         config.Lifetime,
+			net:               config.Net,
+			log:               config.Log,
+			abortTransactions: config.AbortTransactions,
 		},
 	}
 
@@ -291,6 +292,11 @@ func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer net.Addr) chan 
 		defer c.workerWG.Done()
 		var err error
 		for range maxRetryAttempts {
+			if c.isClosed() {
+				err = errClosed
+
+				break
+			}
 			if err = c.createPermission(perm, peer); !errors.Is(err, errTryAgain) {
 				break
 			}
@@ -580,6 +586,12 @@ func (c *UDPConn) startClose() (bool, error) {
 		close(c.closeCh)
 	}
 
+	// Wake workers blocked on in-flight transaction waits so Close does not
+	// wait out the retransmission budget against an unresponsive server.
+	if c.abortTransactions != nil {
+		c.abortTransactions()
+	}
+
 	c.client.OnDeallocated(c.relayedAddr)
 
 	return true, c.refreshAllocation(0, true /* dontWait=true */)
@@ -768,11 +780,19 @@ func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
 func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
 	var err error
 	for range maxRetryAttempts {
+		if c.isClosed() {
+			return errClosed
+		}
 		if err = c.bind(bound); !errors.Is(err, errTryAgain) {
 			break
 		}
 	}
 	if err != nil {
+		if c.isClosed() {
+			// Closing: the binding state no longer matters, and an aborted
+			// transaction must not count as a bind failure.
+			return err
+		}
 		if c.handleBindChannelError(bound, startState, err) {
 			return nil
 		}

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/allocation"
-	"github.com/pion/turn/v5/internal/auth"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/allocation"
+	"github.com/the-sarge/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 // Request contains all the state needed to process a single incoming datagram.

--- a/internal/server/stun.go
+++ b/internal/server/stun.go
@@ -5,7 +5,7 @@ package server
 
 import (
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/ipnet"
+	"github.com/the-sarge/turn/v5/internal/ipnet"
 )
 
 func handleBindingRequest(req Request, stunMsg *stun.Message) error {

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/pion/randutil"
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/allocation"
-	"github.com/pion/turn/v5/internal/ipnet"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/allocation"
+	"github.com/the-sarge/turn/v5/internal/ipnet"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 const runesAlpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/internal/server/turn_test.go
+++ b/internal/server/turn_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/pion/transport/v4/test"
-	"github.com/pion/turn/v5/internal/allocation"
-	"github.com/pion/turn/v5/internal/auth"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/allocation"
+	"github.com/the-sarge/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
-	"github.com/pion/turn/v5/internal/auth"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 const (

--- a/lt_cred.go
+++ b/lt_cred.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5/internal/auth"
 )
 
 // GenerateLongTermCredentials can be used to create credentials valid for [duration] time.

--- a/lt_cred_test.go
+++ b/lt_cred_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5/internal/auth"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notes/grill-allocation-lifecycle-CONTEXT.md
+++ b/notes/grill-allocation-lifecycle-CONTEXT.md
@@ -1,0 +1,33 @@
+# TURN
+
+This context describes the language used for relay state owned by a TURN server.
+
+## Language
+
+**Allocation**:
+The relay state associated with one client-server five-tuple. It owns a relay transport address and the permissions, channel bindings, and peer data connections created beneath it.
+_Avoid_: Session
+
+**Five-tuple**:
+The client transport address, server transport address, and transport protocol that together identify an allocation.
+_Avoid_: Connection ID
+
+**Relay transport address**:
+The server transport address allocated for communication between a client and its peers.
+_Avoid_: Relay address when the transport distinction matters
+
+**Permission**:
+An allocation-scoped authorization to communicate with a peer IP address, independent of the peer port.
+_Avoid_: Peer connection
+
+**Channel binding**:
+An allocation-scoped association between one channel number and one peer transport address. A channel binding also creates or refreshes the required permission.
+_Avoid_: Permission
+
+**Peer data connection**:
+A TCP connection between a TURN server and a peer, associated with a TCP allocation and identified to the client by a connection ID.
+_Avoid_: Control connection
+
+**Reservation token**:
+A short-lived value that identifies a reserved relay transport address for a subsequent allocation.
+_Avoid_: Connection ID

--- a/notes/grill-request-processing-CONTEXT.md
+++ b/notes/grill-request-processing-CONTEXT.md
@@ -1,0 +1,13 @@
+# TURN
+
+This context describes the language used for messages and relay state in a TURN client or server.
+
+## Language
+
+**Inbound TURN message**:
+A complete message received by a TURN server from a client, represented as either a STUN-formatted message or ChannelData.
+_Avoid_: Request, packet
+
+**TURN request**:
+A STUN-formatted request asking a TURN server to perform a TURN method. Indications and ChannelData are not TURN requests.
+_Avoid_: Inbound TURN message when the distinction matters

--- a/server.go
+++ b/server.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5/internal/allocation"
-	"github.com/pion/turn/v5/internal/proto"
-	"github.com/pion/turn/v5/internal/server"
+	"github.com/the-sarge/turn/v5/internal/allocation"
+	"github.com/the-sarge/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/server"
 )
 
 const (

--- a/server_config.go
+++ b/server_config.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/pion/logging"
-	"github.com/pion/turn/v5/internal/allocation"
-	"github.com/pion/turn/v5/internal/auth"
+	"github.com/the-sarge/turn/v5/internal/allocation"
+	"github.com/the-sarge/turn/v5/internal/auth"
 )
 
 // AllocateListenerConfig defines the parameters passed to the relay address allocator.

--- a/server_test.go
+++ b/server_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pion/transport/v4/reuseport"
 	"github.com/pion/transport/v4/test"
 	"github.com/pion/transport/v4/vnet"
-	"github.com/pion/turn/v5/internal/allocation"
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/allocation"
+	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/stun_conn.go
+++ b/stun_conn.go
@@ -6,7 +6,7 @@ package turn
 import (
 	"net"
 
-	"github.com/pion/turn/v5/internal/proto"
+	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
 type STUNConn = proto.STUNConn


### PR DESCRIPTION
Scoped re-audit receipt for `docs/adr/2026-08-14-cut-and-stabilize-plan.md` — Slice 1 (#4, parent #3), triggered during `$implement-architecture-slice` preflight at plan commit `db6086424f930a58efc249e39874de7a2234aeda`. The accepted child, end-to-end outcome, representation contract, and one-PR boundary are all retained; this amendment corrects two invalidated factual assumptions and one blast-radius omission.

## Invalidated assumption 1: "Dependency-update automation (Renovate) remains functional"

Evidence that Renovate never operated on this fork:

- `GET /repos/the-sarge/turn/actions/runs` → `total_count: 0` (no workflow run has ever executed here).
- No PRs by `renovate[bot]`/`dependabot[bot]`; no Renovate Dependency Dashboard issue (issues #1–#6 are all human/program issues).
- `.github/workflows/renovate-go-sum-fix.yaml` requires `secrets.PIONBOT_PRIVATE_KEY`, a pion-org secret absent in this fork.
- The `origin/renovate/*` branches are carried upstream residue (last commit 2026-08-04, pre-pivot; identical refs exist on `upstream/`).

There is nothing to preserve. D2 (scope doc) names the outcome — "dependency CVEs flow through normal dependency updates" — not the tool. The portfolio standard's vehicle is Dependabot (`GridSwarm/wiremux/.github/dependabot.yml` precedent), functional from a config file alone with no app installation. Amendment: the slice establishes `.github/dependabot.yml`; stop condition reworded from "Renovate/dependency automation cannot be preserved" to "dependency-update automation cannot be made functional".

## Invalidated assumption 2: "green on the pre-cut tree with no Go code changes"

The module rename (`e8db91a`) changed import sort order (`github.com/pion/turn/...` → `github.com/the-sarge/turn/...`) without re-sorting import blocks. Observed on the pre-cut tree at `db60864`:

- `gofmt -l` flags 11 files (import-line ordering only).
- Pinned golangci-lint `v2.10.1` (the version inherited CI uses) reports exactly 12 `gci` issues and nothing else; the config's `gci` uses default ordering, no stale prefix.

The slice's format/lint jobs therefore cannot be green without re-sorting those imports — a mechanical, zero-semantic edit. Amendment: the slice admits import-order-only normalization; the normalization diff must contain only import-line reordering, verified by diff inspection plus a green suite; any other Go edit remains a stop condition.

## Blast-radius correction

The original "`.github/` only" contradicted the portfolio responsibility boundary that D4's mandated flow imposes (workflow YAML = orchestration; Taskfile/scripts = portable commands). Amended to include `Taskfile.yml` and `scripts/ci/`.

## Gates re-run

Representation ownership (workflow files, example-level), artifact classification (all verification aid / process metadata; gate remains the approved maintained deliverable), evidence budget (unchanged: one green run per job + one observed-red demonstration), single owner (fork `.github` tree), authority completeness (n/a), transitional seams (none; removes `.goassets` coupling and the dead pion-secret Renovate helper), preservation (import normalization evidenced as reorder-only), context fit, and split/merge cases — all pass unchanged for the same child and one-PR outcome.

Note: opening this docs PR triggers the inherited pion `pull_request` workflows one bootstrap time; they are not required checks (no ruleset/branch protection exists) and the repo is public (no billed minutes). Expected advisory failures: Lint (the 12 pre-existing gci issues above), possibly REUSE/API. These do not gate this docs merge and are the exact defects Slice 1 removes/fixes.