### PR TITLE
Reject cross-family peers in Send indications

### DIFF
--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -469,6 +469,15 @@ func handleSendIndication(req Request, stunMsg *stun.Message) error {
 		return err
 	}
 
+	// RFC 6156: Peer address must match allocation's address family.
+	// Unlike CreatePermission and ChannelBind, a Send indication carries no
+	// response, so mismatched data is discarded instead of rejected with 443.
+	if !ipMatchesFamily(peerAddress.IP, alloc.AddressFamily()) {
+		req.Log.Infof("peer address family mismatch for client %s to peer %s", req.SrcAddr, peerAddress.IP)
+
+		return errPeerAddressFamilyMismatch
+	}
+
 	msgDst := &net.UDPAddr{IP: peerAddress.IP, Port: peerAddress.Port}
 	if perm := alloc.GetPermission(msgDst); perm == nil {
 		return fmt.Errorf("%w: %v", errNoPermission, msgDst)

--- a/internal/server/turn.go
+++ b/internal/server/turn.go
@@ -469,18 +469,22 @@ func handleSendIndication(req Request, stunMsg *stun.Message) error {
 		return err
 	}
 
-	// RFC 6156: Peer address must match allocation's address family.
-	// Unlike CreatePermission and ChannelBind, a Send indication carries no
-	// response, so mismatched data is discarded instead of rejected with 443.
-	if !ipMatchesFamily(peerAddress.IP, alloc.AddressFamily()) {
-		req.Log.Infof("peer address family mismatch for client %s to peer %s", req.SrcAddr, peerAddress.IP)
-
-		return errPeerAddressFamilyMismatch
-	}
-
 	msgDst := &net.UDPAddr{IP: peerAddress.IP, Port: peerAddress.Port}
+	// RFC 8656 Section 11.2: the permission check comes before any
+	// address/port restrictions, and a Send indication never refreshes the
+	// permission.
 	if perm := alloc.GetPermission(msgDst); perm == nil {
 		return fmt.Errorf("%w: %v", errNoPermission, msgDst)
+	}
+
+	// RFC 8656 Section 11.2: the server MAY impose restrictions on the peer
+	// address; the peer address family must match the allocation's address
+	// family (see Section 10.2). A Send indication carries no response, so
+	// mismatched data is silently discarded.
+	if !ipMatchesFamily(peerAddress.IP, alloc.AddressFamily()) {
+		req.Log.Debugf("peer address family mismatch for client %s to peer %s", req.SrcAddr, peerAddress.IP)
+
+		return errPeerAddressFamilyMismatch
 	}
 
 	l, err := alloc.WriteTo(dataAttr, msgDst)

--- a/internal/server/turn_family_test.go
+++ b/internal/server/turn_family_test.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
 // SPDX-License-Identifier: MIT
 
+//go:build !js
+
 package server
 
 import (
@@ -51,7 +53,7 @@ func (c *blockingRelayConn) Close() error {
 
 // TestHandleSendIndicationAddressFamilyMismatch verifies that a Send
 // indication addressed to a peer of a different address family than the
-// allocation is not relayed, matching the RFC 6156 model where the relayed
+// allocation is not relayed, matching the RFC 8656 model where the relayed
 // transport address family constrains every peer it communicates with.
 //
 // CreatePermission and ChannelBind already enforce this (443 Peer Address
@@ -161,4 +163,58 @@ func TestHandleSendIndicationSameFamilyStillRelays(t *testing.T) {
 
 	assert.NoError(t, handleSendIndication(req, m))
 	assert.NotEmpty(t, relayConn.lastWrite, "same-family data must be relayed")
+}
+
+// TestHandleSendIndicationPermissionBeforeFamily locks the RFC 8656
+// Section 11.2 ordering: the permission check runs before the address
+// family restriction, so a cross-family peer without a permission is
+// dropped as "no permission", not as a family mismatch.
+func TestHandleSendIndicationPermissionBeforeFamily(t *testing.T) {
+	logger := &captureLogger{}
+	turnConn := newCapturePacketConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3478})
+	relayConn := newBlockingRelayConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50002})
+	defer relayConn.Close() //nolint:errcheck
+
+	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
+		AllocatePacketConn: func(allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			return relayConn, relayConn.LocalAddr(), nil
+		},
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
+			return nil, nil, nil //nolint:nilnil
+		},
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
+			return nil, nil //nolint:nilnil
+		},
+		LeveledLogger: logger,
+	})
+	assert.NoError(t, err)
+	defer allocationManager.Close() //nolint:errcheck
+
+	req := Request{
+		Conn:              turnConn,
+		SrcAddr:           &net.UDPAddr{IP: net.ParseIP("192.0.2.3"), Port: 50000},
+		AllocationManager: allocationManager,
+		Log:               logger,
+	}
+
+	fiveTuple := &allocation.FiveTuple{
+		SrcAddr:  req.SrcAddr,
+		DstAddr:  req.Conn.LocalAddr(),
+		Protocol: allocation.UDP,
+	}
+	_, err = req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, proto.ProtoUDP,
+		0, time.Hour, "", "", proto.RequestedFamilyIPv4)
+	assert.NoError(t, err)
+
+	// No permission installed: the permission check must fail first, even
+	// though the peer address family also mismatches the allocation.
+	m := &stun.Message{}
+	m.TransactionID = stun.NewTransactionID()
+	assert.NoError(t, m.Build(stun.NewType(stun.MethodSend, stun.ClassIndication)))
+	assert.NoError(t, (proto.Data([]byte("test data"))).AddTo(m))
+	assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("2001:db8::1"), Port: 8080}).AddTo(m))
+
+	err = handleSendIndication(req, m)
+	assert.ErrorIs(t, err, errNoPermission)
+	assert.Empty(t, relayConn.lastWrite, "data without permission must not be relayed")
 }

