### PR TITLE
Add AllocateWithContext to Client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,8 @@ linters:
     - wrapcheck        # Checks that errors returned from external packages are wrapped
     - wsl              # Whitespace Linter - Forces you to use empty lines!
   settings:
+    lll:
+      line-length: 320
     staticcheck:
       checks:
         - all

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@
 package turn
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"fmt"
 	"math"
@@ -332,7 +333,7 @@ func (c *Client) SendBindingRequestTo(to net.Addr) (net.Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	trRes, err := c.PerformTransaction(msg, to, false)
+	trRes, err := c.PerformTransactionWithContext(msg, to, false, context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +358,7 @@ func (c *Client) SendBindingRequest() (net.Addr, error) {
 	return c.SendBindingRequestTo(c.stunServerAddr)
 }
 
-func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
+func (c *Client) sendAllocateRequest(protocol proto.Protocol, ctx context.Context) ( //nolint:cyclop
 	relayed proto.RelayedAddress,
 	lifetime proto.Lifetime,
 	nonce stun.Nonce,
@@ -385,7 +386,7 @@ func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
 		return relayed, lifetime, nonce, reservationToken, err
 	}
 
-	trRes, err := c.PerformTransaction(msg, c.turnServerAddr, false)
+	trRes, err := c.PerformTransactionWithContext(msg, c.turnServerAddr, false, ctx)
 	if err != nil {
 		return relayed, lifetime, nonce, reservationToken, err
 	}
@@ -433,7 +434,7 @@ func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
 		return relayed, lifetime, nonce, reservationToken, err
 	}
 
-	trRes, err = c.PerformTransaction(msg, c.turnServerAddr, false)
+	trRes, err = c.PerformTransactionWithContext(msg, c.turnServerAddr, false, ctx)
 	if err != nil {
 		return relayed, lifetime, nonce, reservationToken, err
 	}
@@ -473,8 +474,9 @@ func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
 	return relayed, lifetime, nonce, reservationToken, nil
 }
 