--- a/internal/server/turn_family_test.go
+++ b/internal/server/turn_family_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package server
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/stun/v3"
+	"github.com/pion/turn/v5/internal/allocation"
+	"github.com/pion/turn/v5/internal/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+// blockingRelayConn is a PacketConn used as the relay socket of an
+// allocation. ReadFrom blocks until the conn is closed so the relay read
+// goroutine stays idle, while WriteTo records relayed payloads.
+type blockingRelayConn struct {
+	*capturePacketConn
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newBlockingRelayConn(localAddr net.Addr) *blockingRelayConn {
+	return &blockingRelayConn{
+		capturePacketConn: newCapturePacketConn(localAddr),
+		done:              make(chan struct{}),
+	}
+}
+
+func (c *blockingRelayConn) ReadFrom([]byte) (int, net.Addr, error) {
+	<-c.done
+
+	return 0, nil, net.ErrClosed
+}
+
+// Close is idempotent: the allocation teardown and the deferred test cleanup
+// may both close this conn.
+func (c *blockingRelayConn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		err = c.capturePacketConn.Close()
+		close(c.done)
+	})
+
+	return err
+}
+
+// TestHandleSendIndicationAddressFamilyMismatch verifies that a Send
+// indication addressed to a peer of a different address family than the
+// allocation is not relayed, matching the RFC 6156 model where the relayed
+// transport address family constrains every peer it communicates with.
+//
+// CreatePermission and ChannelBind already enforce this (443 Peer Address
+// Family Mismatch), but handleSendIndication historically relayed the data
+// whenever a matching permission existed.
+func TestHandleSendIndicationAddressFamilyMismatch(t *testing.T) {
+	logger := &captureLogger{}
+	turnConn := newCapturePacketConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3478})
+	relayConn := newBlockingRelayConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50000})
+	defer relayConn.Close() //nolint:errcheck
+
+	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
+		AllocatePacketConn: func(allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			return relayConn, relayConn.LocalAddr(), nil
+		},
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
+			return nil, nil, nil //nolint:nilnil
+		},
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
+			return nil, nil //nolint:nilnil
+		},
+		LeveledLogger: logger,
+	})
+	assert.NoError(t, err)
+	defer allocationManager.Close() //nolint:errcheck
+
+	req := Request{
+		Conn:              turnConn,
+		SrcAddr:           &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 50000},
+		AllocationManager: allocationManager,
+		Log:               logger,
+	}
+
+	fiveTuple := &allocation.FiveTuple{
+		SrcAddr:  req.SrcAddr,
+		DstAddr:  req.Conn.LocalAddr(),
+		Protocol: allocation.UDP,
+	}
+	alloc, err := req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, proto.ProtoUDP,
+		0, time.Hour, "", "", proto.RequestedFamilyIPv4)
+	assert.NoError(t, err)
+
+	// The STUN handlers refuse to create cross-family permissions (443), but
+	// an allocation with a stale or manually injected permission must still
+	// not relay cross-family data.
+	ipv6Peer := &net.UDPAddr{IP: net.ParseIP("2001:db8::1"), Port: 8080}
+	alloc.AddPermission(allocation.NewPermission(ipv6Peer, logger, 5*time.Minute))
+
+	m := &stun.Message{}
+	m.TransactionID = stun.NewTransactionID()
+	assert.NoError(t, m.Build(stun.NewType(stun.MethodSend, stun.ClassIndication)))
+	assert.NoError(t, (proto.Data([]byte("test data"))).AddTo(m))
+	assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("2001:db8::1"), Port: 8080}).AddTo(m))
+
+	err = handleSendIndication(req, m)
+	assert.ErrorIs(t, err, errPeerAddressFamilyMismatch)
+	assert.Empty(t, relayConn.lastWrite, "cross-family data must not be relayed")
+}
+
+// TestHandleSendIndicationSameFamilyStillRelays guards the fix against
+// over-rejection: same-family Send indications must keep relaying.
+func TestHandleSendIndicationSameFamilyStillRelays(t *testing.T) {
+	logger := &captureLogger{}
+	turnConn := newCapturePacketConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3478})
+	relayConn := newBlockingRelayConn(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 50001})
+	defer relayConn.Close() //nolint:errcheck
+
+	allocationManager, err := allocation.NewManager(allocation.ManagerConfig{
+		AllocatePacketConn: func(allocation.AllocateListenerConfig) (net.PacketConn, net.Addr, error) {
+			return relayConn, relayConn.LocalAddr(), nil
+		},
+		AllocateListener: func(allocation.AllocateListenerConfig) (net.Listener, net.Addr, error) {
+			return nil, nil, nil //nolint:nilnil
+		},
+		AllocateConn: func(allocation.AllocateConnConfig) (net.Conn, error) {
+			return nil, nil //nolint:nilnil
+		},
+		LeveledLogger: logger,
+	})
+	assert.NoError(t, err)
+	defer allocationManager.Close() //nolint:errcheck
+
+	req := Request{
+		Conn:              turnConn,
+		SrcAddr:           &net.UDPAddr{IP: net.ParseIP("192.0.2.2"), Port: 50000},
+		AllocationManager: allocationManager,
+		Log:               logger,
+	}
+
+	fiveTuple := &allocation.FiveTuple{
+		SrcAddr:  req.SrcAddr,
+		DstAddr:  req.Conn.LocalAddr(),
+		Protocol: allocation.UDP,
+	}
+	alloc, err := req.AllocationManager.CreateAllocation(fiveTuple, req.Conn, proto.ProtoUDP,
+		0, time.Hour, "", "", proto.RequestedFamilyIPv4)
+	assert.NoError(t, err)
+
+	ipv4Peer := &net.UDPAddr{IP: net.ParseIP("192.168.1.1"), Port: 8080}
+	alloc.AddPermission(allocation.NewPermission(ipv4Peer, logger, 5*time.Minute))
+
+	m := &stun.Message{}
+	m.TransactionID = stun.NewTransactionID()
+	assert.NoError(t, m.Build(stun.NewType(stun.MethodSend, stun.ClassIndication)))
+	assert.NoError(t, (proto.Data([]byte("test data"))).AddTo(m))
+	assert.NoError(t, (proto.PeerAddress{IP: net.ParseIP("192.168.1.1"), Port: 8080}).AddTo(m))
+
+	assert.NoError(t, handleSendIndication(req, m))
+	assert.NotEmpty(t, relayConn.lastWrite, "same-family data must be relayed")
+}


### PR DESCRIPTION
SUMMARY

RFC 6156 constrains every peer of an allocation to the address family
of its relayed transport address. The server enforces this for
CreatePermission and ChannelBind requests, but handleSendIndication
historically relayed data whenever a matching permission existed,
even when the peer address family differed from the allocation's.

A Send indication carries no response, so mismatched data is
discarded (logged and dropped) instead of rejected with a 443 error,
consistent with how RFC 5766 handles data without a permission.

TEST

- TestHandleSendIndicationAddressFamilyMismatch fails before the fix
  (cross-family data was written to the relay socket with no error)
  and passes after.
- TestHandleSendIndicationSameFamilyStillRelays guards against
  over-rejection.
- Existing TestHandleSendIndication subtests, CreatePermission and
  ChannelBind family tests all pass.
- golangci-lint v2.10.1: 0 issues. go test -race: pass.

CONTEXT

This complements the family-consistency model established by #575
(which closed #566): rather than relaxing the family checks, #575
fixed the default allocation family. This change applies the same
model to the remaining handler that was missing it.

Note: PR #567 proposes relaxing ipMatchesFamily for dual-stack
relays; if adopted, the Send indication check added here would need
the same relaxation.