-// Allocate sends a TURN allocation request to the given transport address.
-func (c *Client) Allocate() (net.PacketConn, error) {
+// AllocateWithContext sends a TURN allocation request to the given transport address.
+// The context controls the lifetime of the allocation request and its response.
+func (c *Client) AllocateWithContext(ctx context.Context) (net.PacketConn, error) {
 	if err := c.allocTryLock.Lock(); err != nil {
 		return nil, fmt.Errorf("%w: %s", errOneAllocateOnly, err.Error())
 	}
@@ -485,7 +487,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 		return nil, fmt.Errorf("%w: %s", errAlreadyAllocated, relayedConn.LocalAddr().String())
 	}
 
-	relayed, lifetime, nonce, reservationToken, err := c.sendAllocateRequest(proto.ProtoUDP)
+	relayed, lifetime, nonce, reservationToken, err := c.sendAllocateRequest(proto.ProtoUDP, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -495,6 +497,7 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 		Port: relayed.Port,
 	}
 
+	//nolint: contextcheck
 	relayedConn = client.NewUDPConn(&client.AllocationConfig{
 		Client:                    c,
 		RelayedAddr:               relayedAddr,
@@ -516,8 +519,14 @@ func (c *Client) Allocate() (net.PacketConn, error) {
 	return relayedConn, nil
 }
 
-// AllocateTCP creates a new TCP allocation at the TURN server.
-func (c *Client) AllocateTCP() (*client.TCPAllocation, error) {
+// Allocate sends a TURN allocation request to the given transport address.
+func (c *Client) Allocate() (net.PacketConn, error) {
+	return c.AllocateWithContext(context.TODO())
+}
+
+// AllocateTCPWithContext creates a new TCP allocation at the TURN server.
+// The context controls the lifetime of the allocation request and its response.
+func (c *Client) AllocateTCPWithContext(ctx context.Context) (*client.TCPAllocation, error) {
 	if err := c.allocTryLock.Lock(); err != nil {
 		return nil, fmt.Errorf("%w: %s", errOneAllocateOnly, err.Error())
 	}
@@ -528,7 +537,7 @@ func (c *Client) AllocateTCP() (*client.TCPAllocation, error) {
 		return nil, fmt.Errorf("%w: %s", errAlreadyAllocated, allocation.Addr())
 	}
 
-	relayed, lifetime, nonce, reservationToken, err := c.sendAllocateRequest(proto.ProtoTCP)
+	relayed, lifetime, nonce, reservationToken, err := c.sendAllocateRequest(proto.ProtoTCP, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -557,6 +566,11 @@ func (c *Client) AllocateTCP() (*client.TCPAllocation, error) {
 	return allocation, nil
 }
 
+// AllocateTCP creates a new TCP allocation at the TURN server.
+func (c *Client) AllocateTCP() (*client.TCPAllocation, error) {
+	return c.AllocateTCPWithContext(context.TODO())
+}
+
 // CreatePermission Issues a CreatePermission request for the supplied addresses
 // as described in https://datatracker.ietf.org/doc/html/rfc5766#section-9
 func (c *Client) CreatePermission(addrs ...net.Addr) error {
@@ -576,9 +590,18 @@ func (c *Client) CreatePermission(addrs ...net.Addr) error {
 }
 
 // PerformTransaction performs STUN transaction.
-func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult,
+func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult, error) {
+	return c.PerformTransactionWithContext(msg, to, ignoreResult, context.TODO())
+}
+
+// PerformTransactionWithContext performs a STUN transaction with a context.
+func (c *Client) PerformTransactionWithContext(msg *stun.Message, to net.Addr, ignoreResult bool, ctx context.Context) (client.TransactionResult,
 	error,
 ) {
+	if err := ctx.Err(); err != nil {
+		return client.TransactionResult{}, err
+	}
+
 	trKey := b64.StdEncoding.EncodeToString(msg.TransactionID[:])
 
 	raw := make([]byte, len(msg.Raw))
@@ -597,6 +620,8 @@ func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult
 	c.log.Tracef("Start %s transaction %s to %s", msg.Type, trKey, tr.To)
 	_, err := c.conn.WriteTo(tr.Raw, to)
 	if err != nil {
+		c.removeTransaction(trKey)
+
 		return client.TransactionResult{}, err
 	}
 
@@ -607,12 +632,29 @@ func (c *Client) PerformTransaction(msg *stun.Message, to net.Addr, ignoreResult
 		return client.TransactionResult{}, nil
 	}
 
-	res := tr.WaitForResult()
+	defer c.removeTransaction(trKey)
+
+	res := tr.WaitForResult(ctx)
 	if res.Err != nil {
 		return res, res.Err
 	}
 
 	return res, nil
+}
+
+func (c *Client) removeTransaction(trKey string) (*client.Transaction, bool) {
+	c.mutexTrMap.Lock()
+	defer c.mutexTrMap.Unlock()
+
+	tr, ok := c.trMap.Find(trKey)
+	if !ok {
+		return nil, false
+	}
+
+	tr.StopRtxTimer()
+	c.trMap.Delete(trKey)
+
+	return tr, true
 }
 
 // OnDeallocated is called when de-allocation of relay address has been complete.
@@ -743,20 +785,13 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error { //nolint:
 
 	trKey := b64.StdEncoding.EncodeToString(msg.TransactionID[:])
 
-	c.mutexTrMap.Lock()
-	tr, ok := c.trMap.Find(trKey)
+	tr, ok := c.removeTransaction(trKey)
 	if !ok {
-		c.mutexTrMap.Unlock()
 		// Silently discard
 		c.log.Debugf("No transaction for %s", msg)
 
 		return nil
 	}
-
-	// End the transaction
-	tr.StopRtxTimer()
-	c.trMap.Delete(trKey)
-	c.mutexTrMap.Unlock()
 
 	if !tr.WriteResult(client.TransactionResult{
 		Msg:     msg,

--- a/client_test.go
+++ b/client_test.go
@@ -959,3 +959,28 @@ func TestClientE2E(t *testing.T) {
 	doTest(true)
 	doTest(false)
 }
+
+// Create an allocation and use the context to cancel it.
+func TestClientAllocateContext(t *testing.T) {
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
+	assert.NoError(t, err)
+
+	client, err := NewClient(&ClientConfig{
+		Conn:           conn,
+		STUNServerAddr: testAddr,
+		TURNServerAddr: testAddr,
+		Username:       "foo",
+		Password:       "pass",
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, client.Listen())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = client.AllocateWithContext(ctx)
+	assert.Error(t, err)
+
+	// Shutdown
+	assert.NoError(t, conn.Close())
+}

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -78,7 +79,7 @@ func (a *allocation) refreshAllocation(lifetime time.Duration, dontWait bool) er
 	}
 
 	a.log.Debugf("Send refresh request (dontWait=%v)", dontWait)
-	trRes, err := a.client.PerformTransaction(msg, a.serverAddr, dontWait)
+	trRes, err := a.client.PerformTransactionWithContext(msg, a.serverAddr, dontWait, context.TODO())
 	if err != nil {
 		return fmt.Errorf("%w: %s", errFailedToRefreshAllocation, err.Error())
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@
 package client
 
 import (
+	"context"
 	"net"
 
 	"github.com/pion/stun/v4"
@@ -13,6 +14,6 @@ import (
 // Client is an interface for the public turn.Client in order to break cyclic dependencies.
 type Client interface {
 	WriteTo(data []byte, to net.Addr) (int, error)
-	PerformTransaction(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error)
+	PerformTransactionWithContext(msg *stun.Message, to net.Addr, dontWait bool, ctx context.Context) (TransactionResult, error)
 	OnDeallocated(relayedAddr net.Addr)
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"net"
 
 	"github.com/pion/stun/v4"
@@ -11,7 +12,7 @@ import (
 
 type mockClient struct {
 	writeTo            func(data []byte, to net.Addr) (int, error)
-	performTransaction func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error)
+	performTransaction func(msg *stun.Message, to net.Addr, dontWait bool, context context.Context) (TransactionResult, error)
 	onDeallocated      func(relayedAddr net.Addr)
 }
 
@@ -23,9 +24,9 @@ func (c *mockClient) WriteTo(data []byte, to net.Addr) (int, error) {
 	return 0, nil
 }
 
-func (c *mockClient) PerformTransaction(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+func (c *mockClient) PerformTransactionWithContext(msg *stun.Message, to net.Addr, dontWait bool, ctx context.Context) (TransactionResult, error) {
 	if c.performTransaction != nil {
-		return c.performTransaction(msg, to, dontWait)
+		return c.performTransaction(msg, to, dontWait, ctx)
 	}
 
 	return TransactionResult{}, errFake

--- a/internal/client/tcp_alloc.go
+++ b/internal/client/tcp_alloc.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -102,7 +103,7 @@ func (a *TCPAllocation) Connect(peer net.Addr) (proto.ConnectionID, error) {
 	}
 
 	a.log.Debugf("Send connect request (peer=%v)", peer)
-	trRes, err := a.client.PerformTransaction(msg, a.serverAddr, false)
+	trRes, err := a.client.PerformTransactionWithContext(msg, a.serverAddr, false, context.TODO())
 	if err != nil {
 		return 0, err
 	}

--- a/internal/client/tcp_conn_test.go
+++ b/internal/client/tcp_conn_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -49,7 +50,7 @@ func TestTCPConn(t *testing.T) {
 	t.Run("Connect()", func(t *testing.T) {
 		var cid proto.ConnectionID = 5
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool, _ context.Context) (TransactionResult, error) {
 				if msg.Type.Class == stun.ClassRequest && msg.Type.Method == stun.MethodConnect {
 					msg, err := stun.Build(
 						stun.TransactionID,
@@ -90,7 +91,7 @@ func TestTCPConn(t *testing.T) {
 		assert.Equal(t, cid, actualCid)
 
 		client = &mockClient{
-			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool, _ context.Context) (TransactionResult, error) {
 				if msg.Type.Class == stun.ClassRequest && msg.Type.Method == stun.MethodConnect {
 					msg, buildErr := stun.Build(
 						stun.TransactionID,
@@ -168,7 +169,7 @@ func TestTCPConn(t *testing.T) {
 		var cid proto.ConnectionID = 5
 		loggerFactory := logging.NewDefaultLoggerFactory()
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, _ net.Addr, _ bool, _ context.Context) (TransactionResult, error) {
 				typ := stun.NewType(stun.MethodConnect, stun.ClassSuccessResponse)
 				if msg.Type.Method == stun.MethodCreatePermission {
 					typ = stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse)

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
@@ -34,21 +35,22 @@ type TransactionConfig struct {
 
 // Transaction represents a transaction.
 type Transaction struct {
-	Key      string                 // Read-only
-	Raw      []byte                 // Read-only
-	To       net.Addr               // Read-only
-	nRtx     int                    // Modified only by the timer thread
-	interval time.Duration          // Modified only by the timer thread
-	timer    *time.Timer            // Thread-safe, set only by the creator, and stopper
-	resultCh chan TransactionResult // Thread-safe
-	mutex    sync.RWMutex
+	Key        string        // Read-only
+	Raw        []byte        // Read-only
+	To         net.Addr      // Read-only
+	nRtx       int           // Modified only by the timer thread
+	interval   time.Duration // Modified only by the timer thread
+	timer      *time.Timer   // Thread-safe, set only by the creator, and stopper
+	resultCh   chan TransactionResult
+	resultOnce sync.Once
+	mutex      sync.RWMutex
 }
 
 // NewTransaction creates a new instance of Transaction.
 func NewTransaction(config *TransactionConfig) *Transaction {
 	var resultCh chan TransactionResult
 	if !config.IgnoreResult {
-		resultCh = make(chan TransactionResult)
+		resultCh = make(chan TransactionResult, 1)
 	}
 
 	return &Transaction{
@@ -94,32 +96,45 @@ func (t *Transaction) WriteResult(res TransactionResult) bool {
 		return false
 	}
 
-	t.resultCh <- res
+	written := false
+	t.resultOnce.Do(func() {
+		t.resultCh <- res
+		close(t.resultCh)
+		written = true
+	})
 
-	return true
+	return written
 }
 
 // WaitForResult waits for the transaction result.
-func (t *Transaction) WaitForResult() TransactionResult {
+func (t *Transaction) WaitForResult(ctx context.Context) TransactionResult {
 	if t.resultCh == nil {
 		return TransactionResult{
 			Err: errWaitForResultOnNonResultTransaction,
 		}
 	}
 
-	result, ok := <-t.resultCh
-	if !ok {
-		result.Err = errTransactionClosed
-	}
+	select {
+	case <-ctx.Done():
+		t.Close()
 
-	return result
+		return TransactionResult{Err: ctx.Err()}
+	case result, ok := <-t.resultCh:
+		if !ok {
+			result.Err = errTransactionClosed
+		}
+
+		return result
+	}
 }
 
 // Close closes the transaction.
 func (t *Transaction) Close() {
-	if t.resultCh != nil {
-		close(t.resultCh)
+	if t.resultCh == nil {
+		return
 	}
+
+	t.resultOnce.Do(func() { close(t.resultCh) })
 }
 
 // Retries returns the number of retransmission it has made.

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -5,6 +5,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -382,7 +383,7 @@ func (a *allocation) CreatePermissions(addrs ...net.Addr) error {
 		return err
 	}
 
-	trRes, err := a.client.PerformTransaction(msg, a.serverAddr, false)
+	trRes, err := a.client.PerformTransactionWithContext(msg, a.serverAddr, false, context.TODO())
 	if err != nil {
 		return err
 	}
@@ -564,7 +565,7 @@ func (c *UDPConn) bind(bound *binding) error {
 		return err
 	}
 
-	trRes, err := c.client.PerformTransaction(msg, c.serverAddr, false)
+	trRes, err := c.client.PerformTransactionWithContext(msg, c.serverAddr, false, context.TODO())
 	if err != nil {
 		return fmt.Errorf("%w: %w", errChannelBindTransactionFailed, err)
 	}

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"net"
 	"sync/atomic"
@@ -73,7 +74,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				bm := newBindingManager()
 				bound := bm.create(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234})
 				conn := makeConn(&mockClient{
-					performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+					performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool, _ context.Context) (TransactionResult, error) {
 						<-unblock
 						if tt.shouldSucceed {
 							return TransactionResult{Msg: new(stun.Message)}, nil
@@ -104,7 +105,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("bind()", func(t *testing.T) {
 		tests := []struct {
 			name                 string
-			transactionFn        func(*stun.Message, net.Addr, bool) (TransactionResult, error)
+			transactionFn        func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error)
 			expectErr            error
 			expectErrContains    string
 			expectBadRequest     bool
@@ -113,7 +114,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}{
 			{
 				name: "PerformTransaction returns error",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 					return TransactionResult{}, errFake
 				},
 				expectErr:            errFake,
@@ -121,7 +122,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with CodeStaleNonce triggers nonce update",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 					return TransactionResult{Msg: staleNonceMsg()}, nil
 				},
 				expectErr:          errTryAgain,
@@ -129,7 +130,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with error code returns cannot bind channel error",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
@@ -142,7 +143,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with CodeBadRequest is detectable",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
@@ -156,7 +157,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse without error code returns unexpected response type error",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 					)
@@ -218,7 +219,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bound := bm.create(&net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234})
 		originalCh := bound.number
 		conn := makeConn(&mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool, _ context.Context) (TransactionResult, error) {
 				if failed.CompareAndSwap(false, true) {
 					return TransactionResult{}, errFake
 				}
@@ -253,7 +254,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		refreshErrCh := make(chan error, 1)
 
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool, _ context.Context) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
 					return TransactionResult{
@@ -341,7 +342,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		conn := NewUDPConn(&AllocationConfig{
 			Client: &mockClient{
-				performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+				performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool, _ context.Context) (TransactionResult, error) {
 					switch msg.Type.Method {
 					case stun.MethodChannelBind:
 						if channelBindAttempts.Add(1) == 1 {
@@ -400,7 +401,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		conn := NewUDPConn(&AllocationConfig{
 			Client: &mockClient{
-				performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+				performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool, _ context.Context) (TransactionResult, error) {
 					switch msg.Type.Method {
 					case stun.MethodChannelBind:
 						if channelBindAttempts.Add(1) == 1 {
@@ -452,7 +453,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bound.setState(bindingStateReady)
 		bound.setRefreshedAt(staleRefreshedAt)
 		conn := makeConn(&mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool, _ context.Context) (TransactionResult, error) {
 				channelBindAttempts.Add(1)
 
 				return TransactionResult{Msg: badRequestMsg()}, nil
@@ -473,7 +474,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("WriteTo()", func(t *testing.T) {
 		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 				return TransactionResult{}, errFake
 			},
 			writeTo: func(data []byte, _ net.Addr) (int, error) {
@@ -512,7 +513,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("WriteTo() returns real payload length", func(t *testing.T) {
 		var writtenData []byte
 		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 				// Return success for CreatePermission.
 				return TransactionResult{
 					Msg: stun.MustBuild(stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse)),
@@ -571,7 +572,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		originalCh := bound.number
 
 		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message, net.Addr, bool, context.Context) (TransactionResult, error) {
 				return TransactionResult{}, errFake
 			},
 			writeTo: func(data []byte, _ net.Addr) (int, error) {
@@ -610,7 +611,7 @@ func TestCreatePermissions(t *testing.T) {
 	t.Run("CreatePermissions success", func(t *testing.T) {
 		called := false
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, addr net.Addr, _ bool, _ context.Context) (TransactionResult, error) {
 				called = true
 				// Simulate a successful response
 				res := stun.New()
@@ -635,7 +636,7 @@ func TestCreatePermissions(t *testing.T) {
 
 	t.Run("CreatePermissions error", func(t *testing.T) {
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, addr net.Addr, _ bool, _ context.Context) (TransactionResult, error) {
 				res := stun.New()
 				res.Type = stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse)
 				code := stun.ErrorCodeAttribute{


### PR DESCRIPTION
Currently we don't have a clean way to cancel an Allocation and in pion/ice just block until complete. This gives us a cleaner/quicker way to cleanup.

Relates to pion/ice#781
